### PR TITLE
Created candidate submit code task to backend

### DIFF
--- a/src/components/candidate/CodeEditor.test.tsx
+++ b/src/components/candidate/CodeEditor.test.tsx
@@ -8,13 +8,9 @@ type MonacoMockProps = {
   loading?: React.ReactNode;
 };
 
-type LoaderModule = {
-  config: (args: { paths: { vs: string } }) => void;
-};
-
 jest.mock("@monaco-editor/loader", () => ({
   __esModule: true,
-  default: { config: jest.fn() } satisfies LoaderModule,
+  default: { config: jest.fn() },
 }));
 
 jest.mock("@monaco-editor/react", () => ({
@@ -34,7 +30,7 @@ jest.mock("@monaco-editor/react", () => ({
 }));
 
 jest.mock("next/dynamic", () => {
-  return (_importer: unknown) => {
+  return (_importer: unknown, _opts?: unknown) => {
     return function DynamicMock(props: MonacoMockProps) {
       const mod = jest.requireMock("@monaco-editor/react") as {
         default: (p: MonacoMockProps) => React.ReactElement;
@@ -47,7 +43,7 @@ jest.mock("next/dynamic", () => {
 
 describe("CodeEditor", () => {
   it("renders and calls onChange when typing", () => {
-    const onChange = jest.fn() as unknown as (v: string) => void;
+    const onChange = jest.fn<void, [string]>();
 
     render(<CodeEditor value={"console.log('hi')\n"} onChange={onChange} language="typescript" />);
 
@@ -56,7 +52,7 @@ describe("CodeEditor", () => {
 
     fireEvent.change(textarea, { target: { value: "updated\n" } });
 
-    expect((onChange as unknown as jest.Mock).mock.calls[0]?.[0]).toBe("updated\n");
+    expect(onChange).toHaveBeenCalledWith("updated\n");
   });
 
   it("shows loading placeholder while editor loads (mocked)", () => {

--- a/src/components/candidate/CodeEditor.tsx
+++ b/src/components/candidate/CodeEditor.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from "next/dynamic";
 import loader from "@monaco-editor/loader";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import type { EditorProps } from "@monaco-editor/react";
 
 let monacoConfigured = false;
@@ -28,12 +28,16 @@ export default function CodeEditor({
   value,
   onChange,
   language = "typescript",
+  height = 420,
 }: {
   value: string;
   onChange: (v: string) => void;
   language?: "javascript" | "typescript";
+  height?: number;
 }) {
-  ensureMonacoConfigured();
+  useEffect(() => {
+    ensureMonacoConfigured();
+  }, []);
 
   const options = useMemo<NonNullable<EditorProps["options"]>>(
     () => ({
@@ -51,7 +55,7 @@ export default function CodeEditor({
   return (
     <div className="border rounded-md overflow-hidden">
       <MonacoEditor
-        height="420px"
+        height={`${height}px`}
         language={language}
         value={value}
         onChange={(v: string | undefined) => onChange(v ?? "")}

--- a/src/lib/codeDrafts.ts
+++ b/src/lib/codeDrafts.ts
@@ -1,18 +1,32 @@
-export function codeDraftKey(candidateSessionId: string, taskId: string) {
-  return `simuhire:candidate:codeDraft:${candidateSessionId}:${taskId}`;
+export function codeDraftKey(candidateSessionId: number | string, taskId: number | string) {
+  return `simuhire:candidate:codeDraft:${String(candidateSessionId)}:${String(taskId)}`;
 }
 
-export function loadCodeDraft(candidateSessionId: string, taskId: string): string | null {
+export function loadCodeDraft(candidateSessionId: number | string, taskId: number | string): string | null {
   if (typeof window === "undefined") return null;
-  return window.sessionStorage.getItem(codeDraftKey(candidateSessionId, taskId));
+  try {
+    return window.sessionStorage.getItem(codeDraftKey(candidateSessionId, taskId));
+  } catch {
+    return null;
+  }
 }
 
-export function saveCodeDraft(candidateSessionId: string, taskId: string, code: string) {
+export function saveCodeDraft(candidateSessionId: number | string, taskId: number | string, code: string) {
   if (typeof window === "undefined") return;
-  window.sessionStorage.setItem(codeDraftKey(candidateSessionId, taskId), code);
+  try {
+    window.sessionStorage.setItem(codeDraftKey(candidateSessionId, taskId), code);
+  } catch {
+  }
 }
 
-export function clearCodeDraft(candidateSessionId: string, taskId: string) {
+export function clearCodeDraft(candidateSessionId: number | string, taskId: number | string) {
   if (typeof window === "undefined") return;
-  window.sessionStorage.removeItem(codeDraftKey(candidateSessionId, taskId));
+  try {
+    window.sessionStorage.removeItem(codeDraftKey(candidateSessionId, taskId));
+  } catch {
+  }
+}
+
+export function hasCodeDraft(candidateSessionId: number | string, taskId: number | string): boolean {
+  return loadCodeDraft(candidateSessionId, taskId) !== null;
 }


### PR DESCRIPTION
## Summary

This PR wires **code/debug task submission** from the Candidate Portal’s Monaco editor to the backend `POST /api/tasks/{taskId}/submit` endpoint, with clear loading/success/error UI states and safe draft persistence.

Key outcomes:
- Candidates can submit **code/debug** tasks with `{ codeBlob }` payload.
- UI shows **Submitting…** and **Submitted ✓** feedback (including progress when available).
- On success, the UI **advances to the next day/task** by refreshing the current task.
- Error responses show a clear message and **do not lose editor content**.
- Drafts persist in `sessionStorage` and are only cleared after successful submission.

---

## GitHub Issue

**Title:** candidate-portal: submit code task to backend (no tests yet) #7

**Requirements addressed:**
- Collect current editor content and submit it to backend ✅
- Call `POST /tasks/{taskId}/submit` with code payload ✅
- Loading and success/failure states ✅
- On success, update progress and load next task ✅
- No run-tests button yet (M1) ✅
- Errors are clear and editor contents are preserved ✅

---

## Backend Contract Used (Source of Truth)

### Candidate auth headers
- `x-candidate-token: <invite token>`
- `x-candidate-session-id: <candidateSessionId>`

### Submit endpoint
`POST /api/tasks/{taskId}/submit`

Payload:
- Text tasks: `{ "contentText": "..." }`
- Code/debug tasks: `{ "codeBlob": "..." }`

Example submit response (used for UI progress display):
```json
{
  "submissionId": 22,
  "taskId": 93,
  "candidateSessionId": 13,
  "submittedAt": "2025-12-16T07:31:28.834718Z",
  "progress": { "completed": 3, "total": 5 },
  "isComplete": false
}
```

---

## Implementation Overview

### 1) Candidate API client updates
**File:** `src/lib/candidateApi.ts`

- Uses `safeFetch` for consistent network error handling.
- Implements `submitCandidateTask()` which posts `{ contentText }` or `{ codeBlob }`.
- Adds/uses a typed submit response to avoid `any`:
  - `CandidateTaskSubmitResponse` (matches backend response shape including `progress`).

Error handling is mapped to friendly messages:
- `400` → Task out of order
- `404` → Session mismatch / not found
- `409` → Task already submitted
- `410` → Invite expired
- `0` / network → “check your connection”

---

### 2) TaskView: wire code submissions + preserve drafts + show feedback
**File:** `src/components/candidate/TaskView.tsx`

Changes include:
- Supports both text tasks (textarea) and code/debug tasks (Monaco editor).
- Uses per-task draft persistence:
  - **Text**: `sessionStorage` key `:candidate:textDraft:<taskId>`
  - **Code**: `src/lib/codeDrafts.ts` keyed by `(candidateSessionId, taskId)`
- Debounced autosave while typing (refresh-safe).
- Shows submit state and feedback:
  - `Submitting…`
  - `Submitted ✓ Progress: completed/total` when submit response includes progress
- Clears the relevant draft **only after successful submission**.
- Validation:
  - Empty text → “Please enter an answer before submitting.”
  - Empty code → “Please write some code before submitting.”

**Note:** TaskView now requires `candidateSessionId` prop for proper code draft keys.

---

### 3) CandidateSimulationContent: return submit response + delayed refresh
**File:** `src/app/(public)/(candidate)/candidate/[token]/CandidateSimulationContent.tsx`

- `handleSubmit()` now:
  - Validates payload (non-empty) without throwing (keeps UI stable and tests aligned).
  - Calls `submitCandidateTask(...)` and **returns the typed response**.
  - Schedules a delayed refresh (`~900ms`) via `setTimeout` to fetch the next task:
    - This supports the “Submitted ✓ Progress…” UI, then advances the task.
- Adds a guard to only render TaskView when `candidateSessionId !== null` to satisfy TypeScript and prevent edge-case crashes.

---

### 4) Monaco editor and draft utilities
**Files:**
- `src/components/candidate/CodeEditor.tsx`
- `src/lib/codeDrafts.ts`

- Monaco is loaded client-only and configured via CDN loader to avoid worker/bundling issues.
- Draft helper functions:
  - `loadCodeDraft(candidateSessionId, taskId)`
  - `saveCodeDraft(candidateSessionId, taskId, code)`
  - `clearCodeDraft(candidateSessionId, taskId)`

---

## Tests Updated

### Candidate flow tests (delayed refresh + new TaskView prop)
**File:** `src/app/(public)/(candidate)/candidate/[token]/CandidateSimulationContent.test.tsx`

- Updated TaskView mock to accept `candidateSessionId`.
- Uses `jest.useFakeTimers()` and `act()` to advance timers by 900ms for the post-submit refresh.
- Validates:
  - Successful submit uses correct payload
  - Empty submit shows validation error and does not call submit endpoint
  - After submit, task advances (Day 1 → Day 2)
  - Completion state rendering
  - Session restoration from `sessionStorage`

### Code editor tests (fix Jest mock hoisting/TDZ)
**File:** `src/components/candidate/CodeEditor.test.tsx`

- Avoids referencing top-level mock variables inside `jest.mock` factories (prevents TDZ error).
- Keeps the Monaco editor mocked via a textarea, ensuring deterministic tests.

---

## Manual Verification Checklist (Local)

### Setup
- Backend: `./runBackend.sh` (FastAPI on `http://localhost:8000`)
- Frontend: `npm run dev` with `NEXT_PUBLIC_API_BASE_URL=http://localhost:8000`

### Candidate portal flow
1. Generate an invite URL via:
   - `POST /api/simulations`
   - `POST /api/simulations/{id}/invite`
2. Open `http://localhost:3000/candidate/<token>`
3. Start simulation
4. Submit each day through Day 5:
   - Code tasks submit `{ codeBlob }`
   - Text tasks submit `{ contentText }`
5. Confirm:
   - Network calls appear in DevTools
   - Submit shows “Submitting…” then “Submitted ✓”
   - Task advances after submit (Day 2 → Day 3 → Day 4 → …)
   - Errors do not clear editor contents
   - Refresh mid-task preserves drafts
   - After successful submission, drafts are cleared

### Observed backend logs (example)
- `POST /api/tasks/{id}/submit` returns 201
- `GET /api/candidate/session/{candidateSessionId}/current_task` returns 200 after submit

---

## Files Changed (high-level)

- `src/lib/candidateApi.ts`
- `src/app/(public)/(candidate)/candidate/[token]/CandidateSimulationContent.tsx`
- `src/app/(public)/(candidate)/candidate/[token]/CandidateSimulationContent.test.tsx`
- `src/components/candidate/TaskView.tsx`
- `src/components/candidate/CodeEditor.tsx`
- `src/components/candidate/CodeEditor.test.tsx`
- `src/lib/codeDrafts.ts`

---

## Notes / Follow-ups (not in scope for M1)

- “Run tests” button and sandbox integration will be added in M2.
- Multi-file support and richer editor file tree can be explored later; M1 is single-file `{ codeBlob }` MVP.



Fixes #7 