### PR TITLE
Candidate Portal — design/text task submission (Day 1 & Day 5)

### DIFF
--- a/src/components/candidate/TextTaskEditor.test.tsx
+++ b/src/components/candidate/TextTaskEditor.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import TextTaskEditor from "./TextTaskEditor";
+
+function draftKey(taskId: number) {
+  return `simuhire:candidate:draft:text:${taskId}`;
+}
+
+describe("TextTaskEditor", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    jest.resetAllMocks();
+  });
+
+  it("loads an existing draft from sessionStorage on mount", () => {
+    sessionStorage.setItem(draftKey(101), "hello draft");
+
+    render(
+      <TextTaskEditor taskId={101} onSubmit={async () => {}} disabled={false} submitError={null} />
+    );
+
+    expect(screen.getByRole("textbox")).toHaveValue("hello draft");
+  });
+
+  it("Save draft persists current textarea value to sessionStorage", () => {
+    render(
+      <TextTaskEditor taskId={202} onSubmit={async () => {}} disabled={false} submitError={null} />
+    );
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "draft content" } });
+    fireEvent.click(screen.getByRole("button", { name: /save draft/i }));
+
+    expect(sessionStorage.getItem(draftKey(202))).toBe("draft content");
+  });
+
+  it("Submit trims input, calls onSubmit, and clears the saved draft on success", async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+    sessionStorage.setItem(draftKey(303), "old draft");
+
+    render(
+      <TextTaskEditor taskId={303} onSubmit={onSubmit} disabled={false} submitError={null} />
+    );
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "   hello world   " } });
+    fireEvent.click(screen.getByRole("button", { name: /^submit$/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(onSubmit).toHaveBeenCalledWith("hello world");
+    });
+
+    expect(sessionStorage.getItem(draftKey(303))).toBeNull();
+  });
+
+  it("empty submission shows validation error and does not call onSubmit", () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+    render(
+      <TextTaskEditor taskId={404} onSubmit={onSubmit} disabled={false} submitError={null} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^submit$/i }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText(/please enter an answer before submitting/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/candidate/TextTaskEditor.tsx
+++ b/src/components/candidate/TextTaskEditor.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import * as React from 'react';
+import Button from '../common/Button';
+
+function draftKey(taskId: number) {
+  return `simuhire:candidate:draft:text:${taskId}`;
+}
+
+type Props = {
+  taskId: number;
+  disabled?: boolean;
+  submitError?: string | null;
+  onSubmit: (contentText: string) => Promise<void>;
+};
+
+export default function TextTaskEditor({ taskId, disabled, submitError, onSubmit }: Props) {
+  const [value, setValue] = React.useState('');
+  const [localError, setLocalError] = React.useState<string | null>(null);
+  const [savedAt, setSavedAt] = React.useState<number | null>(null);
+
+  React.useEffect(() => {
+    const existing = sessionStorage.getItem(draftKey(taskId));
+    if (existing != null) setValue(existing);
+  }, [taskId]);
+
+  const charCount = value.length;
+
+  const handleSaveDraft = () => {
+    sessionStorage.setItem(draftKey(taskId), value);
+    setSavedAt(Date.now());
+    setTimeout(() => setSavedAt((t) => (t === null ? null : t)), 0);
+  };
+
+  const handleSubmit = async () => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      setLocalError('Please enter an answer before submitting.');
+      return;
+    }
+    setLocalError(null);
+    await onSubmit(trimmed);
+    sessionStorage.removeItem(draftKey(taskId));
+  };
+
+  return (
+    <div className="mt-4 space-y-3">
+      <textarea
+        className="w-full min-h-[260px] rounded-md border p-3 text-sm leading-6"
+        placeholder="Write your response here…"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        disabled={disabled}
+      />
+
+      <div className="flex items-center justify-between text-xs text-gray-600">
+        <span>{charCount.toLocaleString()} characters</span>
+        {savedAt && <span>Draft saved</span>}
+      </div>
+
+      {(localError || submitError) && (
+        <div className="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-700">
+          {localError ?? submitError}
+        </div>
+      )}
+
+      <div className="flex gap-2">
+        <Button type="button" onClick={handleSaveDraft} disabled={disabled}>
+            Save draft
+        </Button>
+        <Button type="button" onClick={handleSubmit} disabled={disabled}>
+          Submit
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

This PR implements the full **text-based task submission** experience for **design** and **documentation** tasks in the Candidate Portal (also supports **handoff** as a text task). Candidates can write long-form answers, save drafts locally, submit to the backend using `contentText`, see clear validation/errors, and progress to the next day on success.

## What changed

### Candidate task UI (text tasks)

- Added a dedicated **TextTaskEditor** component for text-based tasks:
  - Large textarea for the answer
  - Character count display
  - **Save draft** button (persists draft in `sessionStorage` using a task-scoped key)
  - **Submit** button with client-side validation (prevents empty/whitespace-only submissions)
  - Clears stored draft after successful submission
  - Displays errors (`localError` and `submitError`) in a consistent UI block

**File added/updated**
- `src/components/candidate/TextTaskEditor.tsx`

### TaskView: render text editor for design/docs (and handoff)

- Updated `TaskView` to treat the following as **text tasks**:
  - `design`
  - `documentation`
  - `handoff`
- Text tasks render the text editor UX (textarea + character count + Save draft + Submit).
- Code/debug tasks continue to use the existing Monaco-based `CodeEditor`.
- Draft storage remains task-scoped to avoid cross-task bleed.
- Added user-friendly validation/error surfacing for text submissions.

**File updated**
- `src/components/candidate/TaskView.tsx`

### CandidateSimulationContent: submission + validation + progress advance

- Ensured text submissions send payload shape:
  - `{ contentText: "<answer>" }`
- Added client-side validation in the submit handler for text tasks to block empty submissions early.
- On successful submit:
  - Refetches `GET /candidate/session/{candidateSessionId}/current_task`
  - Updates progress + advances current task in UI
- Error handling remains mapped to friendly messages (400/404/409/etc.)

**File updated**
- `src/app/(public)/(candidate)/candidate/[token]/CandidateSimulationContent.tsx`

## Tests

### New unit tests

- Added tests for `TextTaskEditor`:
  - Loads draft from `sessionStorage`
  - Save draft persists changes
  - Submit trims input, calls `onSubmit`, clears stored draft on success
  - Empty submission shows validation error and does not submit

**File added**
- `src/components/candidate/TextTaskEditor.test.tsx`

### Updated integration tests

- Updated `CandidateSimulationContent` tests to:
  - Avoid brittle selectors (e.g., “Day 1” appears in both TaskProgress and TaskView)
  - Verify design/docs submission uses `contentText`
  - Verify empty submission is blocked client-side (no backend submit call)
  - Verify progress advances to next day on success
  - Verify refresh retains progress behavior

**File updated**
- `src/app/(public)/(candidate)/candidate/[token]/CandidateSimulationContent.test.tsx`

## Manual QA performed

Local backend + frontend verification (UI + Postman):

- Opened invite URL `/candidate/[token]` and started simulation.
- Confirmed Day 1 (design) shows textarea + character count + Save draft + Submit.
- Saved draft, refreshed page, and confirmed draft persisted.
- Submitted non-empty answer and confirmed backend returned 200 and UI advanced to Day 2.
- Attempted empty submission and confirmed validation error without submitting.
- Completed remaining days and confirmed completion screen shown at end.
- Verified `POST /tasks/{taskId}/submit` sends `{ contentText: "..." }` for text tasks.

## Notes / follow-ups (non-blocking)

- Backend currently does not expose prior submission content via `current_task`, so we do not render “submitted answer history” on refresh beyond progress state. If/when submissions are exposed (M2+), we can enhance the UI to show prior submitted text.

---

### Checklist

- [x] Large textarea for design/documentation tasks
- [x] Character count
- [x] Save draft (sessionStorage)
- [x] Submit sends `contentText`
- [x] Loading + error states
- [x] Progress advances to next task on success
- [x] Empty submission validation
- [x] Unit + integration tests
- [x] `./precommit.sh` passes


Fixes #5 