### PR TITLE
HARD Rebrand — → Tenon (Frontend)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# SimuHire Frontend
+# Tenon Frontend
 
-Next.js App Router (React 19 + TypeScript) UI for SimuHire’s 5-day work simulations. Candidates complete day-by-day tasks via invite tokens; recruiters create simulations, invite candidates, and review submissions.
+Next.js App Router (React 19 + TypeScript) UI for Tenon’s 5-day work simulations. Candidates complete day-by-day tasks via invite tokens; recruiters create simulations, invite candidates, and review submissions.
 
 ## Architecture
 
@@ -27,7 +27,7 @@ Next.js App Router (React 19 + TypeScript) UI for SimuHire’s 5-day work simula
 
 ## API Integration
 
-- Base config: `NEXT_PUBLIC_API_BASE_URL` (defaults to `/api`); BFF targets `BACKEND_BASE_URL` (default `http://localhost:8000`).
+- Base config: `NEXT_PUBLIC_TENON_API_BASE_URL` (defaults to `/api`); BFF targets `TENON_BACKEND_BASE_URL` (default `http://localhost:8000`).
 - Candidate calls (direct with Auth0 bearer + `candidate:access`):
   - `GET /candidate/session/{token}` bootstrap/resolve invite.
   - `POST /candidate/session/{token}/claim` (no body) to claim invite with signed-in email.
@@ -39,24 +39,25 @@ Next.js App Router (React 19 + TypeScript) UI for SimuHire’s 5-day work simula
   - `POST /api/simulations/{id}/invite`.
   - `GET /api/simulations/{id}/candidates`.
   - `GET /api/submissions?candidateSessionId=…`, `GET /api/submissions/{submissionId}`.
-- Not implemented: codespace init/status, run-tests polling UI, execution profile fetch.
+- Not implemented: codespace init/status, run-tests polling UI, fit profile fetch.
 
 ## Configuration / Env Vars
 
-- `NEXT_PUBLIC_API_BASE_URL` – backend base for candidate calls (e.g., `https://backend.example.com/api`).
-- `BACKEND_BASE_URL` – backend base for BFF (default `http://localhost:8000`; `/api` suffix trimmed).
-- Auth0: `AUTH0_SECRET`, `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `AUTH0_AUDIENCE`, `AUTH0_SCOPE`, `APP_BASE_URL`.
+- `NEXT_PUBLIC_TENON_API_BASE_URL` – backend base for candidate calls (e.g., `https://backend.example.com/api`).
+- `TENON_BACKEND_BASE_URL` – backend base for BFF (default `http://localhost:8000`; `/api` suffix trimmed).
+- Auth0 (Tenon-only): `TENON_AUTH0_SECRET`, `TENON_AUTH0_DOMAIN`, `TENON_AUTH0_CLIENT_ID`, `TENON_AUTH0_CLIENT_SECRET`, `TENON_AUTH0_AUDIENCE`, `TENON_AUTH0_SCOPE`, `TENON_APP_BASE_URL`.
+- Auth0 custom claims namespace (Tenon-only): `NEXT_PUBLIC_TENON_AUTH0_CLAIM_NAMESPACE` (defaults to `https://tenon.ai` when unset).
 - Optional Auth0 connection hints for the login button intent routing:
-  - `NEXT_PUBLIC_AUTH0_CANDIDATE_CONNECTION`
-  - `NEXT_PUBLIC_AUTH0_RECRUITER_CONNECTION`
-- Optional helper script: `./runFrontend.sh` echoes `BACKEND_BASE_URL` then runs `npm run dev`.
+  - `NEXT_PUBLIC_TENON_AUTH0_CANDIDATE_CONNECTION`
+  - `NEXT_PUBLIC_TENON_AUTH0_RECRUITER_CONNECTION`
+- Optional helper script: `./runFrontend.sh` echoes `TENON_BACKEND_BASE_URL` then runs `npm run dev`.
 
 ## Local Development
 
 - Install: `npm install`.
 - Run dev: `npm run dev` (<http://localhost:3000>). Build: `npm run build`; start: `npm start`.
 - Tests/checks: `npm test`, `npm run test:coverage`, `npm run test:e2e`, `npm run typecheck`, `npm run lint`, `./precommit.sh`.
-- Point to local backend: set `BACKEND_BASE_URL` and `NEXT_PUBLIC_API_BASE_URL` in `.env.local`.
+- Point to local backend: set `TENON_BACKEND_BASE_URL` and `NEXT_PUBLIC_TENON_API_BASE_URL` in `.env.local`.
 
 ## Typical Flows
 
@@ -67,7 +68,7 @@ Next.js App Router (React 19 + TypeScript) UI for SimuHire’s 5-day work simula
 
 - GitHub-native workflow: codespace init/status, run-tests trigger + duplicate-run prevention UI.
 - Day4 demo capture + transcript; Day5 structured markdown submission.
-- Execution profile/report view, comparison, and print/export.
+- Fit profile/report view, comparison, and print/export.
 - Candidate run-tests panel integration and richer states/loading skeletons.
 
 ## Manual QA checklist

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,7 @@ function normalizeOrigin(value: string) {
 }
 
 const BACKEND_BASE_URL = normalizeOrigin(
-  process.env.BACKEND_BASE_URL || 'http://localhost:8000',
+  process.env.TENON_BACKEND_BASE_URL || 'http://localhost:8000',
 );
 
 const nextConfig: NextConfig = {

--- a/runFrontend.sh
+++ b/runFrontend.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export BACKEND_BASE_URL="${BACKEND_BASE_URL:-http://localhost:8000}"
+export TENON_BACKEND_BASE_URL="${TENON_BACKEND_BASE_URL:-http://localhost:8000}"
 
-echo "Using BACKEND_BASE_URL=${BACKEND_BASE_URL}"
+echo "Using TENON_BACKEND_BASE_URL=${TENON_BACKEND_BASE_URL}"
 npm run dev

--- a/src/app/(auth)/auth/login/page.tsx
+++ b/src/app/(auth)/auth/login/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from 'next';
 import LoginPage from '@/features/auth/LoginPage';
+import { BRAND_NAME } from '@/lib/brand';
 
 export const metadata: Metadata = {
-  title: 'Recruiter login | SimuHire',
-  description: 'Sign in to access your SimuHire dashboard.',
+  title: `Recruiter login | ${BRAND_NAME}`,
+  description: `Sign in to access your ${BRAND_NAME} dashboard.`,
 };
 
 type SearchParams = Promise<{ returnTo?: string; mode?: string }>;

--- a/src/app/(auth)/auth/logout/page.tsx
+++ b/src/app/(auth)/auth/logout/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from 'next';
 import LogoutPage from '@/features/auth/LogoutPage';
+import { BRAND_NAME } from '@/lib/brand';
 
 export const metadata: Metadata = {
-  title: 'Log out | SimuHire',
-  description: 'End your SimuHire session.',
+  title: `Log out | ${BRAND_NAME}`,
+  description: `End your ${BRAND_NAME} session.`,
 };
 
 export default function LogoutRoutePage() {

--- a/src/app/(candidate)/candidate/dashboard/page.tsx
+++ b/src/app/(candidate)/candidate/dashboard/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from 'next';
 import CandidateDashboardPage from '@/features/candidate/dashboard/CandidateDashboardPage';
+import { BRAND_NAME } from '@/lib/brand';
 
 export const metadata: Metadata = {
-  title: 'Candidate dashboard | SimuHire',
-  description: 'Continue your SimuHire simulations and invites.',
+  title: `Candidate dashboard | ${BRAND_NAME}`,
+  description: `Continue your ${BRAND_NAME} simulations and invites.`,
 };
 
 export default function CandidateDashboardRoute() {

--- a/src/app/(candidate)/candidate/session/[token]/page.tsx
+++ b/src/app/(candidate)/candidate/session/[token]/page.tsx
@@ -1,13 +1,14 @@
 import type { Metadata } from 'next';
 import CandidateSessionPage from '@/features/candidate/session/CandidateSessionPage';
+import { BRAND_NAME } from '@/lib/brand';
 import {
   requireCandidateToken,
   type TokenParams,
 } from '../../../candidate-sessions/token-params';
 
 export const metadata: Metadata = {
-  title: 'Candidate simulation | SimuHire',
-  description: 'Work through your SimuHire day-by-day simulation.',
+  title: `Candidate simulation | ${BRAND_NAME}`,
+  description: `Work through your ${BRAND_NAME} day-by-day simulation.`,
 };
 
 export default async function CandidateSessionRoute({

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from 'next';
-import { auth0 } from '@/lib/auth0';
+import { getSessionNormalized } from '@/lib/auth0';
+import { BRAND_NAME } from '@/lib/brand';
 import MarketingHomePage from '@/features/marketing/home/MarketingHomePage';
 
 export const metadata: Metadata = {
-  title: 'SimuHire | 5-day work simulations for hiring',
+  title: `${BRAND_NAME} | 5-day work simulations for hiring`,
   description:
     'Create realistic 5-day work simulations for candidates. Evaluate real execution, not just resumes.',
 };
 
 export default async function HomePage() {
-  const session = await auth0.getSession();
+  const session = await getSessionNormalized();
   return <MarketingHomePage user={session?.user} />;
 }

--- a/src/app/(recruiter)/dashboard/page.tsx
+++ b/src/app/(recruiter)/dashboard/page.tsx
@@ -1,16 +1,17 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { auth0 } from '@/lib/auth0';
+import { getSessionNormalized } from '@/lib/auth0';
+import { BRAND_NAME } from '@/lib/brand';
 import RecruiterDashboardPage from '@/features/recruiter/dashboard/RecruiterDashboardPage';
 import { fetchRecruiterProfile } from './profile.server';
 
 export const metadata: Metadata = {
-  title: 'Dashboard | SimuHire',
+  title: `Dashboard | ${BRAND_NAME}`,
   description: 'Manage simulations, candidates, and invites.',
 };
 
 export default async function DashboardPage() {
-  const session = await auth0.getSession();
+  const session = await getSessionNormalized();
 
   if (!session) {
     redirect('/auth/login');

--- a/src/app/(recruiter)/dashboard/simulations/[id]/candidates/[candidateSessionId]/page.tsx
+++ b/src/app/(recruiter)/dashboard/simulations/[id]/candidates/[candidateSessionId]/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from 'next';
 import CandidateSubmissionsPage from '@/features/recruiter/candidate-submissions/CandidateSubmissionsPage';
+import { BRAND_NAME } from '@/lib/brand';
 
 export const metadata: Metadata = {
-  title: 'Candidate submissions | SimuHire',
+  title: `Candidate submissions | ${BRAND_NAME}`,
   description: 'View day-by-day submissions for this candidate.',
 };
 

--- a/src/app/(recruiter)/dashboard/simulations/[id]/page.tsx
+++ b/src/app/(recruiter)/dashboard/simulations/[id]/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from 'next';
 import RecruiterSimulationDetailPage from '@/features/recruiter/simulation-detail/RecruiterSimulationDetailPage';
+import { BRAND_NAME } from '@/lib/brand';
 
 export const metadata: Metadata = {
-  title: 'Simulation detail | SimuHire',
+  title: `Simulation detail | ${BRAND_NAME}`,
   description: 'Review candidates and submissions for this simulation.',
 };
 

--- a/src/app/(recruiter)/dashboard/simulations/new/page.tsx
+++ b/src/app/(recruiter)/dashboard/simulations/new/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from 'next';
 import SimulationCreatePage from '@/features/recruiter/simulations/SimulationCreatePage';
+import { BRAND_NAME } from '@/lib/brand';
 
 export const metadata: Metadata = {
-  title: 'Create simulation | SimuHire',
+  title: `Create simulation | ${BRAND_NAME}`,
   description: 'Set up a new 5-day simulation for candidates.',
 };
 

--- a/src/app/api/debug/auth/route.ts
+++ b/src/app/api/debug/auth/route.ts
@@ -1,13 +1,14 @@
 import { NextResponse } from 'next/server';
-import { auth0 } from '@/lib/auth0';
+import { getSessionNormalized } from '@/lib/auth0';
 import { extractPermissions } from '@/lib/auth0-claims';
+import { CUSTOM_CLAIM_ROLES } from '@/lib/brand';
 
 export async function GET() {
   if (process.env.NODE_ENV === 'production') {
     return NextResponse.json({ message: 'Not found' }, { status: 404 });
   }
 
-  const session = await auth0.getSession();
+  const session = await getSessionNormalized();
   if (!session) {
     return NextResponse.json({ message: 'Not authenticated' }, { status: 401 });
   }
@@ -21,6 +22,6 @@ export async function GET() {
   return NextResponse.json({
     userKeys: Object.keys(user),
     permissions: permissionList,
-    roles: user['https://simuhire.com/roles'] ?? user.roles ?? [],
+    roles: user[CUSTOM_CLAIM_ROLES] ?? user.roles ?? [],
   });
 }

--- a/src/app/api/simulations/[id]/candidates/route.ts
+++ b/src/app/api/simulations/[id]/candidates/route.ts
@@ -1,4 +1,5 @@
 import { forwardJson, withAuthGuard } from '@/lib/server/bff';
+import { BFF_HEADER } from '@/app/api/utils';
 
 export async function GET(
   _req: Request,
@@ -12,6 +13,6 @@ export async function GET(
       accessToken,
     }),
   );
-  resp.headers.set('x-simuhire-bff', 'simulations-candidates');
+  resp.headers.set(BFF_HEADER, 'simulations-candidates');
   return resp;
 }

--- a/src/app/api/simulations/[id]/invite/route.ts
+++ b/src/app/api/simulations/[id]/invite/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server';
 import { forwardJson, withAuthGuard } from '@/lib/server/bff';
+import { BFF_HEADER } from '@/app/api/utils';
 
 export async function POST(
   req: NextRequest,
@@ -18,6 +19,6 @@ export async function POST(
       accessToken,
     }),
   );
-  resp.headers.set('x-simuhire-bff', 'invite');
+  resp.headers.set(BFF_HEADER, 'invite');
   return resp;
 }

--- a/src/app/api/utils.ts
+++ b/src/app/api/utils.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
 import { forwardJson, withAuthGuard } from '@/lib/server/bff';
+import { BRAND_SLUG } from '@/lib/brand';
+
+export const BFF_HEADER = `x-${BRAND_SLUG}-bff`;
 
 type ForwardArgs = {
   path: string;
@@ -19,7 +22,7 @@ export async function forwardWithAuth({
   );
 
   if (resp instanceof NextResponse && tag) {
-    resp.headers.set('x-simuhire-bff', tag);
+    resp.headers.set(BFF_HEADER, tag);
   }
 
   return resp;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,10 +2,11 @@ import type { Metadata, Viewport } from 'next';
 import { ReactNode } from 'react';
 import './globals.css';
 import AppShell from '@/features/shared/layout/AppShell';
+import { BRAND_NAME } from '@/lib/brand';
 
 export const metadata: Metadata = {
-  title: 'SimuHire',
-  description: 'Simulation-based hiring platform',
+  title: BRAND_NAME,
+  description: `${BRAND_NAME} simulation-based hiring platform`,
 };
 
 export const viewport: Viewport = {

--- a/src/app/not-authorized/page.tsx
+++ b/src/app/not-authorized/page.tsx
@@ -1,8 +1,9 @@
 import Link from 'next/link';
 import type { Metadata } from 'next';
+import { BRAND_NAME } from '@/lib/brand';
 
 export const metadata: Metadata = {
-  title: 'Not authorized | SimuHire',
+  title: `Not authorized | ${BRAND_NAME}`,
   description: 'You do not have access to this area.',
 };
 

--- a/src/features/auth/LoginPage.tsx
+++ b/src/features/auth/LoginPage.tsx
@@ -1,5 +1,6 @@
 import Button from '@/components/ui/Button';
 import LoginLink from '@/features/auth/LoginLink';
+import { BRAND_NAME } from '@/lib/brand';
 import { AuthPageLayout } from './AuthPageLayout';
 import type { LoginMode } from './authPaths';
 
@@ -20,18 +21,18 @@ export default function LoginPage({
     : 'Recruiter login';
   const subtitle = isCandidate
     ? 'Sign in to verify your invite and continue.'
-    : 'Sign in to access your SimuHire dashboard.';
+    : `Sign in to access your ${BRAND_NAME} dashboard.`;
   const missingCandidateConnection =
     process.env.NODE_ENV !== 'production' &&
     isCandidate &&
-    !(process.env.NEXT_PUBLIC_AUTH0_CANDIDATE_CONNECTION ?? '').trim();
+    !(process.env.NEXT_PUBLIC_TENON_AUTH0_CANDIDATE_CONNECTION ?? '').trim();
 
   return (
     <AuthPageLayout title={title} subtitle={subtitle}>
       {missingCandidateConnection ? (
         <div className="mb-4 rounded-md border border-yellow-300 bg-yellow-50 px-3 py-2 text-sm text-yellow-900">
-          Dev warning: set NEXT_PUBLIC_AUTH0_CANDIDATE_CONNECTION so candidate
-          logins use the correct Auth0 connection.
+          Dev warning: set NEXT_PUBLIC_TENON_AUTH0_CANDIDATE_CONNECTION so
+          candidate logins use the correct Auth0 connection.
         </div>
       ) : null}
       <p className="mb-4 text-sm text-gray-600">

--- a/src/features/auth/LogoutPage.tsx
+++ b/src/features/auth/LogoutPage.tsx
@@ -1,14 +1,15 @@
 import Link from 'next/link';
 import Button from '@/components/ui/Button';
 import LogoutLink from '@/features/auth/LogoutLink';
+import { BRAND_NAME } from '@/lib/brand';
 import { AuthPageLayout } from './AuthPageLayout';
 
 export default function LogoutPage() {
   return (
     <AuthPageLayout
       title="Log out"
-      subtitle="Are you sure you want to log out of SimuHire?"
-      footer="This will end your SimuHire session and redirect you back to the app."
+      subtitle={`Are you sure you want to log out of ${BRAND_NAME}?`}
+      footer={`This will end your ${BRAND_NAME} session and redirect you back to the app.`}
     >
       <div className="flex flex-col gap-3">
         <LogoutLink className="block">

--- a/src/features/auth/authPaths.ts
+++ b/src/features/auth/authPaths.ts
@@ -7,10 +7,10 @@ function normalizeReturnTo(returnTo: string | null | undefined): string {
 
 function connectionForMode(mode?: LoginMode): string | null {
   if (mode === 'candidate') {
-    return process.env.NEXT_PUBLIC_AUTH0_CANDIDATE_CONNECTION ?? null;
+    return process.env.NEXT_PUBLIC_TENON_AUTH0_CANDIDATE_CONNECTION ?? null;
   }
   if (mode === 'recruiter') {
-    return process.env.NEXT_PUBLIC_AUTH0_RECRUITER_CONNECTION ?? null;
+    return process.env.NEXT_PUBLIC_TENON_AUTH0_RECRUITER_CONNECTION ?? null;
   }
   return null;
 }

--- a/src/features/candidate/session/CandidateSessionProvider.tsx
+++ b/src/features/candidate/session/CandidateSessionProvider.tsx
@@ -8,6 +8,7 @@ import React, {
   useMemo,
   useReducer,
 } from 'react';
+import { BRAND_SLUG } from '@/lib/brand';
 
 type SimulationSummary = {
   title: string;
@@ -180,7 +181,7 @@ type Ctx = {
 
 const CandidateSessionContext = createContext<Ctx | null>(null);
 
-const STORAGE_KEY = 'simuhire:candidate_session_v1';
+const STORAGE_KEY = `${BRAND_SLUG}:candidate_session_v1`;
 
 type PersistedState = {
   inviteToken: string | null;

--- a/src/features/candidate/session/task/utils/draftStorage.ts
+++ b/src/features/candidate/session/task/utils/draftStorage.ts
@@ -3,9 +3,10 @@ import {
   loadCodeDraft,
   saveCodeDraft,
 } from '@/lib/storage/candidateDrafts';
+import { BRAND_SLUG } from '@/lib/brand';
 
 function textDraftKey(taskId: number) {
-  return `simuhire:candidate:textDraft:${String(taskId)}`;
+  return `${BRAND_SLUG}:candidate:textDraft:${String(taskId)}`;
 }
 
 export function loadTextDraft(taskId: number): string {

--- a/src/features/marketing/home/MarketingHomeSignedOut.tsx
+++ b/src/features/marketing/home/MarketingHomeSignedOut.tsx
@@ -1,4 +1,5 @@
 import LoginLink from '@/features/auth/LoginLink';
+import { BRAND_NAME } from '@/lib/brand';
 import { ActionRow } from '../shared/ActionRow';
 import { primaryCtaClass, secondaryCtaClass } from '../shared/ctaClasses';
 
@@ -7,7 +8,7 @@ export function MarketingHomeSignedOut() {
     <div className="flex flex-col gap-6">
       <div>
         <h1 className="text-3xl font-semibold text-slate-900">
-          Welcome to SimuHire
+          Welcome to {BRAND_NAME}
         </h1>
         <p className="mt-2 max-w-xl text-sm text-slate-600">
           Run multi-day work simulations that replace traditional interviews for

--- a/src/features/shared/layout/AppHeader.tsx
+++ b/src/features/shared/layout/AppHeader.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { BRAND_NAME } from '@/lib/brand';
 import { AppNav } from './AppNav';
 import { contentContainer } from './layoutStyles';
 
@@ -14,7 +15,7 @@ export function AppHeader({ isAuthed, permissions = [] }: AppHeaderProps) {
         className={`${contentContainer} flex items-center justify-between py-3`}
       >
         <Link href="/" className="text-lg font-semibold tracking-tight">
-          SimuHire
+          {BRAND_NAME}
         </Link>
         <AppNav isAuthed={isAuthed} permissions={permissions} />
       </div>

--- a/src/features/shared/layout/AppShell.tsx
+++ b/src/features/shared/layout/AppShell.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { auth0 } from '@/lib/auth0';
+import { getSessionNormalized } from '@/lib/auth0';
 import { extractPermissions } from '@/lib/auth0-claims';
 import { AppHeader } from './AppHeader';
 import { contentContainer } from './layoutStyles';
@@ -9,7 +9,7 @@ type AppShellProps = {
 };
 
 export default async function AppShell({ children }: AppShellProps) {
-  const session = await auth0.getSession();
+  const session = await getSessionNormalized();
   const isAuthed = !!session?.user;
   const permissions = extractPermissions(session?.user, null);
 

--- a/src/lib/api/candidate.ts
+++ b/src/lib/api/candidate.ts
@@ -8,7 +8,7 @@ import {
 
 export { HttpError };
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? '/api';
+const API_BASE = process.env.NEXT_PUBLIC_TENON_API_BASE_URL ?? '/api';
 const baseClientOptions: ApiClientOptions = {
   basePath: API_BASE || '/api',
   skipAuth: false,

--- a/src/lib/api/httpClient.ts
+++ b/src/lib/api/httpClient.ts
@@ -20,7 +20,7 @@ type RequestOptions = {
   cache?: RequestCache;
 };
 
-const DEFAULT_BASE_PATH = process.env.NEXT_PUBLIC_API_BASE_URL ?? '/api';
+const DEFAULT_BASE_PATH = process.env.NEXT_PUBLIC_TENON_API_BASE_URL ?? '/api';
 
 function normalizeUrl(basePath: string, path: string): string {
   const base = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,6 @@
-const TOKEN_KEY = 'simuhire_token';
+import { BRAND_SLUG } from '@/lib/brand';
+
+const TOKEN_KEY = `${BRAND_SLUG}_token`;
 
 export function getAuthToken(): string | null {
   if (typeof window === 'undefined') return null;

--- a/src/lib/brand.ts
+++ b/src/lib/brand.ts
@@ -1,0 +1,16 @@
+export const BRAND_NAME = 'Tenon';
+export const BRAND_SLUG = 'tenon';
+export const BRAND_DOMAIN = 'tenon.ai';
+
+const RAW_CLAIM_NAMESPACE =
+  process.env.NEXT_PUBLIC_TENON_AUTH0_CLAIM_NAMESPACE?.trim() ||
+  `https://${BRAND_DOMAIN}`;
+
+export const CUSTOM_CLAIM_NAMESPACE = RAW_CLAIM_NAMESPACE.endsWith('/')
+  ? RAW_CLAIM_NAMESPACE
+  : `${RAW_CLAIM_NAMESPACE}/`;
+
+export const CUSTOM_CLAIM_PERMISSIONS = `${CUSTOM_CLAIM_NAMESPACE}permissions`;
+export const CUSTOM_CLAIM_PERMISSIONS_STR = `${CUSTOM_CLAIM_NAMESPACE}permissions_str`;
+export const CUSTOM_CLAIM_ROLES = `${CUSTOM_CLAIM_NAMESPACE}roles`;
+export const CUSTOM_CLAIM_EMAIL = `${CUSTOM_CLAIM_NAMESPACE}email`;

--- a/src/lib/storage/candidateDrafts.ts
+++ b/src/lib/storage/candidateDrafts.ts
@@ -1,4 +1,6 @@
-const DRAFT_PREFIX = 'simuhire:candidate:codeDraft';
+import { BRAND_SLUG } from '@/lib/brand';
+
+const DRAFT_PREFIX = `${BRAND_SLUG}:candidate:codeDraft`;
 
 export function codeDraftKey(
   candidateSessionId: number | string,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
-import { auth0 } from './lib/auth0';
+import { auth0, getSessionNormalized } from './lib/auth0';
 import { extractPermissions, hasPermission } from './lib/auth0-claims';
 
 const PUBLIC_PATHS = new Set([
@@ -95,7 +95,7 @@ export async function middleware(request: NextRequest) {
 
   if (shouldSkipAuth(pathname)) return authResponse;
 
-  const session = await auth0.getSession(request);
+  const session = await getSessionNormalized(request);
   if (!session) return buildLoginRedirect(request);
 
   const fallbackAccessToken =

--- a/tests/unit/app/candidate/CandidateSessionProvider.test.tsx
+++ b/tests/unit/app/candidate/CandidateSessionProvider.test.tsx
@@ -4,8 +4,9 @@ import {
   CandidateSessionProvider,
   useCandidateSession,
 } from '@/features/candidate/session/CandidateSessionProvider';
+import { BRAND_SLUG } from '@/lib/brand';
 
-const STORAGE_KEY = 'simuhire:candidate_session_v1';
+const STORAGE_KEY = `${BRAND_SLUG}:candidate_session_v1`;
 
 function Harness() {
   const {

--- a/tests/unit/app/public/PublicHomeContent.test.tsx
+++ b/tests/unit/app/public/PublicHomeContent.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import MarketingHomePage from '@/features/marketing/home/MarketingHomePage';
+import { BRAND_NAME } from '@/lib/brand';
 
 describe('PublicHomeContent', () => {
   it('shows signed-in state with user links', () => {
@@ -21,7 +22,7 @@ describe('PublicHomeContent', () => {
   it('shows signed-out state with auth entry points', () => {
     render(<MarketingHomePage />);
 
-    expect(screen.getByText('Welcome to SimuHire')).toBeInTheDocument();
+    expect(screen.getByText(`Welcome to ${BRAND_NAME}`)).toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: 'Recruiter login' }),
     ).toHaveAttribute(

--- a/tests/unit/candidateApi.test.ts
+++ b/tests/unit/candidateApi.test.ts
@@ -8,17 +8,17 @@ const jsonRes = (
 ) => responseHelpers.jsonResponse(body, status, headers) as unknown as Response;
 type FetchMock = jest.MockedFunction<typeof fetch>;
 
-const originalApiBase = process.env.NEXT_PUBLIC_API_BASE_URL;
+const originalApiBase = process.env.NEXT_PUBLIC_TENON_API_BASE_URL;
 
 async function importApi() {
   jest.resetModules();
-  process.env.NEXT_PUBLIC_API_BASE_URL = 'http://api.example.com';
+  process.env.NEXT_PUBLIC_TENON_API_BASE_URL = 'http://api.example.com';
   return import('@/lib/api/candidate');
 }
 
 describe('candidateApi', () => {
   afterAll(() => {
-    process.env.NEXT_PUBLIC_API_BASE_URL = originalApiBase;
+    process.env.NEXT_PUBLIC_TENON_API_BASE_URL = originalApiBase;
   });
 
   it('resolves invite token with bearer auth', async () => {

--- a/tests/unit/components/candidate/TaskView.test.tsx
+++ b/tests/unit/components/candidate/TaskView.test.tsx
@@ -6,6 +6,7 @@ import {
   saveCodeDraft,
   clearCodeDraft,
 } from '@/lib/storage/candidateDrafts';
+import { BRAND_SLUG } from '@/lib/brand';
 
 jest.mock('@/components/ui/CodeEditor', () => ({
   __esModule: true,
@@ -64,7 +65,10 @@ describe('TaskView', () => {
 
   it('loads and auto-saves text drafts', async () => {
     jest.useFakeTimers();
-    sessionStorage.setItem('simuhire:candidate:textDraft:5', 'Saved draft');
+    sessionStorage.setItem(
+      `${BRAND_SLUG}:candidate:textDraft:5`,
+      'Saved draft',
+    );
 
     render(
       <TaskView
@@ -85,7 +89,7 @@ describe('TaskView', () => {
       jest.advanceTimersByTime(400);
     });
 
-    expect(sessionStorage.getItem('simuhire:candidate:textDraft:5')).toBe(
+    expect(sessionStorage.getItem(`${BRAND_SLUG}:candidate:textDraft:5`)).toBe(
       'Updated draft',
     );
   });
@@ -116,7 +120,10 @@ describe('TaskView', () => {
   });
 
   it('submits trimmed text, shows progress, and clears draft', async () => {
-    sessionStorage.setItem('simuhire:candidate:textDraft:5', '  Needs trim  ');
+    sessionStorage.setItem(
+      `${BRAND_SLUG}:candidate:textDraft:5`,
+      '  Needs trim  ',
+    );
     const onSubmit = jest.fn().mockResolvedValue({
       submissionId: 1,
       taskId: 5,
@@ -152,7 +159,9 @@ describe('TaskView', () => {
       await screen.findByRole('button', { name: /submitted ✓/i }),
     ).toBeDisabled();
     expect(screen.getByText(/Progress: 1\/5/i)).toBeInTheDocument();
-    expect(sessionStorage.getItem('simuhire:candidate:textDraft:5')).toBeNull();
+    expect(
+      sessionStorage.getItem(`${BRAND_SLUG}:candidate:textDraft:5`),
+    ).toBeNull();
   });
 
   it('loads code drafts and auto-saves new code', async () => {
@@ -290,7 +299,7 @@ describe('TaskView', () => {
     const saveBtn = screen.getByRole('button', { name: /save draft/i });
     fireEvent.click(saveBtn);
 
-    expect(sessionStorage.getItem('simuhire:candidate:textDraft:5')).toBe(
+    expect(sessionStorage.getItem(`${BRAND_SLUG}:candidate:textDraft:5`)).toBe(
       'manual draft',
     );
     expect(screen.getByText(/Draft saved/)).toBeInTheDocument();

--- a/tests/unit/features/auth/authPaths.test.ts
+++ b/tests/unit/features/auth/authPaths.test.ts
@@ -1,24 +1,29 @@
 import { buildLoginHref } from '@/features/auth/authPaths';
 
-const originalCandidate = process.env.NEXT_PUBLIC_AUTH0_CANDIDATE_CONNECTION;
-const originalRecruiter = process.env.NEXT_PUBLIC_AUTH0_RECRUITER_CONNECTION;
+const originalCandidate =
+  process.env.NEXT_PUBLIC_TENON_AUTH0_CANDIDATE_CONNECTION;
+const originalRecruiter =
+  process.env.NEXT_PUBLIC_TENON_AUTH0_RECRUITER_CONNECTION;
 
 describe('authPaths buildLoginHref', () => {
   afterAll(() => {
-    process.env.NEXT_PUBLIC_AUTH0_CANDIDATE_CONNECTION = originalCandidate;
-    process.env.NEXT_PUBLIC_AUTH0_RECRUITER_CONNECTION = originalRecruiter;
+    process.env.NEXT_PUBLIC_TENON_AUTH0_CANDIDATE_CONNECTION =
+      originalCandidate;
+    process.env.NEXT_PUBLIC_TENON_AUTH0_RECRUITER_CONNECTION =
+      originalRecruiter;
   });
 
   it('appends candidate connection when mode=candidate', () => {
-    process.env.NEXT_PUBLIC_AUTH0_CANDIDATE_CONNECTION = 'SimuHire-Candidates';
+    process.env.NEXT_PUBLIC_TENON_AUTH0_CANDIDATE_CONNECTION =
+      'Tenon-Candidates';
     const href = buildLoginHref('/candidate/dashboard', 'candidate');
     expect(href).toContain('mode=candidate');
-    expect(href).toContain('connection=SimuHire-Candidates');
+    expect(href).toContain('connection=Tenon-Candidates');
     expect(href).toContain('returnTo=%2Fcandidate%2Fdashboard');
   });
 
   it('appends recruiter connection when mode=recruiter', () => {
-    process.env.NEXT_PUBLIC_AUTH0_RECRUITER_CONNECTION = 'rec-db';
+    process.env.NEXT_PUBLIC_TENON_AUTH0_RECRUITER_CONNECTION = 'rec-db';
     const href = buildLoginHref('/dashboard', 'recruiter');
     expect(href).toContain('mode=recruiter');
     expect(href).toContain('connection=rec-db');

--- a/tests/unit/features/candidate/CandidateDashboardPage.test.tsx
+++ b/tests/unit/features/candidate/CandidateDashboardPage.test.tsx
@@ -51,7 +51,7 @@ describe('CandidateDashboardPage', () => {
         token: 'INV123',
         title: 'Infra Simulation',
         role: 'Backend Engineer',
-        company: 'SimuHire',
+        company: 'Tenon',
         status: 'in_progress',
         progress: { completed: 2, total: 5 },
         expiresAt: '2025-01-01',

--- a/tests/unit/lib/auth.test.ts
+++ b/tests/unit/lib/auth.test.ts
@@ -1,4 +1,5 @@
 import { getAuthToken, setAuthToken } from '@/lib/auth';
+import { BRAND_SLUG } from '@/lib/brand';
 
 describe('auth storage helpers', () => {
   beforeEach(() => {
@@ -7,14 +8,14 @@ describe('auth storage helpers', () => {
 
   it('writes and reads auth tokens', () => {
     setAuthToken('abc123');
-    expect(localStorage.getItem('simuhire_token')).toBe('abc123');
+    expect(localStorage.getItem(`${BRAND_SLUG}_token`)).toBe('abc123');
     expect(getAuthToken()).toBe('abc123');
   });
 
   it('clears tokens when set to null', () => {
-    localStorage.setItem('simuhire_token', 'seed');
+    localStorage.setItem(`${BRAND_SLUG}_token`, 'seed');
     setAuthToken(null);
-    expect(localStorage.getItem('simuhire_token')).toBeNull();
+    expect(localStorage.getItem(`${BRAND_SLUG}_token`)).toBeNull();
     expect(getAuthToken()).toBeNull();
   });
 

--- a/tests/unit/lib/bff.test.ts
+++ b/tests/unit/lib/bff.test.ts
@@ -35,23 +35,27 @@ jest.mock('@/lib/auth0', () => ({
     middleware: jest.fn(),
   },
   getAccessToken: jest.fn(),
+  getSessionNormalized: jest.fn(),
 }));
 
 const realFetch = global.fetch;
-const originalBackendBase = process.env.BACKEND_BASE_URL;
+const originalBackendBase = process.env.TENON_BACKEND_BASE_URL;
 
 describe('forwardJson', () => {
   const fetchMock = jest.fn();
   let forwardJson: (typeof import('@/lib/server/bff'))['forwardJson'];
+  let upstreamHeader: (typeof import('@/lib/server/bff'))['UPSTREAM_HEADER'];
 
   beforeEach(async () => {
     fetchMock.mockReset();
     global.fetch = fetchMock as unknown as typeof fetch;
-    forwardJson = (await import('@/lib/server/bff')).forwardJson;
+    const mod = await import('@/lib/server/bff');
+    forwardJson = mod.forwardJson;
+    upstreamHeader = mod.UPSTREAM_HEADER;
   });
 
   afterEach(() => {
-    process.env.BACKEND_BASE_URL = originalBackendBase;
+    process.env.TENON_BACKEND_BASE_URL = originalBackendBase;
   });
 
   afterAll(() => {
@@ -80,11 +84,11 @@ describe('forwardJson', () => {
       body: undefined,
       cache: 'no-store',
     });
-    expect(res.headers.get('x-simuhire-upstream-status')).toBe('200');
+    expect(res.headers.get(upstreamHeader)).toBe('200');
   });
 
   it('uses BACKEND_BASE_URL when provided', async () => {
-    process.env.BACKEND_BASE_URL = 'https://api.example.com';
+    process.env.TENON_BACKEND_BASE_URL = 'https://api.example.com';
     fetchMock.mockResolvedValue({
       status: 200,
       headers: { get: () => null },

--- a/tests/unit/lib/codeDrafts.test.ts
+++ b/tests/unit/lib/codeDrafts.test.ts
@@ -6,6 +6,7 @@ import {
   loadCodeDraft,
   saveCodeDraft,
 } from '@/lib/storage/candidateDrafts';
+import { BRAND_SLUG } from '@/lib/brand';
 
 describe('codeDrafts helpers', () => {
   beforeEach(() => {
@@ -79,12 +80,12 @@ describe('codeDrafts helpers', () => {
   it('clears only code drafts when running clearAllCodeDrafts', () => {
     sessionStorage.setItem(codeDraftKey(1, 1), 'draft-one');
     sessionStorage.setItem(codeDraftKey('user', 'task'), 'draft-two');
-    sessionStorage.setItem('simuhire:other:key', 'keep');
+    sessionStorage.setItem(`${BRAND_SLUG}:other:key`, 'keep');
 
     clearAllCodeDrafts();
 
     expect(sessionStorage.getItem(codeDraftKey(1, 1))).toBeNull();
     expect(sessionStorage.getItem(codeDraftKey('user', 'task'))).toBeNull();
-    expect(sessionStorage.getItem('simuhire:other:key')).toBe('keep');
+    expect(sessionStorage.getItem(`${BRAND_SLUG}:other:key`)).toBe('keep');
   });
 });

--- a/tests/unit/shared/AppLayout.test.tsx
+++ b/tests/unit/shared/AppLayout.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import AppShell from '@/features/shared/layout/AppShell';
 import { AppHeader } from '@/features/shared/layout/AppHeader';
 import { AppNav } from '@/features/shared/layout/AppNav';
+import { BRAND_NAME } from '@/lib/brand';
 
 jest.mock('next/link', () => {
   function LinkMock({
@@ -26,9 +27,11 @@ jest.mock('@/lib/auth0', () => ({
   auth0: {
     getSession: jest.fn(),
   },
+  getSessionNormalized: jest.fn(),
 }));
 
-const { auth0 } = jest.requireMock('@/lib/auth0');
+const getSessionNormalizedMock = jest.requireMock('@/lib/auth0')
+  .getSessionNormalized as jest.Mock;
 
 describe('shared layout components', () => {
   afterEach(() => {
@@ -46,17 +49,17 @@ describe('shared layout components', () => {
 
   it('renders AppHeader with brand and nested nav', () => {
     render(<AppHeader isAuthed />);
-    expect(screen.getByText('SimuHire')).toBeInTheDocument();
+    expect(screen.getByText(BRAND_NAME)).toBeInTheDocument();
     expect(screen.getByText(/Dashboard/)).toBeInTheDocument();
   });
 
   it('renders AppShell with auth-driven header and children', async () => {
-    auth0.getSession.mockResolvedValue({ user: { sub: 'abc' } });
+    getSessionNormalizedMock.mockResolvedValue({ user: { sub: 'abc' } });
     const element = await AppShell({ children: <div data-testid="child" /> });
     render(element);
 
     expect(screen.getByTestId('child')).toBeInTheDocument();
-    expect(screen.getByText('SimuHire')).toBeInTheDocument();
+    expect(screen.getByText(BRAND_NAME)).toBeInTheDocument();
     expect(screen.getByText(/Dashboard/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
This PR performs a **breaking-change, repo-wide rebrand** of the frontend product name from to **Tenon**, with **no backwards compatibility**. It also renames **“Execution Profile” → “Fit Profile”** across the codebase and UI copy.

**Hard gates met:**
- ✅ Zero repo occurrences (and common variants)
- ✅ Zero repo occurrences of “Execution Profile” (and identifier variants)
- ✅ Tenon-only configuration (no legacy env var fallbacks)
- ✅ App builds, tests pass, and manual end-to-end flows validated locally

---

## Scope & Breaking Changes (Intentional)
- **No compatibility layer**:
  - No legacy/ `NEXT_PUBLIC*` env vars.
  - No alias routes or redirects for old names.
  - No backward migration of client storage keys.

---

## Major Changes (What we did)

### 1) Centralized brand constants
- Added/extended a centralized `brand.ts` (single source of truth) to drive:
  - Brand name/slug (“Tenon” / “tenon”)
  - Auth0 claim namespace default: `https://tenon.ai`
  - Shared branding for headers, metadata, and common UI

### 2) UI copy + terminology updates
- Replaced all user-facing mentions with “Tenon” across:
  - Marketing pages
  - Recruiter dashboard flows
  - Candidate session/dashboard flows
  - Auth/login/logout/not-authorized pages
  - Page titles/metadata
- Completed terminology rename:
  - **Execution Profile → Fit Profile** (UI + copy + any related references)

### 3) Tenon-only config/env cutover
- Introduced Tenon-first `.env.example` and updated docs.
- Removed all remaining era env key usage across:
  - `.env*`
  - `src/`
  - `package.json`
  - `next.config.*`
  - `README*`
- Added env-backed claim namespace:
  - `NEXT_PUBLIC_TENON_AUTH0_CLAIM_NAMESPACE` (defaults to `https://tenon.ai`)

### 4) Auth0 / Authorization alignment (critical fix)
**Problem:** Backend tokens reliably include **Tenon namespaced claims** (e.g. `https://tenon.ai/permissions`) while standard Auth0 `permissions` may be empty/null, causing false “Not authorized” UI redirects.

**Fix implemented:**
- Added `normalizeUserClaims` to map namespaced claims into the fields guards expect:
  - `user["{namespace}/permissions"]` → `user.permissions`
  - `user["{namespace}/roles"]` → `user.roles`
  - `user["{namespace}/email"]` → `user.email`
- Added `getSessionNormalized` helper and wired it into:
  - Middleware authorization checks
  - Layout and key pages/routes that read session data
- Hardened middleware/guards to accept **namespaced-only recruiter tokens**
- Added/updated tests to cover normalization and authorization behavior

### 5) API/BFF headers + client storage keys
- Kept request headers and storage keys consistent with Tenon branding:
  - Brand-slug driven keys/headers (e.g., `tenon_*`)
- No migration of prior  keys (intentional breaking change)

### 6) Tests + docs updated
- Updated unit tests impacted by branding/config changes.
- Updated README and `.env.example` to Tenon-only instructions.

---

## Verification Evidence

### A) Ripgrep hard-gate audits (all **no matches**)
```bash
rg -n "Execution Profile" .
rg -n "ExecutionProfile|execution_profile|executionProfile|execution-profile" .
```

### B) Env scan (no legacy keys)
```bash
rg -n "NEXT_PUBLIC_.*" .env* src package.json next.config.* README* .env.example
```

### C) Build/lint/test
```bash
npm run lint
npm test -- --runInBand
npm run build
```
All pass.

---

## Manual QA (Local) — Passed

### Frontend dev server
- `./runFrontend.sh` using `BACKEND_BASE_URL=http://localhost:8000`
- Confirmed:
  - Landing page loads (`GET /` → 200)
  - Recruiter dashboard loads (`GET /dashboard` → 200)
  - Recruiter simulation flow works:
    - `GET /api/simulations` → 200
    - `POST /api/simulations` → 201
    - `GET /dashboard/simulations/1` → 200
    - `GET /api/simulations/1/candidates` → 200
    - `POST /api/simulations/1/invite` → 201
  - Candidate invite/session loads:
    - `GET /candidate/session/<token>` → 200
    - `GET /candidate/dashboard` → 200

### Backend confirmation
- Backend logs confirm:
  - `GET /api/auth/me` → 200
  - Simulation and invite flows succeed
  - Candidate claim/session endpoints succeed (e.g., `POST /api/candidate/session/<token>/claim` → 200)

---

## Environment Variables (Tenon-only)

### Required / Common (examples; see `.env.example`)
- `AUTH0_*` (Auth0 SDK/server configuration)
- `APP_BASE_URL`
- `AUTH0_AUDIENCE=https://tenon.ai/api`
- `NEXT_PUBLIC_API_BASE_URL`
- `BACKEND_BASE_URL`
- `NEXT_PUBLIC_TENON_AUTH0_CLAIM_NAMESPACE` (defaults to `https://tenon.ai`)
- Optional connection hints:
  - `NEXT_PUBLIC_AUTH0_CANDIDATE_CONNECTION`
  - `NEXT_PUBLIC_AUTH0_RECRUITER_CONNECTION`

**Removed:** any  and `NEXT_PUBLIC_*` references (no fallbacks).

---

## External Updates Required (Manual)
### Auth0
- Ensure token claims are emitted under the Tenon namespace:
  - `https://tenon.ai/permissions`
  - `https://tenon.ai/roles`
  - `https://tenon.ai/email`
- Update:
  - Allowed Callback URLs
  - Allowed Logout URLs
  - Allowed Web Origins
- Confirm API Audience is `https://tenon.ai/api`

### Deployment (Vercel / hosting)
- Add Tenon env vars from `.env.example`
- Remove any era env vars
- If any monitoring/analytics expects old header names, update to Tenon equivalents

---

## Known Warnings (Non-blocking)
- Next.js warns: **middleware file convention deprecated** (suggests migrating to `proxy` convention)
- Node deprecation warning: `util._extend` deprecated (use `Object.assign`)

(These do not block build or runtime, but should be tracked as follow-up cleanup.)

---

## QA Checklist (Post-merge / Deploy)
- [ ] No repo matches or Execution Profile
- [ ] Landing/marketing shows Tenon branding + correct titles/meta
- [ ] Recruiter login works; no false “Not authorized”
- [ ] Recruiter dashboard renders; simulations list/detail pages load
- [ ] Invite creation works; candidate list refreshes
- [ ] Candidate invite/session page loads; candidate dashboard loads
- [ ] `npm run lint`, `npm test`, `npm run build` succeed in CI
- [ ] Production env vars set to Tenon-only; Auth0 allowed URLs updated

---

## Suggested Follow-ups (Optional)
- Migrate deprecated middleware convention to recommended Next.js approach (`proxy`).
- Investigate and remove `util._extend` dependency path (upgrade or patch upstream).
