### PR TITLE
Created simulation form for recruiters

### DIFF
--- a/src/app/(private)/(recruiter)/dashboard/RecruiterDashboardContent.test.tsx
+++ b/src/app/(private)/(recruiter)/dashboard/RecruiterDashboardContent.test.tsx
@@ -8,6 +8,18 @@ jest.mock("@/lib/recruiterApi", () => ({
   inviteCandidate: jest.fn(),
 }));
 
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    refresh: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+  }),
+}));
+
+
 const mockedListSimulations = listSimulations as jest.MockedFunction<typeof listSimulations>;
 const mockedInviteCandidate = inviteCandidate as jest.MockedFunction<typeof inviteCandidate>;
 

--- a/src/app/(private)/(recruiter)/dashboard/RecruiterDashboardContent.tsx
+++ b/src/app/(private)/(recruiter)/dashboard/RecruiterDashboardContent.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import {
   inviteCandidate,
   listSimulations,
   type SimulationListItem,
 } from "@/lib/recruiterApi";
 import Button from "@/components/common/Button";
+import PageHeader from "@/components/common/PageHeader";
 
 export type RecruiterProfile = {
   id: number;
@@ -186,6 +188,8 @@ export default function RecruiterDashboardContent({
   profile,
   error,
 }: RecruiterDashboardContentProps) {
+  const router = useRouter();
+
   const [loading, setLoading] = useState(true);
   const [simulations, setSimulations] = useState<SimulationListItem[]>([]);
   const [simError, setSimError] = useState<string | null>(null);
@@ -276,7 +280,17 @@ export default function RecruiterDashboardContent({
 
   return (
     <main className="flex flex-col gap-4 py-8">
-      <h1 className="text-2xl font-semibold">Dashboard</h1>
+      <PageHeader
+        title="Dashboard"
+        actions={
+          <Button
+            type="button"
+            onClick={() => router.push("/dashboard/simulations/new")}
+          >
+            New Simulation
+          </Button>
+        }
+      />
 
       {toast.open ? (
         <div
@@ -324,11 +338,15 @@ export default function RecruiterDashboardContent({
       <section className="flex flex-col gap-3">
         <h2 className="text-lg font-semibold">Simulations</h2>
 
-        {loading ? <p className="text-sm text-gray-600">Loading simulations…</p> : null}
+        {loading ? (
+          <p className="text-sm text-gray-600">Loading simulations…</p>
+        ) : null}
 
         {!loading && simError ? (
           <div className="rounded border border-red-200 bg-red-50 p-3">
-            <p className="text-sm font-medium text-red-700">Couldn’t load simulations</p>
+            <p className="text-sm font-medium text-red-700">
+              Couldn’t load simulations
+            </p>
             <p className="text-sm text-red-700">{simError}</p>
           </div>
         ) : null}
@@ -349,7 +367,10 @@ export default function RecruiterDashboardContent({
             </div>
 
             {simulations.map((sim) => (
-              <div key={sim.id} className="border-b border-gray-200 p-3 last:border-b-0">
+              <div
+                key={sim.id}
+                className="border-b border-gray-200 p-3 last:border-b-0"
+              >
                 <div className="grid grid-cols-12 items-center gap-3">
                   <div className="col-span-4">
                     <p className="font-medium">{sim.title}</p>
@@ -371,7 +392,9 @@ export default function RecruiterDashboardContent({
                   </div>
 
                   <div className="col-span-2 flex justify-end">
-                    <Button onClick={() => openInviteModal(sim)}>Invite candidate</Button>
+                    <Button onClick={() => openInviteModal(sim)}>
+                      Invite candidate
+                    </Button>
                   </div>
                 </div>
               </div>

--- a/src/app/(private)/(recruiter)/dashboard/simulations/new/CreateSimulationContent.tsx
+++ b/src/app/(private)/(recruiter)/dashboard/simulations/new/CreateSimulationContent.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import Button from "@/components/common/Button";
+import Input from "@/components/common/Input";
+import PageHeader from "@/components/common/PageHeader";
+import { createSimulation, type CreateSimulationInput } from "@/lib/recruiterApi";
+
+type FieldErrors = Partial<Record<keyof CreateSimulationInput, string>> & {
+  form?: string;
+};
+
+type HttpishError = {
+  status?: number;
+  response?: { status?: number };
+  body?: { message?: string; detail?: string };
+  message?: string;
+};
+
+const SENIORITY_OPTIONS: CreateSimulationInput["seniority"][] = [
+  "Junior",
+  "Mid",
+  "Senior",
+];
+
+export default function CreateSimulationContent() {
+  const router = useRouter();
+
+  const [title, setTitle] = useState<string>("");
+  const [role, setRole] = useState<string>("Backend Engineer");
+  const [techStack, setTechStack] = useState<string>("Node.js + Postgres");
+  const [seniority, setSeniority] =
+    useState<CreateSimulationInput["seniority"]>("Mid");
+  const [focus, setFocus] = useState<string>("");
+
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
+  const payload: CreateSimulationInput = useMemo(
+    () => ({
+      title: title.trim(),
+      role: role.trim(),
+      techStack: techStack.trim(),
+      seniority,
+      focus: focus.trim() ? focus.trim() : undefined,
+    }),
+    [title, role, techStack, seniority, focus]
+  );
+
+  function validate(input: CreateSimulationInput): FieldErrors {
+    const next: FieldErrors = {};
+    if (!input.title) next.title = "Title is required.";
+    if (!input.role) next.role = "Role is required.";
+    if (!input.techStack) next.techStack = "Tech stack is required.";
+    if (!input.seniority) next.seniority = "Seniority is required.";
+    return next;
+  }
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    const nextErrors = validate(payload);
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors);
+      return;
+    }
+
+    setErrors({});
+    setIsSubmitting(true);
+
+    try {
+      const res = await createSimulation(payload);
+
+      if (!res.id) {
+        setErrors({ form: "Simulation created but no id was returned." });
+        return;
+      }
+
+      router.push("/dashboard");
+      router.refresh();
+    } catch (caught: unknown) {
+      const err = caught as HttpishError;
+      const status = err.status ?? err.response?.status;
+
+      if (status === 401) {
+        router.push("/login");
+        return;
+      }
+
+      const message =
+        err.body?.message ??
+        err.body?.detail ??
+        err.message ??
+        "Failed to create simulation. Please try again.";
+
+      setErrors({ form: message });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="flex flex-col gap-6 py-8">
+      <PageHeader
+        title="New Simulation"
+        subtitle="Create a new 5-day simulation."
+        actions={
+          <Button type="button" onClick={() => router.push("/dashboard")}>
+            Back
+          </Button>
+        }
+      />
+
+      <form onSubmit={onSubmit} className="flex max-w-2xl flex-col gap-4">
+        {errors.form ? (
+          <div className="rounded border border-red-200 bg-red-50 p-3" role="alert">
+            <p className="text-sm font-medium text-red-700">Couldn’t create simulation</p>
+            <p className="text-sm text-red-700">{errors.form}</p>
+          </div>
+        ) : null}
+
+        <div>
+          <label
+            htmlFor="title"
+            className="text-xs font-medium uppercase tracking-wide text-gray-500"
+          >
+            Title
+          </label>
+          <Input
+            id="title"
+            className="mt-1 w-full"
+            value={title}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setTitle(e.target.value)
+            }
+            placeholder="Backend Engineer — Payments API"
+            aria-invalid={Boolean(errors.title)}
+            aria-describedby={errors.title ? "title-error" : undefined}
+            disabled={isSubmitting}
+          />
+          {errors.title ? (
+            <p id="title-error" className="mt-1 text-sm text-red-700" role="alert">
+              {errors.title}
+            </p>
+          ) : null}
+        </div>
+
+        <div>
+          <label
+            htmlFor="role"
+            className="text-xs font-medium uppercase tracking-wide text-gray-500"
+          >
+            Role
+          </label>
+          <Input
+            id="role"
+            className="mt-1 w-full"
+            value={role}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setRole(e.target.value)
+            }
+            placeholder="Backend Engineer"
+            aria-invalid={Boolean(errors.role)}
+            aria-describedby={errors.role ? "role-error" : undefined}
+            disabled={isSubmitting}
+          />
+          {errors.role ? (
+            <p id="role-error" className="mt-1 text-sm text-red-700" role="alert">
+              {errors.role}
+            </p>
+          ) : null}
+        </div>
+
+        <div>
+          <label
+            htmlFor="techStack"
+            className="text-xs font-medium uppercase tracking-wide text-gray-500"
+          >
+            Tech stack
+          </label>
+          <Input
+            id="techStack"
+            className="mt-1 w-full"
+            value={techStack}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setTechStack(e.target.value)
+            }
+            placeholder="Node.js + Postgres"
+            aria-invalid={Boolean(errors.techStack)}
+            aria-describedby={errors.techStack ? "techStack-error" : undefined}
+            disabled={isSubmitting}
+          />
+          {errors.techStack ? (
+            <p
+              id="techStack-error"
+              className="mt-1 text-sm text-red-700"
+              role="alert"
+            >
+              {errors.techStack}
+            </p>
+          ) : null}
+        </div>
+
+        <div>
+          <label
+            htmlFor="seniority"
+            className="text-xs font-medium uppercase tracking-wide text-gray-500"
+          >
+            Seniority
+          </label>
+          <select
+            id="seniority"
+            className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+            value={seniority}
+            onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+              setSeniority(e.target.value as CreateSimulationInput["seniority"])
+            }
+            disabled={isSubmitting}
+            aria-invalid={Boolean(errors.seniority)}
+            aria-describedby={errors.seniority ? "seniority-error" : undefined}
+          >
+            {SENIORITY_OPTIONS.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt}
+              </option>
+            ))}
+          </select>
+          {errors.seniority ? (
+            <p
+              id="seniority-error"
+              className="mt-1 text-sm text-red-700"
+              role="alert"
+            >
+              {errors.seniority}
+            </p>
+          ) : null}
+        </div>
+
+        <div>
+          <label
+            htmlFor="focus"
+            className="text-xs font-medium uppercase tracking-wide text-gray-500"
+          >
+            Focus / notes (optional)
+          </label>
+          <textarea
+            id="focus"
+            className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+            value={focus}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+              setFocus(e.target.value)
+            }
+            rows={4}
+            placeholder="Optional context or what to emphasize"
+            disabled={isSubmitting}
+          />
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <Button type="button" onClick={() => router.push("/dashboard")} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? "Creating…" : "Create simulation"}
+          </Button>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/src/app/(private)/(recruiter)/dashboard/simulations/new/page.tsx
+++ b/src/app/(private)/(recruiter)/dashboard/simulations/new/page.tsx
@@ -1,0 +1,5 @@
+import CreateSimulationContent from "./CreateSimulationContent";
+
+export default function Page() {
+  return <CreateSimulationContent />;
+}

--- a/src/lib/recruiterApi.ts
+++ b/src/lib/recruiterApi.ts
@@ -14,6 +14,18 @@ export type InviteCandidateResponse = {
   inviteUrl: string;
 };
 
+export type CreateSimulationInput = {
+  title: string;
+  role: string;
+  techStack: string;
+  seniority: "Junior" | "Mid" | "Senior";
+  focus?: string;
+};
+
+export type CreateSimulationResponse = {
+  id: string;
+};
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -98,4 +110,34 @@ export async function inviteCandidate(
   });
 
   return normalizeInviteResponse(data);
+}
+
+
+function normalizeCreateSimulationResponse(raw: unknown): CreateSimulationResponse {
+  if (!isRecord(raw)) return { id: "" };
+  const id = getId(raw.id ?? raw.simulationId ?? raw.simulation_id);
+  return { id };
+}
+
+
+export async function createSimulation(
+  input: CreateSimulationInput
+): Promise<CreateSimulationResponse> {
+  const safeTitle = input.title.trim();
+  const safeRole = input.role.trim();
+  const safeTechStack = input.techStack.trim();
+
+  if (!safeTitle || !safeRole || !safeTechStack) {
+    return { id: "" };
+  }
+
+  const data = await apiClient.post<unknown>("/simulations", {
+    title: safeTitle,
+    role: safeRole,
+    techStack: safeTechStack,
+    seniority: input.seniority,
+    focus: input.focus?.trim() ? input.focus.trim() : undefined,
+  });
+
+  return normalizeCreateSimulationResponse(data);
 }


### PR DESCRIPTION
## Summary

This PR implements a simple recruiter-facing UI to create a new simulation using the backend **POST `/api/simulations`** endpoint. It adds:

- A **New Simulation** entry point on `/dashboard`
- A dedicated page at **`/dashboard/simulations/new`** with an MVP create-simulation form
- Backend-for-Frontend (BFF) support for **POST** on `/api/simulations`
- Client API support in `recruiterApi` for creating simulations
- Validation, loading, and error states
- Redirect + refresh so the newly-created simulation appears on `/dashboard` without manual refresh
- Updated unit tests and App Router mocking in tests so Jest runs cleanly

---

## User-facing behavior

### Entry points
- Recruiter dashboard (`/dashboard`) now includes a **New Simulation** button.
- Clicking it navigates to **`/dashboard/simulations/new`**.

### Create Simulation form (MVP fields)
- **Title** (required)
- **Role** (required, e.g. “Backend Engineer”)
- **Tech stack** (required, free text, e.g. “Node.js + Postgres”)
- **Seniority** (required dropdown: Junior / Mid / Senior)
- **Focus / notes** (optional free text)

### Submit behavior
- On submit, UI sends a POST to the frontend BFF: **`POST /api/simulations`**
- BFF proxies to backend: **`POST {BACKEND_BASE_URL}/api/simulations`** with recruiter auth
- While submitting:
  - Button shows **Creating…**
  - Inputs are disabled
- On success (200/201):
  - Redirects to `/dashboard`
  - Triggers a refresh so the new simulation appears without manual reload

### Validation + errors
- Client-side validation prevents submit and shows inline errors for missing required fields
- Backend validation or upstream errors (400/401/422/500) show a clear inline error box
- Unauthorized (no recruiter session):
  - BFF returns 401
  - UI redirects to `/login` or shows appropriate protected-route behavior via middleware (depending on session flow)

---

## Backend API contract used

### Recruiter-auth required
- `GET /api/simulations` — list simulations (already existed from issue #8)
- `POST /api/simulations` — create a simulation with form data (added in this PR via BFF proxy)

### Payload sent on create
```json
{
  "title": "Backend Engineer — Payments API",
  "role": "Backend Engineer",
  "techStack": "Node.js + Postgres",
  "seniority": "Mid",
  "focus": "Optional notes..."
}
```

---

## Code changes (high level)

### Routes / Pages
- Added a dedicated create page:
  - `src/app/(private)/(recruiter)/dashboard/simulations/new/page.tsx`
  - `src/app/(private)/(recruiter)/dashboard/simulations/new/CreateSimulationContent.tsx`

- Updated dashboard header to include **New Simulation**:
  - `src/app/(private)/(recruiter)/dashboard/RecruiterDashboardContent.tsx`

### BFF routes (Next.js App Router API)
- Added POST support to simulations BFF endpoint:
  - `src/app/api/simulations/route.ts`
    - Existing GET remains
    - New POST proxies request body + passes recruiter bearer token

### Client API layer
- Added createSimulation helper + types:
  - `src/lib/recruiterApi.ts`
    - `CreateSimulationInput`
    - `createSimulation(input)` (calls `apiClient.post("/simulations", ...)`)
    - Normalizes returned simulation id

### Tests
- Updated tests to work with `useRouter()` usage by mocking App Router in Jest:
  - `src/app/(private)/(recruiter)/dashboard/RecruiterDashboardContent.test.tsx`
- All tests pass with `./precommit.sh`

---

## How to test (manual QA)

### Prerequisites
- Backend running on `http://localhost:8000`
- Frontend running on `http://localhost:3000`
- Ensure `BACKEND_BASE_URL=http://localhost:8000` in the frontend environment (or fallback default applies)

### Steps
1. Go to `http://localhost:3000/dashboard` (recruiter-auth required).
2. Click **New Simulation**.
3. On `/dashboard/simulations/new`:
   - Try submitting with a missing Title → expect inline validation error and no network request.
4. Fill valid fields and click **Create simulation**:
   - Expect “Creating…” state
   - Expect redirect to `/dashboard`
   - Expect the new simulation appears in the list **without manual refresh**
5. Force backend failure (stop backend or trigger 400/422) and submit:
   - Expect a clear inline error box
6. Log out and access `/dashboard/simulations/new`:
   - Expect redirect to login or unauthorized handling via middleware/BFF

---

## Automated checks

- `./precommit.sh`:
  - ✅ ESLint
  - ✅ Jest unit tests (CI mode)
  - ✅ Typecheck
  - ✅ Next build

---

## Notes / Follow-ups

- Future enhancement (later milestone): redirect to `/dashboard/simulations/{id}` when a simulation detail page exists.
- Styling remains intentionally lightweight for M1 functionality; follows existing Tailwind conventions in the recruiter UI.


Fixes #36 