### PR TITLE
Configure Vercel → Render proxy + env-driven backend routing

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,42 +1,83 @@
 name: Frontend CI
 
 on:
-  push:
-    branches:
-      - main
-      - develop
   pull_request:
-    branches:
-      - main
-      - develop
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+
+concurrency:
+  group: frontend-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  NEXT_PUBLIC_API_BASE_URL: "http://localhost:8000"
+  NEXT_TELEMETRY_DISABLED: "1"
+  CI: "true"
+
+  AUTH0_SECRET: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  AUTH0_BASE_URL: "http://localhost:3000"
+  AUTH0_ISSUER_BASE_URL: "https://example.auth0.com"
+  AUTH0_CLIENT_ID: "dummy_client_id"
+  AUTH0_CLIENT_SECRET: "dummy_client_secret"
 
 jobs:
-  lint-test-build:
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
-
-    env:
-      # Safe defaults for build-time envs
-      NEXT_PUBLIC_API_BASE_URL: "http://localhost:8000"
-      NEXT_TELEMETRY_DISABLED: "1"
-
+    timeout-minutes: 10
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Use Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "npm"
 
-      - name: Install dependencies
+      - name: Install deps
         run: npm ci
 
       - name: Lint
         run: npm run lint
 
-      - name: Run unit tests
-        run: npm test
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test:ci
+
+  build:
+    name: Typecheck + Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
 
       - name: Build
         run: npm run build

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+.next
+node_modules
+coverage
+out

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,24 @@
 import type { NextConfig } from "next";
 
+function normalizeOrigin(value: string) {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+const BACKEND_BASE_URL = normalizeOrigin(
+  process.env.BACKEND_BASE_URL || "http://localhost:8000"
+);
+
+const BACKEND_API_PREFIX = "/api";
+
 const nextConfig: NextConfig = {
-  /* config options here */
-  reactCompiler: true,
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${BACKEND_BASE_URL}${BACKEND_API_PREFIX}/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,9 +30,10 @@
         "eslint-plugin-no-comments": "^1.1.10",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "prettier": "^3.7.4",
         "tailwindcss": "^4",
         "ts-jest": "^29.4.6",
-        "typescript": "^5"
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -10218,6 +10219,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
+      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint",
-    "test": "jest"
+    "lint": "eslint . --max-warnings=0",
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:ci": "jest --ci --runInBand"
   },
   "dependencies": {
     "@auth0/nextjs-auth0": "^4.13.2",
@@ -32,8 +34,9 @@
     "eslint-plugin-no-comments": "^1.1.10",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "prettier": "^3.7.4",
     "tailwindcss": "^4",
     "ts-jest": "^29.4.6",
-    "typescript": "^5"
+    "typescript": "^5.9.3"
   }
 }

--- a/precommit.sh
+++ b/precommit.sh
@@ -4,8 +4,11 @@ set -euo pipefail
 echo "Running lint..."
 npm run lint
 
-echo "Running tests..."
-npm test
+echo "Running unit tests (CI mode)..."
+npm run test:ci
+
+echo "Running typecheck..."
+npm run typecheck
 
 echo "Building frontend..."
 npm run build


### PR DESCRIPTION
## Summary
This PR switches the frontend to **Option B** networking: the Next.js app calls backend endpoints via a same-origin proxy (`/api/*`) and Vercel rewrites those requests to the Render backend using an environment variable (`BACKEND_BASE_URL`). This avoids hardcoding the backend destination and reduces CORS/auth complexity.

## Key changes
### Frontend
- **`src/lib/apiClient.ts`**
  - Default base path is now `"/api"` (Vercel proxy-first).
  - Requests are made to `"/api/<path>"` (e.g. `POST /api/auth/login`).
  - Supports optional overrides via `ApiClientOptions` (useful for tests/SSR later).
  - Keeps JWT bearer token injection via `getAuthToken()` and preserves `credentials: "include"`.

### Next.js config
- **`next.config.ts`**
  - Adds a rewrite: `"/api/:path*"` → `"{BACKEND_BASE_URL}/api/:path*"`
  - Destination is **env-driven** (no hardcoded Render URL).
  - Correctly accounts for the backend `API_PREFIX="/api"` to avoid `/api/api/...` issues.

## Why
- Keeps frontend requests **same-origin** (`/api/...`) while deploying on Vercel.
- Avoids brittle CORS rules during early iterations.
- Lets us swap backend environments (local / staging / prod) by changing env vars only.

## Environment variables
### Vercel (Production + Preview)
- `BACKEND_BASE_URL` = `https://backend-vg12.onrender.com`
- Auth0 vars (if using Auth0 in the frontend runtime):
  - `AUTH0_SECRET`
  - `AUTH0_DOMAIN`
  - `AUTH0_CLIENT_ID`
  - `AUTH0_CLIENT_SECRET`
  - `APP_BASE_URL` = `https://frontend-five-zeta-84.vercel.app` (no trailing slash)
  - Optional: `AUTH0_AUDIENCE`, `AUTH0_SCOPE`, `NEXT_TELEMETRY_DISABLED=1`

### Local dev
- Use `.env.local` as usual
- Backend default for rewrite falls back to `http://localhost:8000` if `BACKEND_BASE_URL` is not set.

## How to test
### Local
1. Ensure backend is running on `http://localhost:8000` and exposes routes under `/api/...`
2. Start frontend:
   - `npm run dev`
3. Verify proxy works:
   - Open `http://localhost:3000/api/health` (should proxy to backend `/api/health`)
4. Verify auth login request path (if backend supports it):
   - Submit login form → should call `POST /api/auth/login`

### Vercel
1. Set env vars listed above.
2. Trigger a redeploy (env used by `next.config.ts` is applied at build time).
3. Verify:
   - `https://frontend-five-zeta-84.vercel.app/api/health` returns backend JSON
   - Login flow does not crash at runtime.

## Notes / Follow-ups
- If we later want strict security, we can lock down backend CORS to only allow the Vercel domain (and preview regex), but Option B generally minimizes the need for CORS.
- Next milestone: standardize auth handling (cookie vs local storage) and add a small `/api` health smoke test in CI.
