### PR TITLE
Patch for removing trailing api prefix

### DIFF
--- a/src/app/api/simulations/[id]/invite/route.ts
+++ b/src/app/api/simulations/[id]/invite/route.ts
@@ -2,7 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth0, getAccessToken } from "@/lib/auth0";
 
 function getBackendBaseUrl(): string {
-  return process.env.BACKEND_BASE_URL ?? "http://localhost:8000";
+  const raw = process.env.BACKEND_BASE_URL ?? "http://localhost:8000";
+  const trimmed = raw.replace(/\/+$/, "");
+  return trimmed.endsWith("/api") ? trimmed.slice(0, -4) : trimmed;
 }
 
 async function parseBody(res: Response): Promise<unknown> {

--- a/src/app/api/simulations/route.ts
+++ b/src/app/api/simulations/route.ts
@@ -2,7 +2,9 @@ import { NextResponse } from "next/server";
 import { auth0, getAccessToken } from "@/lib/auth0";
 
 function getBackendBaseUrl(): string {
-  return process.env.BACKEND_BASE_URL ?? "http://localhost:8000";
+  const raw = process.env.BACKEND_BASE_URL ?? "http://localhost:8000";
+  const trimmed = raw.replace(/\/+$/, "");
+  return trimmed.endsWith("/api") ? trimmed.slice(0, -4) : trimmed;
 }
 
 export async function GET() {

--- a/src/lib/candidateApi.ts
+++ b/src/lib/candidateApi.ts
@@ -122,7 +122,7 @@ export async function submitCandidateTask(params: {
 }) {
   const { taskId, token, candidateSessionId, contentText, codeBlob } = params;
 
-  const url = `${API_BASE}/api/tasks/${taskId}/submit`;
+  const url = `${API_BASE}/tasks/${taskId}/submit`;
 
   const res = await safeFetch(url, {
     method: "POST",


### PR DESCRIPTION
Addresses the following bug by normalizing backend base URL and removing trailing "/api" prefixes:

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/98eb1bcb-a250-4532-a70a-b46d31308c32" />

