### PR TITLE
Candidate Portal — Monaco editor for code/debug tasks (Day 2–4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@auth0/nextjs-auth0": "^4.13.2",
+        "@monaco-editor/loader": "^1.7.0",
         "@monaco-editor/react": "^4.7.0",
         "monaco-editor": "^0.55.1",
         "next": "16.0.8",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@auth0/nextjs-auth0": "^4.13.2",
+    "@monaco-editor/loader": "^1.7.0",
     "@monaco-editor/react": "^4.7.0",
     "monaco-editor": "^0.55.1",
     "next": "16.0.8",

--- a/src/app/(public)/(candidate)/candidate/[token]/CandidateSimulationContent.tsx
+++ b/src/app/(public)/(candidate)/candidate/[token]/CandidateSimulationContent.tsx
@@ -208,11 +208,20 @@ export default function CandidateSimulationContent({ token }: { token: string })
 
       const type = String(state.taskState.currentTask.type);
       const isTextTask = type === "design" || type === "documentation" || type === "handoff";
+      const isCodeTask = type === "code" || type === "debug";
 
       if (isTextTask) {
         const trimmed = (payload.contentText ?? "").trim();
         if (!trimmed) {
           setTaskError("Please enter an answer before submitting.");
+          return;
+        }
+      }
+
+      if (isCodeTask) {
+        const trimmedCode = (payload.codeBlob ?? "").trim();
+        if (!trimmedCode) {
+          setTaskError("Please write some code before submitting.");
           return;
         }
       }

--- a/src/components/candidate/CodeEditor.test.tsx
+++ b/src/components/candidate/CodeEditor.test.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import CodeEditor from "./CodeEditor";
+
+type MonacoMockProps = {
+  value?: string;
+  onChange?: (value?: string) => void;
+  loading?: React.ReactNode;
+};
+
+type LoaderModule = {
+  config: (args: { paths: { vs: string } }) => void;
+};
+
+jest.mock("@monaco-editor/loader", () => ({
+  __esModule: true,
+  default: { config: jest.fn() } satisfies LoaderModule,
+}));
+
+jest.mock("@monaco-editor/react", () => ({
+  __esModule: true,
+  default: function MockMonacoEditor({ value, onChange, loading }: MonacoMockProps) {
+    return (
+      <div>
+        {loading}
+        <textarea
+          data-testid="monaco-mock"
+          value={value ?? ""}
+          onChange={(e) => onChange?.(e.target.value)}
+        />
+      </div>
+    );
+  },
+}));
+
+jest.mock("next/dynamic", () => {
+  return (_importer: unknown) => {
+    return function DynamicMock(props: MonacoMockProps) {
+      const mod = jest.requireMock("@monaco-editor/react") as {
+        default: (p: MonacoMockProps) => React.ReactElement;
+      };
+      const Comp = mod.default;
+      return <Comp {...props} />;
+    };
+  };
+});
+
+describe("CodeEditor", () => {
+  it("renders and calls onChange when typing", () => {
+    const onChange = jest.fn() as unknown as (v: string) => void;
+
+    render(<CodeEditor value={"console.log('hi')\n"} onChange={onChange} language="typescript" />);
+
+    const textarea = screen.getByTestId("monaco-mock") as HTMLTextAreaElement;
+    expect(textarea.value).toContain("console.log('hi')");
+
+    fireEvent.change(textarea, { target: { value: "updated\n" } });
+
+    expect((onChange as unknown as jest.Mock).mock.calls[0]?.[0]).toBe("updated\n");
+  });
+
+  it("shows loading placeholder while editor loads (mocked)", () => {
+    render(<CodeEditor value={"x"} onChange={() => {}} language="typescript" />);
+    expect(screen.getByText(/Loading editor/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/candidate/CodeEditor.tsx
+++ b/src/components/candidate/CodeEditor.tsx
@@ -1,8 +1,23 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import loader from "@monaco-editor/loader";
 import { useMemo } from "react";
 import type { EditorProps } from "@monaco-editor/react";
+
+let monacoConfigured = false;
+
+function ensureMonacoConfigured() {
+  if (monacoConfigured) return;
+  if (typeof window === "undefined") return;
+
+  monacoConfigured = true;
+  loader.config({
+    paths: {
+      vs: "https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs",
+    },
+  });
+}
 
 const MonacoEditor = dynamic<EditorProps>(
   () => import("@monaco-editor/react").then((mod) => mod.default),
@@ -18,12 +33,17 @@ export default function CodeEditor({
   onChange: (v: string) => void;
   language?: "javascript" | "typescript";
 }) {
+  ensureMonacoConfigured();
+
   const options = useMemo<NonNullable<EditorProps["options"]>>(
     () => ({
       minimap: { enabled: false },
       fontSize: 14,
       wordWrap: "on",
       scrollBeyondLastLine: false,
+      automaticLayout: true,
+      tabSize: 2,
+      insertSpaces: true,
     }),
     []
   );
@@ -36,6 +56,7 @@ export default function CodeEditor({
         value={value}
         onChange={(v: string | undefined) => onChange(v ?? "")}
         options={options}
+        loading={<div className="p-3 text-sm text-gray-600">Loading editor…</div>}
       />
     </div>
   );

--- a/src/lib/codeDrafts.ts
+++ b/src/lib/codeDrafts.ts
@@ -1,0 +1,18 @@
+export function codeDraftKey(candidateSessionId: string, taskId: string) {
+  return `simuhire:candidate:codeDraft:${candidateSessionId}:${taskId}`;
+}
+
+export function loadCodeDraft(candidateSessionId: string, taskId: string): string | null {
+  if (typeof window === "undefined") return null;
+  return window.sessionStorage.getItem(codeDraftKey(candidateSessionId, taskId));
+}
+
+export function saveCodeDraft(candidateSessionId: string, taskId: string, code: string) {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.setItem(codeDraftKey(candidateSessionId, taskId), code);
+}
+
+export function clearCodeDraft(candidateSessionId: string, taskId: string) {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.removeItem(codeDraftKey(candidateSessionId, taskId));
+}

--- a/src/lib/starterCode.ts
+++ b/src/lib/starterCode.ts
@@ -1,0 +1,15 @@
+export function getStarterCodeForTask(params: { dayIndex?: number; taskType: string }) {
+  const { dayIndex, taskType } = params;
+
+  const base = `// Welcome to SimuHire.\n// Implement the task requirements below.\n\nexport function handler() {\n  return "TODO";\n}\n`;
+
+  if (taskType === "debug") {
+    return `// Debug task\n// Fix failing tests.\n\n${base}`;
+  }
+
+  if (dayIndex === 2) return `// Day 2 — Implementation\n\n${base}`;
+  if (dayIndex === 3) return `// Day 3 — Iteration / New requirement\n\n${base}`;
+  if (dayIndex === 4) return `// Day 4 — Debugging\n\n${base}`;
+
+  return base;
+}


### PR DESCRIPTION
## Summary

This PR integrates the **Monaco editor** into the Candidate Portal for tasks of type **`code`** and **`debug`** (Days 2–4). It provides:

- Monaco editor rendered client-side (Next.js SSR-safe)
- JS/TS language mode support (defaulting to TypeScript in current UI)
- **Starter code** loaded on first visit (static MVP starter snippet)
- **Single-file indicator** (e.g., `index.ts`)
- **Local draft persistence** (autosave to `sessionStorage` while typing) and removal on successful submission
- Tests updated/added; `./precommit.sh` passes
- Manual local verification completed (frontend + backend + Postman)

## Why

Code and debug tasks require a real code editing experience. Monaco provides a familiar editor UI and unlocks the Day 2–4 experience without needing multi-file project infrastructure yet.

## What changed

### UI behavior (Candidate Portal)

For `code` / `debug` tasks:

- Render Monaco editor in the task view
- Show a simple file label: **File: `index.ts`**
- Autosave draft code to `sessionStorage` as the candidate types (refresh-safe until submit)
- Validate non-empty code on submit
- Submit to backend with `{ "codeBlob": "..." }`
- Clear the saved draft on successful submission
- Continue advancing through the 5-day flow using the existing refetch-on-submit pattern

### Monaco integration details

- Uses `@monaco-editor/react`
- Uses `@monaco-editor/loader` configured to load Monaco assets from a CDN to avoid common Next.js worker/bundling console errors
- Editor is dynamically imported with `ssr: false` to prevent SSR crashes

## Files changed (high level)

> Note: filenames reflect the working locations in the current repo structure.

- `src/components/candidate/CodeEditor.tsx`
  - Monaco editor wrapper
  - CDN loader configuration
  - Editor options (word wrap, minimap off, automatic layout)
- `src/components/candidate/TaskView.tsx`
  - Render `CodeEditor` for `code` / `debug`
  - File indicator
  - Autosave draft for code (and text) via `sessionStorage`
  - Code validation on submit
- `src/app/(public)/(candidate)/candidate/[token]/CandidateSimulationContent.tsx`
  - Submission validation updated to validate code tasks as non-empty as well
- `src/app/(public)/(candidate)/candidate/[token]/CandidateSimulationContent.test.tsx`
  - Updated mocks and selectors to avoid ambiguous button matches
- `src/components/candidate/CodeEditor.test.tsx`
  - New/updated test for Monaco wrapper using mocks (JSDOM-safe)
  - Lint-safe typings (no `any`, no forbidden `require()` imports)
- `package.json` / `package-lock.json`
  - Added:
    - `@monaco-editor/react`
    - `@monaco-editor/loader`

## Requirements checklist (Issue #6)

- [x] For tasks of type **code** or **debug**, render Monaco editor (JS/TS mode)
- [x] Load **starter code** from static MVP source on first visit (no draft)
- [x] Provide a basic **file name indicator** for single-file MVP (`index.ts`)
- [x] Persist editor state locally while the user types until submission (sessionStorage autosave)
- [x] Day 2 shows Monaco editor with starter code preloaded (verified manually)
- [x] Typing inside editor does not reload or lose content on minor state changes (verified manually)
- [x] Refreshing before submit preserves code (sessionStorage) (verified manually)
- [x] No console errors due to Monaco setup on common browsers (verified manually)

## How to test

### Automated

1. Run lint + tests:
   ```bash
   ./precommit.sh
   ```

### Manual local end-to-end (recommended)

**Backend**
1. Start backend locally (ensure DB + env configured)
2. Confirm Swagger loads: `http://localhost:8000/docs`

**Frontend**
1. Set frontend API base URL to local backend (e.g. `.env.local`)
2. Start frontend:
   ```bash
   npm run dev
   ```
3. Open candidate link: `http://localhost:3000/candidate/{token}`

**Flow validation**
1. Use Postman to create a simulation + invite to obtain `{ candidateSessionId, token }`
2. In browser:
   - Start simulation
   - Submit Day 1 (text)
   - Confirm Day 2 loads Monaco with starter code
   - Type code, refresh page, confirm draft persists
   - Submit Day 2 with `{ codeBlob }` and confirm progression to Day 3/4
3. Confirm devtools console shows **no Monaco worker/loading errors**

## Notes / Follow-ups (not required for M1)

- Swap static starter code to backend-provided starter code when available (e.g., `currentTask.starterCode`).
- Multi-file support can be added later (tabs + virtual FS / sandbox integration) in M2+.


Fixes #6 