### PR TITLE
Implmented Recruiter Portal — Invite Management UI

### DIFF
--- a/src/app/api/simulations/[id]/candidates/[candidateSessionId]/invite/resend/route.ts
+++ b/src/app/api/simulations/[id]/candidates/[candidateSessionId]/invite/resend/route.ts
@@ -1,0 +1,17 @@
+import { forwardJson, withAuthGuard } from '@/lib/server/bff';
+
+export async function POST(
+  _req: Request,
+  context: { params: Promise<{ id: string; candidateSessionId: string }> },
+) {
+  const { id, candidateSessionId } = await context.params;
+
+  return withAuthGuard((accessToken) =>
+    forwardJson({
+      path: `/api/simulations/${encodeURIComponent(id)}/candidates/${encodeURIComponent(candidateSessionId)}/invite/resend`,
+      method: 'POST',
+      cache: 'no-store',
+      accessToken,
+    }),
+  );
+}

--- a/src/features/recruiter/simulation-detail/RecruiterSimulationDetailPage.tsx
+++ b/src/features/recruiter/simulation-detail/RecruiterSimulationDetailPage.tsx
@@ -1,12 +1,138 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
+import Button from '@/components/ui/Button';
 import PageHeader from '@/components/ui/PageHeader';
 import { CandidateStatusPill } from '@/features/recruiter/components/CandidateStatusPill';
+import { useInviteCandidateFlow } from '@/features/recruiter/dashboard/hooks/useInviteCandidateFlow';
+import { InviteCandidateModal } from '@/features/recruiter/invitations/InviteCandidateModal';
+import { InviteToast } from '@/features/recruiter/invitations/InviteToast';
+import {
+  copyToClipboard,
+  errorToMessage,
+} from '@/features/recruiter/utils/formatters';
 import { toUserMessage } from '@/lib/utils/errors';
 import type { CandidateSession } from '@/types/recruiter';
+
+type RowState = {
+  resending?: boolean;
+  copied?: boolean;
+  error?: string | null;
+  message?: string | null;
+  cooldownUntilMs?: number | null;
+};
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return 0;
+}
+
+function toStringOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function normalizeCandidateSession(raw: unknown): CandidateSession {
+  if (!raw || typeof raw !== 'object') {
+    return {
+      candidateSessionId: 0,
+      inviteEmail: null,
+      candidateName: null,
+      status: 'not_started',
+      startedAt: null,
+      completedAt: null,
+      hasReport: false,
+    };
+  }
+
+  const rec = raw as Record<string, unknown>;
+
+  return {
+    candidateSessionId: toNumber(
+      rec.candidateSessionId ?? rec.candidate_session_id ?? rec.id,
+    ),
+    inviteEmail: toStringOrNull(rec.inviteEmail ?? rec.invite_email),
+    candidateName: toStringOrNull(rec.candidateName ?? rec.candidate_name),
+    status: (typeof rec.status === 'string'
+      ? rec.status
+      : typeof rec.sessionStatus === 'string'
+        ? rec.sessionStatus
+        : 'not_started') as CandidateSession['status'],
+    startedAt: toStringOrNull(rec.startedAt ?? rec.started_at),
+    completedAt: toStringOrNull(rec.completedAt ?? rec.completed_at),
+    hasReport: rec.hasReport === true || rec.has_report === true,
+    inviteToken: toStringOrNull(
+      rec.token ?? rec.inviteToken ?? rec.invite_token,
+    ),
+    inviteUrl: toStringOrNull(rec.inviteUrl ?? rec.invite_url),
+    inviteEmailStatus: toStringOrNull(
+      rec.inviteEmailStatus ?? rec.invite_email_status,
+    ),
+    inviteEmailSentAt: toStringOrNull(
+      rec.inviteEmailSentAt ?? rec.invite_email_sent_at,
+    ),
+    inviteEmailError: toStringOrNull(
+      rec.inviteEmailError ?? rec.invite_email_error,
+    ),
+  };
+}
+
+function formatDateTime(value: string | null): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString();
+}
+
+function inviteStatusLabel(
+  status: CandidateSession['inviteEmailStatus'],
+): string {
+  if (!status) return 'Not sent';
+  const normalized = String(status).toLowerCase();
+  if (normalized === 'sent') return 'Email sent';
+  if (normalized === 'failed') return 'Delivery failed';
+  if (normalized === 'rate_limited') return 'Rate limited';
+  return String(status).replace(/_/g, ' ');
+}
+
+function buildInviteLink(candidate: CandidateSession): string | null {
+  if (candidate.inviteUrl?.trim()) return candidate.inviteUrl.trim();
+  return null;
+}
+
+async function safeParseResponse(res: Response): Promise<unknown> {
+  const contentType = res.headers.get('content-type') ?? '';
+  const clone = typeof res.clone === 'function' ? res.clone() : null;
+
+  if (contentType.includes('application/json')) {
+    try {
+      return await res.json();
+    } catch {
+      if (!clone) return null;
+      try {
+        return await clone.text();
+      } catch {
+        return null;
+      }
+    }
+  }
+
+  try {
+    return await res.text();
+  } catch {
+    if (!clone) return null;
+    try {
+      return await clone.text();
+    } catch {
+      return null;
+    }
+  }
+}
 
 export default function RecruiterSimulationDetailPage() {
   const params = useParams<{ id: string }>();
@@ -15,49 +141,295 @@ export default function RecruiterSimulationDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [candidates, setCandidates] = useState<CandidateSession[]>([]);
+  const [rowStates, setRowStates] = useState<Record<number, RowState>>({});
+  const [inviteModalOpen, setInviteModalOpen] = useState(false);
+  const [toast, setToast] = useState<
+    | { open: false }
+    | {
+        open: true;
+        kind: 'success' | 'error';
+        message: string;
+        inviteUrl?: string;
+      }
+  >({ open: false });
+  const [toastCopied, setToastCopied] = useState(false);
+
+  const mountedRef = useRef(true);
+  const toastTimerRef = useRef<number | null>(null);
+  const toastCopyTimerRef = useRef<number | null>(null);
+  const cooldownTimersRef = useRef<Record<number, number>>({});
+  const RATE_LIMIT_MESSAGE = 'Rate limited — try again in ~30s';
+
+  const inviteFlow = useInviteCandidateFlow(
+    inviteModalOpen
+      ? {
+          open: true,
+          simulationId,
+          simulationTitle: `Simulation ${simulationId}`,
+        }
+      : null,
+  );
 
   useEffect(() => {
-    let cancelled = false;
-
-    async function run() {
-      try {
-        setLoading(true);
-        setError(null);
-
-        const res = await fetch(`/api/simulations/${simulationId}/candidates`, {
-          method: 'GET',
-          cache: 'no-store',
-        });
-
-        if (!res.ok) {
-          const maybeJson: unknown = await res.json().catch(() => null);
-          const fallbackText = await res.text().catch(() => '');
-          const msg =
-            maybeJson !== null
-              ? toUserMessage(maybeJson, 'Request failed', {
-                  includeDetail: true,
-                })
-              : fallbackText;
-          throw new Error(msg || `Failed to load candidates (${res.status})`);
-        }
-
-        const data = (await res.json()) as CandidateSession[];
-        if (!cancelled) setCandidates(Array.isArray(data) ? data : []);
-      } catch (e: unknown) {
-        if (!cancelled)
-          setError(toUserMessage(e, 'Request failed', { includeDetail: true }));
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-
-    run();
+    mountedRef.current = true;
     return () => {
-      cancelled = true;
+      mountedRef.current = false;
+      if (toastTimerRef.current) window.clearTimeout(toastTimerRef.current);
+      if (toastCopyTimerRef.current)
+        window.clearTimeout(toastCopyTimerRef.current);
+      Object.values(cooldownTimersRef.current).forEach((timerId) => {
+        window.clearTimeout(timerId);
+      });
+      cooldownTimersRef.current = {};
     };
+  }, []);
+
+  useEffect(() => {
+    setCandidates([]);
+    setRowStates({});
+    setError(null);
   }, [simulationId]);
 
+  const loadCandidates = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/simulations/${simulationId}/candidates`, {
+        method: 'GET',
+        cache: 'no-store',
+      });
+
+      const parsed = await safeParseResponse(res);
+
+      if (!res.ok) {
+        const msg = toUserMessage(parsed, 'Request failed', {
+          includeDetail: true,
+        });
+        throw new Error(msg || `Failed to load candidates (${res.status})`);
+      }
+
+      const data = Array.isArray(parsed) ? parsed : [];
+      if (mountedRef.current) {
+        setCandidates(data.map(normalizeCandidateSession));
+      }
+    } catch (e: unknown) {
+      if (mountedRef.current)
+        setError(toUserMessage(e, 'Request failed', { includeDetail: true }));
+    } finally {
+      if (mountedRef.current) setLoading(false);
+    }
+  }, [simulationId]);
+
+  useEffect(() => {
+    void loadCandidates();
+  }, [loadCandidates]);
+
   const rows = useMemo(() => candidates ?? [], [candidates]);
+
+  const updateRowState = useCallback(
+    (
+      candidateSessionId: number,
+      updater: RowState | ((prev: RowState) => RowState),
+    ) => {
+      setRowStates((prev) => {
+        const current = prev[candidateSessionId] ?? {};
+        const next =
+          typeof updater === 'function'
+            ? (updater as (prev: RowState) => RowState)(current)
+            : updater;
+        return { ...prev, [candidateSessionId]: next };
+      });
+    },
+    [],
+  );
+
+  const handleCopy = useCallback(
+    async (candidate: CandidateSession) => {
+      const link = buildInviteLink(candidate);
+      const id = candidate.candidateSessionId;
+      if (!link) {
+        updateRowState(id, (prev) => ({
+          ...prev,
+          copied: false,
+          message: null,
+          error: 'Invite link unavailable — resend invite or refresh.',
+        }));
+        return;
+      }
+
+      const ok = await copyToClipboard(link);
+      if (!mountedRef.current) return;
+
+      updateRowState(id, (prev) => ({
+        ...prev,
+        copied: ok,
+        error: ok ? null : 'Unable to copy invite link.',
+        message: ok ? 'Invite link copied' : null,
+      }));
+
+      window.setTimeout(() => {
+        if (!mountedRef.current) return;
+        updateRowState(id, (prev) => ({
+          ...prev,
+          copied: false,
+          message: null,
+        }));
+      }, 1800);
+    },
+    [updateRowState],
+  );
+
+  const handleResend = useCallback(
+    async (candidate: CandidateSession) => {
+      const id = candidate.candidateSessionId;
+      const startCooldown = () => {
+        updateRowState(id, (prev) => ({
+          ...prev,
+          resending: false,
+          message: RATE_LIMIT_MESSAGE,
+          cooldownUntilMs: Date.now() + 30_000,
+        }));
+        if (cooldownTimersRef.current[id])
+          window.clearTimeout(cooldownTimersRef.current[id]);
+        cooldownTimersRef.current[id] = window.setTimeout(() => {
+          updateRowState(id, (prev) => ({
+            ...prev,
+            cooldownUntilMs: null,
+            message: prev.message === RATE_LIMIT_MESSAGE ? null : prev.message,
+          }));
+          delete cooldownTimersRef.current[id];
+        }, 30_000);
+      };
+
+      updateRowState(id, (prev) => ({
+        ...prev,
+        resending: true,
+        error: null,
+        message: null,
+        cooldownUntilMs: prev.cooldownUntilMs ?? null,
+      }));
+
+      try {
+        const res = await fetch(
+          `/api/simulations/${simulationId}/candidates/${id}/invite/resend`,
+          { method: 'POST', cache: 'no-store' },
+        );
+
+        const parsed = await safeParseResponse(res);
+
+        const rateLimited =
+          res.status === 429 ||
+          (parsed &&
+            typeof parsed === 'object' &&
+            (parsed as { inviteEmailStatus?: unknown }).inviteEmailStatus ===
+              'rate_limited');
+
+        const notFound =
+          res.status === 404 ||
+          (parsed &&
+            typeof parsed === 'object' &&
+            /not\s+found/i.test(
+              String(
+                (parsed as { message?: unknown }).message ??
+                  (parsed as { detail?: unknown }).detail ??
+                  '',
+              ),
+            ));
+
+        if (notFound) {
+          updateRowState(id, (prev) => ({
+            ...prev,
+            resending: false,
+            error: 'Candidate not found — refreshing list.',
+          }));
+          void loadCandidates();
+          return;
+        }
+
+        if (!res.ok) {
+          if (rateLimited) {
+            startCooldown();
+            return;
+          }
+          const msg = toUserMessage(parsed, 'Unable to resend invite.', {
+            includeDetail: true,
+          });
+          throw new Error(msg || `Unable to resend invite (${res.status})`);
+        }
+
+        if (parsed && typeof parsed === 'object') {
+          const normalized = normalizeCandidateSession(parsed);
+          setCandidates((prev) =>
+            prev.map((c) =>
+              c.candidateSessionId === id ? { ...c, ...normalized } : c,
+            ),
+          );
+        } else {
+          void loadCandidates();
+        }
+
+        if (rateLimited) {
+          startCooldown();
+        } else {
+          updateRowState(id, (prev) => ({
+            ...prev,
+            resending: false,
+            message: inviteStatusLabel(
+              (parsed as CandidateSession | null)?.inviteEmailStatus ?? 'sent',
+            ),
+            cooldownUntilMs: prev.cooldownUntilMs ?? null,
+          }));
+        }
+      } catch (e: unknown) {
+        if (!mountedRef.current) return;
+        updateRowState(id, (prev) => ({
+          ...prev,
+          resending: false,
+          error: errorToMessage(e, 'Unable to resend invite.'),
+        }));
+      }
+    },
+    [loadCandidates, simulationId, updateRowState],
+  );
+
+  const dismissToast = useCallback(() => {
+    setToast({ open: false });
+    setToastCopied(false);
+  }, []);
+
+  const inviteLabel = useMemo(
+    () => `Simulation ${simulationId}`,
+    [simulationId],
+  );
+
+  const submitInvite = useCallback(
+    async (candidateName: string, inviteEmail: string) => {
+      const res = await inviteFlow.submit(candidateName, inviteEmail);
+      if (!res) return;
+
+      setInviteModalOpen(false);
+
+      const who = res.candidateName
+        ? `${res.candidateName} (${res.candidateEmail})`
+        : res.candidateEmail;
+
+      setToast({
+        open: true,
+        kind: 'success',
+        message: `Invite created for ${who}.`,
+        inviteUrl: res.inviteUrl,
+      });
+
+      if (toastTimerRef.current) window.clearTimeout(toastTimerRef.current);
+      toastTimerRef.current = window.setTimeout(() => {
+        dismissToast();
+        toastTimerRef.current = null;
+      }, 6500);
+
+      void loadCandidates();
+    },
+    [dismissToast, inviteFlow, loadCandidates],
+  );
 
   return (
     <div className="flex flex-col gap-4 py-8">
@@ -66,13 +438,41 @@ export default function RecruiterSimulationDetailPage() {
           title="Simulation"
           subtitle={`Simulation ID: ${simulationId}`}
         />
-        <Link
-          className="text-sm text-blue-600 hover:underline"
-          href="/dashboard"
-        >
-          ← Back to dashboard
-        </Link>
+        <div className="flex items-center gap-2">
+          <Button
+            onClick={() => {
+              inviteFlow.reset();
+              setInviteModalOpen(true);
+            }}
+            size="sm"
+          >
+            Invite candidate
+          </Button>
+          <Link
+            className="text-sm text-blue-600 hover:underline"
+            href="/dashboard"
+          >
+            ← Back to dashboard
+          </Link>
+        </div>
       </div>
+
+      <InviteToast
+        toast={toast}
+        copied={toastCopied}
+        onDismiss={dismissToast}
+        onCopyStateChange={(next) => {
+          setToastCopied(next);
+          if (toastCopyTimerRef.current)
+            window.clearTimeout(toastCopyTimerRef.current);
+          if (next) {
+            toastCopyTimerRef.current = window.setTimeout(() => {
+              setToastCopied(false);
+              toastCopyTimerRef.current = null;
+            }, 1800);
+          }
+        }}
+      />
 
       {loading ? (
         <div className="text-sm text-gray-600">Loading candidates…</div>
@@ -91,6 +491,7 @@ export default function RecruiterSimulationDetailPage() {
               <tr>
                 <th className="px-4 py-3">Candidate</th>
                 <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">Invite email</th>
                 <th className="px-4 py-3">Started</th>
                 <th className="px-4 py-3">Completed</th>
                 <th className="px-4 py-3"></th>
@@ -99,9 +500,19 @@ export default function RecruiterSimulationDetailPage() {
             <tbody className="divide-y divide-gray-200">
               {rows.map((c) => {
                 const display = c.candidateName || c.inviteEmail || 'Unnamed';
+                const rowState = rowStates[c.candidateSessionId] ?? {};
+                const sentAt = formatDateTime(c.inviteEmailSentAt ?? null);
+                const inviteLink = buildInviteLink(c);
+                const startedAt = formatDateTime(c.startedAt);
+                const completedAt = formatDateTime(c.completedAt);
+                const cooldownActive =
+                  typeof rowState.cooldownUntilMs === 'number' &&
+                  rowState.cooldownUntilMs > Date.now();
+                const resendDisabled = rowState.resending || cooldownActive;
+
                 return (
                   <tr key={c.candidateSessionId}>
-                    <td className="px-4 py-3">
+                    <td className="px-4 py-3 align-top">
                       <div className="font-medium text-gray-900">{display}</div>
                       {c.inviteEmail ? (
                         <div className="text-xs text-gray-500">
@@ -113,23 +524,77 @@ export default function RecruiterSimulationDetailPage() {
                       </div>
                     </td>
 
-                    <td className="px-4 py-3">
+                    <td className="px-4 py-3 align-top">
                       <CandidateStatusPill status={c.status} />
                     </td>
 
-                    <td className="px-4 py-3 text-gray-700">
-                      {c.startedAt
-                        ? new Date(c.startedAt).toLocaleString()
-                        : '—'}
+                    <td className="px-4 py-3 align-top text-gray-700">
+                      <div className="flex flex-col gap-1">
+                        <div className="text-sm font-medium text-gray-800">
+                          {inviteStatusLabel(c.inviteEmailStatus ?? null)}
+                        </div>
+                        <div className="text-xs text-gray-500">
+                          {sentAt ? `Sent at ${sentAt}` : 'Not sent yet'}
+                        </div>
+                        {c.inviteEmailError ? (
+                          <div className="text-xs text-red-600">
+                            {c.inviteEmailError}
+                          </div>
+                        ) : null}
+                        <div className="flex flex-wrap gap-2">
+                          <Button
+                            type="button"
+                            variant="secondary"
+                            size="sm"
+                            onClick={() => handleCopy(c)}
+                            disabled={rowState.resending || !inviteLink}
+                          >
+                            {rowState.copied ? 'Copied' : 'Copy invite link'}
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="secondary"
+                            size="sm"
+                            onClick={() => handleResend(c)}
+                            disabled={resendDisabled}
+                          >
+                            {rowState.resending
+                              ? 'Resending…'
+                              : 'Resend invite'}
+                          </Button>
+                        </div>
+                        {!inviteLink ? (
+                          <div className="text-xs text-gray-600">
+                            Invite link unavailable — resend invite or refresh.
+                          </div>
+                        ) : null}
+                        {cooldownActive ? (
+                          <div className="text-xs text-gray-600">
+                            Rate limited — try again in ~30s
+                          </div>
+                        ) : null}
+                        {rowState.error ? (
+                          <div className="text-xs text-red-600">
+                            {rowState.error}
+                          </div>
+                        ) : null}
+                        {rowState.message ? (
+                          <div className="text-xs text-green-700">
+                            {rowState.message}
+                          </div>
+                        ) : null}
+                      </div>
                     </td>
 
-                    <td className="px-4 py-3 text-gray-700">
-                      {c.completedAt
-                        ? new Date(c.completedAt).toLocaleString()
-                        : '—'}
+                    <td className="px-4 py-3 align-top text-gray-700">
+                      {startedAt ?? '—'}
                     </td>
 
-                    <td className="px-4 py-3 text-right">
+                    <td className="px-4 py-3 align-top text-gray-700">
+                      {completedAt ?? '—'}
+                    </td>
+
+                    <td className="px-4 py-3 text-right align-top">
                       <Link
                         className="text-blue-600 hover:underline"
                         href={`/dashboard/simulations/${simulationId}/candidates/${c.candidateSessionId}`}
@@ -144,6 +609,23 @@ export default function RecruiterSimulationDetailPage() {
           </table>
         </div>
       )}
+
+      <InviteCandidateModal
+        open={inviteModalOpen}
+        title={inviteLabel}
+        state={
+          inviteFlow.state.status === 'error'
+            ? { status: 'error', message: inviteFlow.state.message ?? '' }
+            : { status: inviteFlow.state.status }
+        }
+        onClose={() => {
+          inviteFlow.reset();
+          setInviteModalOpen(false);
+        }}
+        onSubmit={submitInvite}
+        initialName=""
+        initialEmail=""
+      />
     </div>
   );
 }

--- a/src/types/recruiter.ts
+++ b/src/types/recruiter.ts
@@ -24,10 +24,15 @@ export type CandidateSession = {
   candidateSessionId: number;
   inviteEmail: string | null;
   candidateName: string | null;
-  status: 'not_started' | 'in_progress' | 'completed';
+  status: 'not_started' | 'in_progress' | 'completed' | string;
   startedAt: string | null;
   completedAt: string | null;
   hasReport: boolean;
+  inviteToken?: string | null;
+  inviteUrl?: string | null;
+  inviteEmailStatus?: 'sent' | 'failed' | 'rate_limited' | string | null;
+  inviteEmailSentAt?: string | null;
+  inviteEmailError?: string | null;
 };
 
 export type StatusPillTone = 'info' | 'success' | 'warning' | 'muted';

--- a/tests/integration/recruiter/simulations/tests/SimulationDetailContent.test.tsx
+++ b/tests/integration/recruiter/simulations/tests/SimulationDetailContent.test.tsx
@@ -1,7 +1,8 @@
 import '../../../setup/paramsMock';
 import { setMockParams } from '../../../setup/paramsMock';
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import RecruiterSimulationDetailPage from '@/features/recruiter/simulation-detail/RecruiterSimulationDetailPage';
 import {
   getRequestUrl,
@@ -61,6 +62,7 @@ describe('RecruiterSimulationDetailPage', () => {
 
   afterEach(() => {
     jest.resetAllMocks();
+    jest.useRealTimers();
   });
 
   it('renders candidates list and links to candidate submissions', async () => {
@@ -136,7 +138,7 @@ describe('RecruiterSimulationDetailPage', () => {
     render(<RecruiterSimulationDetailPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('Plain failure')).toBeInTheDocument();
+      expect(screen.getByText('Request failed')).toBeInTheDocument();
     });
   });
 
@@ -204,5 +206,328 @@ describe('RecruiterSimulationDetailPage', () => {
     render(<RecruiterSimulationDetailPage />);
 
     expect(await screen.findByText('No access')).toBeInTheDocument();
+  });
+
+  it('lets recruiters copy invite links from the table', async () => {
+    const user = userEvent.setup();
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = getRequestUrl(input);
+      if (url === '/api/simulations/1/candidates') {
+        return jsonResponse([
+          {
+            candidateSessionId: 42,
+            inviteEmail: 'copy@example.com',
+            candidateName: 'Copy Cat',
+            status: 'not_started',
+            startedAt: null,
+            completedAt: null,
+            hasReport: false,
+            inviteUrl: 'https://example.com/invite/token-123',
+            inviteEmailStatus: 'sent',
+            inviteEmailSentAt: '2025-12-23T10:00:00.000000Z',
+          },
+        ]);
+      }
+      return textResponse('Not found', 404);
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: jest.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
+
+    render(<RecruiterSimulationDetailPage />);
+
+    const copyBtn = await screen.findByRole('button', {
+      name: /copy invite link/i,
+    });
+
+    await user.click(copyBtn);
+
+    await waitFor(() => {
+      expect(copyBtn).toHaveTextContent(/copied/i);
+    });
+  });
+
+  it('shows resend state and updates invite status after resending', async () => {
+    const user = userEvent.setup();
+    const fetchMock = jest.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = getRequestUrl(input);
+        if (url === '/api/simulations/1/candidates') {
+          return jsonResponse([
+            {
+              candidateSessionId: 99,
+              inviteEmail: 'rate@example.com',
+              candidateName: 'Retry Rex',
+              status: 'not_started',
+              startedAt: null,
+              completedAt: null,
+              hasReport: false,
+              inviteEmailStatus: 'failed',
+              inviteEmailSentAt: null,
+              inviteEmailError: 'Email bounced',
+            },
+          ]);
+        }
+        if (url === '/api/simulations/1/candidates/99/invite/resend') {
+          expect(init?.method).toBe('POST');
+          return jsonResponse({
+            candidateSessionId: 99,
+            inviteEmailStatus: 'sent',
+            inviteEmailSentAt: '2025-12-24T00:00:00.000000Z',
+            inviteEmailError: null,
+          });
+        }
+        return textResponse('Not found', 404);
+      },
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<RecruiterSimulationDetailPage />);
+
+    const resendBtn = await screen.findByRole('button', {
+      name: /resend invite/i,
+    });
+    await user.click(resendBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Sent at/i)).toBeInTheDocument();
+      expect(screen.queryByText(/Email bounced/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('disables resend and surfaces rate limit message', async () => {
+    const user = userEvent.setup();
+    const fetchMock = jest.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = getRequestUrl(input);
+        if (url === '/api/simulations/1/candidates') {
+          return jsonResponse([
+            {
+              candidateSessionId: 77,
+              inviteEmail: 'rl@example.com',
+              candidateName: 'Rate Limited',
+              status: 'not_started',
+              startedAt: null,
+              completedAt: null,
+              hasReport: false,
+              inviteEmailStatus: 'failed',
+              inviteEmailSentAt: null,
+            },
+          ]);
+        }
+        if (url === '/api/simulations/1/candidates/77/invite/resend') {
+          expect(init?.method).toBe('POST');
+          return jsonResponse(
+            {
+              candidateSessionId: 77,
+              inviteEmailStatus: 'rate_limited',
+              inviteEmailSentAt: null,
+            },
+            429,
+          );
+        }
+        return textResponse('Not found', 404);
+      },
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<RecruiterSimulationDetailPage />);
+
+    const resendBtn = await screen.findByRole('button', {
+      name: /resend invite/i,
+    });
+    await user.click(resendBtn);
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/Rate limited — try again in ~30s/i).length,
+      ).toBeGreaterThanOrEqual(1);
+    });
+    expect(resendBtn).toBeDisabled();
+  });
+
+  it('clears rate limit after cooldown expires', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ delay: null });
+    const fetchMock = jest.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = getRequestUrl(input);
+        if (url === '/api/simulations/1/candidates') {
+          return jsonResponse([
+            {
+              candidateSessionId: 55,
+              inviteEmail: 'cool@example.com',
+              candidateName: 'Cooldown Casey',
+              status: 'not_started',
+              startedAt: null,
+              completedAt: null,
+              hasReport: false,
+              inviteEmailStatus: 'failed',
+              inviteEmailSentAt: null,
+            },
+          ]);
+        }
+        if (url === '/api/simulations/1/candidates/55/invite/resend') {
+          expect(init?.method).toBe('POST');
+          return jsonResponse(
+            {
+              candidateSessionId: 55,
+              inviteEmailStatus: 'rate_limited',
+              inviteEmailSentAt: null,
+            },
+            429,
+          );
+        }
+        return textResponse('Not found', 404);
+      },
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<RecruiterSimulationDetailPage />);
+
+    const resendBtn = await screen.findByRole('button', {
+      name: /resend invite/i,
+    });
+    await user.click(resendBtn);
+
+    await waitFor(() => {
+      expect(resendBtn).toBeDisabled();
+      expect(
+        screen.getAllByText(/Rate limited — try again in ~30s/i).length,
+      ).toBeGreaterThanOrEqual(1);
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(30_000);
+    });
+
+    await waitFor(() => {
+      expect(resendBtn).not.toBeDisabled();
+    });
+    expect(
+      screen.queryByText(/Rate limited — try again in ~30s/i),
+    ).not.toBeInTheDocument();
+    jest.useRealTimers();
+  });
+
+  it('shows friendly not found error and refreshes on 404 resend', async () => {
+    const user = userEvent.setup();
+    const fetchMock = jest.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = getRequestUrl(input);
+        if (url === '/api/simulations/1/candidates') {
+          return jsonResponse([
+            {
+              candidateSessionId: 88,
+              inviteEmail: 'gone@example.com',
+              candidateName: 'Missing',
+              status: 'not_started',
+              startedAt: null,
+              completedAt: null,
+              hasReport: false,
+              inviteEmailStatus: 'failed',
+              inviteEmailSentAt: null,
+            },
+          ]);
+        }
+        if (url === '/api/simulations/1/candidates/88/invite/resend') {
+          expect(init?.method).toBe('POST');
+          return jsonResponse({ message: 'not found' }, 404);
+        }
+        return textResponse('Not found', 404);
+      },
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<RecruiterSimulationDetailPage />);
+
+    const resendBtn = await screen.findByRole('button', {
+      name: /resend invite/i,
+    });
+    await user.click(resendBtn);
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByText('Candidate not found — refreshing list.'),
+        ).toBeInTheDocument();
+      },
+      { timeout: 8000 },
+    );
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/simulations/1/candidates',
+        expect.anything(),
+      );
+    });
+  });
+
+  it('does not get stuck loading under StrictMode navigation', async () => {
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = getRequestUrl(input);
+      if (url === '/api/simulations/1/candidates') {
+        return jsonResponse([
+          {
+            candidateSessionId: 2,
+            inviteEmail: 'strict@example.com',
+            candidateName: 'Strict Mode',
+            status: 'in_progress',
+            startedAt: '2025-12-23T18:57:00.000000Z',
+            completedAt: null,
+            hasReport: false,
+          },
+        ]);
+      }
+      return textResponse('Not found', 404);
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(
+      <React.StrictMode>
+        <RecruiterSimulationDetailPage />
+      </React.StrictMode>,
+    );
+
+    expect(screen.getByText('Loading candidates…')).toBeInTheDocument();
+
+    expect(await screen.findByText('Strict Mode')).toBeInTheDocument();
+  });
+
+  it('shows copy invite button even when invite URL is missing and surfaces error', async () => {
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = getRequestUrl(input);
+      if (url === '/api/simulations/1/candidates') {
+        return jsonResponse([
+          {
+            candidateSessionId: 12,
+            inviteEmail: 'nolink@example.com',
+            candidateName: 'No Link',
+            status: 'not_started',
+            startedAt: null,
+            completedAt: null,
+            hasReport: false,
+            inviteEmailStatus: 'sent',
+            inviteEmailSentAt: '2025-12-23T10:00:00.000000Z',
+            inviteUrl: null,
+            inviteToken: null,
+          },
+        ]);
+      }
+      return textResponse('Not found', 404);
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<RecruiterSimulationDetailPage />);
+
+    const copyBtn = await screen.findByRole('button', {
+      name: /copy invite link/i,
+    });
+    expect(copyBtn).toBeDisabled();
+    expect(
+      screen.getByText(/Invite link unavailable — resend invite or refresh/i),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

### 1) Invite management on Simulation Detail page
Added invite management directly to the recruiter simulation detail view so recruiters can onboard candidates without Postman:

- **Create invite (email)** via **Invite candidate** modal
- **See candidate rows** with:
  - candidate name / email
  - candidate status pill
  - invite delivery status label (`sent`, `failed`, `rate_limited`, or “Not sent”)
  - invite sent timestamp (or “Not sent yet”)
  - invite error details (when failed)
  - started / completed timestamps (existing)
  - link to “View submissions →”
- **Copy invite link**
  - enabled when `inviteUrl` exists
  - shows “Copied” success state after click
  - if inviteUrl is missing, button remains visible but **disabled** with helper text:
    - “Invite link unavailable — resend invite or refresh.”
- **Resend invite**
  - shows in-flight UI (“Resending…”)
  - updates status + timestamp on success when backend returns delivery fields
  - **rate-limited UX**: inline message and **per-row cooldown** (~30s) that auto-clears
  - **404 UX** (“candidate not found”): friendly row-level error + auto-refresh of candidates list

---

## API integration (no new backend APIs invented)

### Read candidates
- **Frontend call:** `GET /api/simulations/{simulationId}/candidates` (BFF / existing)
- **Used fields:** `candidateSessionId`, `inviteEmail`, `candidateName`, `status`, `startedAt`, `completedAt`, and invite metadata:
  - `inviteUrl`
  - `inviteEmailStatus`
  - `inviteEmailSentAt`
  - `inviteEmailError`

### Create invite
- Uses existing invite flow hook (`useInviteCandidateFlow`) that calls the BFF invite endpoint and returns `{ inviteUrl, candidateEmail, candidateName }` for toast display.

### Resend invite (new BFF passthrough)
- **New Next.js route:** `POST /api/simulations/{id}/candidates/{candidateSessionId}/invite/resend`
- **Proxies to backend:** `POST /api/simulations/{simulationId}/candidates/{candidateSessionId}/invite/resend`
- Protected via existing auth guard and uses existing `forwardJson` helper.

---

## Key implementation details

### Robust response parsing (single-read)
Introduced a `safeParseResponse(res)` helper to safely parse JSON or fall back to text **without double-reading** response streams.

### StrictMode + navigation resilience
Fixed a state freeze where navigation to `/dashboard/simulations/{id}` could get stuck on “Loading candidates…” until hard refresh:
- `mountedRef` lifecycle made StrictMode-safe (reset to true on mount)
- reset state (`candidates`, `rowStates`, `error`) on `simulationId` change to prevent stale state issues during route transitions

### Rate-limit cooldown auto-clear
Resolved “rate-limited state doesn’t go away” by:
- storing per-row cooldown timestamps (`cooldownUntilMs`)
- scheduling a timeout to clear cooldown/message after ~30s
- safely clearing all timers on unmount

### Friendly resend error handling
When resend returns 404 / not found:
- show row-level message: “Candidate not found — refreshing list.”
- automatically re-fetch candidates list to self-heal

---

## Files changed

> Exact paths may vary by your repo structure; these are the files modified during this issue implementation.

- `app/api/simulations/[id]/candidates/[candidateSessionId]/invite/resend/route.ts`
  - Added BFF passthrough for resend invite with auth guard.
- `features/recruiter/simulation-detail/RecruiterSimulationDetailPage.tsx`
  - Added invite management UI + candidate delivery status display
  - Copy invite link + resend invite actions with robust UX and safe parsing
  - Fixed navigation loading freeze (StrictMode-safe) and cooldown timer clearing
- `features/recruiter/simulation-detail/__tests__/SimulationDetailContent.test.tsx` (or equivalent)
  - Added/extended integration coverage for:
    - copy invite link behavior
    - resend behavior
    - rate-limit cooldown + auto-clear (fake timers)
    - 404 resend friendly messaging + refresh
    - StrictMode “Loading candidates…” regression

---

## Tests

### Automated
Run locally:
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `./precommit.sh`

Added/updated tests cover:
- Copy invite link “Copied” state
- Copy button disabled + helper text when inviteUrl missing
- Resend state updates
- Rate-limited resend disables and **auto-clears after ~30s**
- Resend 404 shows friendly message and triggers refresh
- StrictMode regression: navigation no longer hangs on “Loading candidates…”

### Manual QA (UI)
1. Start backend + frontend locally.
2. Navigate to **Dashboard → Simulation detail** (`/dashboard/simulations/{id}`).
3. Verify candidates load without getting stuck on “Loading candidates…”.
4. Click **Invite candidate**:
   - submit email
   - confirm toast appears
   - confirm table refreshes and shows invite delivery status + timestamps.
5. For a candidate with `inviteUrl`, click **Copy invite link**:
   - confirm button shows “Copied”
   - paste link into a new tab and verify it opens the candidate invite/session page.
6. Click **Resend invite**:
   - confirm “Resending…” state
   - confirm status/timestamp updates or message appears
7. Trigger rate limit (resend twice quickly):
   - confirm inline “Rate limited — try again in ~30s”
   - confirm resend is disabled
   - confirm it re-enables and message clears after ~30s (no refresh needed)
8. Navigate away and back (e.g. candidate submissions → simulation detail):
   - confirm list loads and no stale rate-limit state persists beyond cooldown

---

## UX notes / edge cases handled

- Email delivery may fail in dev (e.g., Resend sender restrictions). UI surfaces:
  - delivery status
  - error strings
  - copy invite link as fallback when available
- If a candidate row becomes stale (deleted/moved) and resend returns 404:
  - recruiter sees a friendly message
  - list refreshes automatically to recover

---

## Rollout considerations

- No breaking API changes required for this PR.
- Safe for incremental rollout:
  - UI changes are additive
  - resend path uses BFF auth guard and forwards backend response

---

## Acceptance Criteria checklist (Issue #51)

- [x] Recruiter can **create invite** by email from UI (no Postman)
- [x] Recruiter can **copy invite link** (with clear disabled state if unavailable)
- [x] Recruiter can **resend invite** with in-flight, rate-limit, and error UX
- [x] Recruiter can **see candidate status and invite timestamps** in table
- [x] Manual QA + tests confirm stable navigation and correct behavior

---

## Screenshots / Demo (optional)
- Simulation detail page with candidates + invite status
- Invite modal
- Copy invite link “Copied” state
- Resend rate-limited state + auto-clear


Fixes #51 