### PR TITLE
Production Bugs Patch 1

### DIFF
--- a/src/app/(candidate)/candidate/dashboard/loading.tsx
+++ b/src/app/(candidate)/candidate/dashboard/loading.tsx
@@ -1,0 +1,9 @@
+export default function Loading() {
+  return (
+    <div className="p-6 space-y-3">
+      <div className="h-6 w-48 animate-pulse rounded bg-gray-200" />
+      <div className="h-4 w-72 animate-pulse rounded bg-gray-200" />
+      <div className="h-4 w-64 animate-pulse rounded bg-gray-200" />
+    </div>
+  );
+}

--- a/src/app/(candidate)/candidate/dashboard/page.tsx
+++ b/src/app/(candidate)/candidate/dashboard/page.tsx
@@ -1,12 +1,18 @@
 import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
 import CandidateDashboardPage from '@/features/candidate/dashboard/CandidateDashboardPage';
 import { BRAND_NAME } from '@/lib/brand';
+import { getSessionNormalized } from '@/lib/auth0';
 
 export const metadata: Metadata = {
   title: `Candidate dashboard | ${BRAND_NAME}`,
   description: `Continue your ${BRAND_NAME} simulations and invites.`,
 };
 
-export default function CandidateDashboardRoute() {
+export default async function CandidateDashboardRoute() {
+  const session = await getSessionNormalized();
+  if (!session) {
+    redirect('/auth/login?mode=candidate&returnTo=/candidate/dashboard');
+  }
   return <CandidateDashboardPage />;
 }

--- a/src/app/(candidate)/candidate/session/[token]/loading.tsx
+++ b/src/app/(candidate)/candidate/session/[token]/loading.tsx
@@ -1,0 +1,9 @@
+export default function Loading() {
+  return (
+    <div className="p-6 space-y-4">
+      <div className="h-6 w-64 animate-pulse rounded bg-gray-200" />
+      <div className="h-4 w-80 animate-pulse rounded bg-gray-200" />
+      <div className="h-4 w-72 animate-pulse rounded bg-gray-200" />
+    </div>
+  );
+}

--- a/src/app/(candidate)/candidate/session/[token]/page.tsx
+++ b/src/app/(candidate)/candidate/session/[token]/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
 import CandidateSessionPage from '@/features/candidate/session/CandidateSessionPage';
 import { BRAND_NAME } from '@/lib/brand';
 import {
   requireCandidateToken,
   type TokenParams,
 } from '../../../candidate-sessions/token-params';
+import { getSessionNormalized } from '@/lib/auth0';
 
 export const metadata: Metadata = {
   title: `Candidate simulation | ${BRAND_NAME}`,
@@ -17,6 +19,13 @@ export default async function CandidateSessionRoute({
   params: TokenParams;
 }) {
   const token = await requireCandidateToken(params);
+
+  const session = await getSessionNormalized();
+  if (!session) {
+    redirect(
+      `/auth/login?mode=candidate&returnTo=${encodeURIComponent(`/candidate/session/${token}`)}`,
+    );
+  }
 
   return <CandidateSessionPage token={token} />;
 }

--- a/src/app/(recruiter)/dashboard/loading.tsx
+++ b/src/app/(recruiter)/dashboard/loading.tsx
@@ -1,0 +1,12 @@
+export default function Loading() {
+  return (
+    <div className="py-8">
+      <div className="h-6 w-40 animate-pulse rounded bg-gray-200" />
+      <div className="mt-4 space-y-3">
+        <div className="h-4 w-64 animate-pulse rounded bg-gray-200" />
+        <div className="h-4 w-56 animate-pulse rounded bg-gray-200" />
+        <div className="h-4 w-48 animate-pulse rounded bg-gray-200" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(recruiter)/dashboard/page.tsx
+++ b/src/app/(recruiter)/dashboard/page.tsx
@@ -14,7 +14,7 @@ export default async function DashboardPage() {
   const session = await getSessionNormalized();
 
   if (!session) {
-    redirect('/auth/login');
+    redirect('/auth/login?mode=recruiter&returnTo=/dashboard');
   }
 
   const { profile, error } = await fetchRecruiterProfile();

--- a/src/app/(recruiter)/dashboard/simulations/[id]/loading.tsx
+++ b/src/app/(recruiter)/dashboard/simulations/[id]/loading.tsx
@@ -1,0 +1,10 @@
+export default function Loading() {
+  return (
+    <div className="py-8 space-y-4">
+      <div className="h-6 w-60 animate-pulse rounded bg-gray-200" />
+      <div className="h-4 w-80 animate-pulse rounded bg-gray-200" />
+      <div className="h-4 w-72 animate-pulse rounded bg-gray-200" />
+      <div className="h-4 w-64 animate-pulse rounded bg-gray-200" />
+    </div>
+  );
+}

--- a/src/app/(recruiter)/dashboard/simulations/new/loading.tsx
+++ b/src/app/(recruiter)/dashboard/simulations/new/loading.tsx
@@ -1,0 +1,9 @@
+export default function Loading() {
+  return (
+    <div className="py-8 space-y-3">
+      <div className="h-6 w-52 animate-pulse rounded bg-gray-200" />
+      <div className="h-4 w-96 animate-pulse rounded bg-gray-200" />
+      <div className="h-4 w-80 animate-pulse rounded bg-gray-200" />
+    </div>
+  );
+}

--- a/src/app/api/debug/auth/route.ts
+++ b/src/app/api/debug/auth/route.ts
@@ -3,6 +3,8 @@ import { getSessionNormalized } from '@/lib/auth0';
 import { extractPermissions } from '@/lib/auth0-claims';
 import { CUSTOM_CLAIM_ROLES } from '@/lib/brand';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET() {
   if (process.env.NODE_ENV === 'production') {
     return NextResponse.json({ message: 'Not found' }, { status: 404 });

--- a/src/app/api/dev/access-token/route.ts
+++ b/src/app/api/dev/access-token/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { ensureAccessToken } from '@/lib/server/bff';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET() {
   const auth = await ensureAccessToken();
   if (auth instanceof NextResponse) return auth;

--- a/src/app/api/simulations/[id]/candidates/[candidateSessionId]/invite/resend/route.ts
+++ b/src/app/api/simulations/[id]/candidates/[candidateSessionId]/invite/resend/route.ts
@@ -1,17 +1,21 @@
 import { forwardJson, withAuthGuard } from '@/lib/server/bff';
 
+export const dynamic = 'force-dynamic';
+
 export async function POST(
   _req: Request,
   context: { params: Promise<{ id: string; candidateSessionId: string }> },
 ) {
   const { id, candidateSessionId } = await context.params;
 
-  return withAuthGuard((accessToken) =>
-    forwardJson({
-      path: `/api/simulations/${encodeURIComponent(id)}/candidates/${encodeURIComponent(candidateSessionId)}/invite/resend`,
-      method: 'POST',
-      cache: 'no-store',
-      accessToken,
-    }),
+  return withAuthGuard(
+    (accessToken) =>
+      forwardJson({
+        path: `/api/simulations/${encodeURIComponent(id)}/candidates/${encodeURIComponent(candidateSessionId)}/invite/resend`,
+        method: 'POST',
+        cache: 'no-store',
+        accessToken,
+      }),
+    { requirePermission: 'recruiter:access' },
   );
 }

--- a/src/app/api/simulations/[id]/candidates/route.ts
+++ b/src/app/api/simulations/[id]/candidates/route.ts
@@ -1,17 +1,21 @@
 import { forwardJson, withAuthGuard } from '@/lib/server/bff';
 import { BFF_HEADER } from '@/app/api/utils';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET(
   _req: Request,
   context: { params: Promise<{ id: string }> },
 ) {
   const { id } = await context.params;
 
-  const resp = await withAuthGuard((accessToken) =>
-    forwardJson({
-      path: `/api/simulations/${encodeURIComponent(id)}/candidates`,
-      accessToken,
-    }),
+  const resp = await withAuthGuard(
+    (accessToken) =>
+      forwardJson({
+        path: `/api/simulations/${encodeURIComponent(id)}/candidates`,
+        accessToken,
+      }),
+    { requirePermission: 'recruiter:access' },
   );
   resp.headers.set(BFF_HEADER, 'simulations-candidates');
   return resp;

--- a/src/app/api/simulations/[id]/invite/route.ts
+++ b/src/app/api/simulations/[id]/invite/route.ts
@@ -2,6 +2,8 @@ import { NextRequest } from 'next/server';
 import { forwardJson, withAuthGuard } from '@/lib/server/bff';
 import { BFF_HEADER } from '@/app/api/utils';
 
+export const dynamic = 'force-dynamic';
+
 export async function POST(
   req: NextRequest,
   context: { params: Promise<{ id: string }> },
@@ -10,14 +12,16 @@ export async function POST(
 
   const payload: unknown = await req.json().catch(() => undefined);
 
-  const resp = await withAuthGuard((accessToken) =>
-    forwardJson({
-      path: `/api/simulations/${encodeURIComponent(id)}/invite`,
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: payload ?? {},
-      accessToken,
-    }),
+  const resp = await withAuthGuard(
+    (accessToken) =>
+      forwardJson({
+        path: `/api/simulations/${encodeURIComponent(id)}/invite`,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: payload ?? {},
+        accessToken,
+      }),
+    { requirePermission: 'recruiter:access' },
   );
   resp.headers.set(BFF_HEADER, 'invite');
   return resp;

--- a/src/app/api/simulations/route.ts
+++ b/src/app/api/simulations/route.ts
@@ -1,11 +1,22 @@
-import { forwardWithAuth, errorResponse } from '@/app/api/utils';
+import { errorResponse, BFF_HEADER } from '@/app/api/utils';
+import { forwardJson, withAuthGuard } from '@/lib/server/bff';
+
+export const dynamic = 'force-dynamic';
 
 export async function GET() {
   try {
-    return await forwardWithAuth({
-      path: '/api/simulations',
-      tag: 'simulations-list',
-    });
+    const resp = await withAuthGuard(
+      (accessToken) =>
+        forwardJson({
+          path: '/api/simulations',
+          accessToken,
+        }),
+      { requirePermission: 'recruiter:access' },
+    );
+    if ('set' in resp.headers) {
+      resp.headers.set(BFF_HEADER, 'simulations-list');
+    }
+    return resp;
   } catch (e: unknown) {
     return errorResponse(e);
   }
@@ -15,13 +26,21 @@ export async function POST(req: Request) {
   try {
     const body = (await req.json()) as unknown;
 
-    return await forwardWithAuth({
-      path: '/api/simulations',
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body,
-      tag: 'simulations-create',
-    });
+    const resp = await withAuthGuard(
+      (accessToken) =>
+        forwardJson({
+          path: '/api/simulations',
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body,
+          accessToken,
+        }),
+      { requirePermission: 'recruiter:access' },
+    );
+    if ('set' in resp.headers) {
+      resp.headers.set(BFF_HEADER, 'simulations-create');
+    }
+    return resp;
   } catch (e: unknown) {
     return errorResponse(e);
   }

--- a/src/app/api/submissions/[submissionId]/route.ts
+++ b/src/app/api/submissions/[submissionId]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest } from 'next/server';
 import { errorResponse, forwardWithAuth } from '@/app/api/utils';
 
+export const dynamic = 'force-dynamic';
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function GET(_req: NextRequest, { params }: any) {
   const submissionId = params.submissionId;

--- a/src/app/api/submissions/route.ts
+++ b/src/app/api/submissions/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest } from 'next/server';
 import { forwardWithAuth } from '@/app/api/utils';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET(req: NextRequest) {
   const search = req.nextUrl.searchParams.toString();
   const path = `/api/submissions${search ? `?${search}` : ''}`;

--- a/src/app/not-authorized/page.tsx
+++ b/src/app/not-authorized/page.tsx
@@ -18,6 +18,7 @@ export default async function NotAuthorizedPage({
   const rawMode = resolved?.mode;
   const mode =
     rawMode === 'candidate' || rawMode === 'recruiter' ? rawMode : undefined;
+  const returnTo = resolved?.returnTo;
 
   return (
     <div className="mx-auto flex max-w-2xl flex-col gap-4 p-6">
@@ -34,13 +35,15 @@ export default async function NotAuthorizedPage({
 
       <div className="flex flex-wrap gap-3">
         <Link
-          href="/candidate/dashboard"
+          href={
+            returnTo && mode === 'candidate' ? returnTo : '/candidate/dashboard'
+          }
           className="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-800 shadow-sm hover:bg-gray-50"
         >
           Go to Candidate Portal
         </Link>
         <Link
-          href="/dashboard"
+          href={returnTo && mode === 'recruiter' ? returnTo : '/dashboard'}
           className="inline-flex items-center rounded-md border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700"
         >
           Go to Recruiter Dashboard

--- a/src/features/auth/LoginLink.tsx
+++ b/src/features/auth/LoginLink.tsx
@@ -16,7 +16,7 @@ export default function LoginLink({
 }: LoginLinkProps) {
   const href = buildLoginHref(returnTo, mode);
   return (
-    <a href={href} className={className}>
+    <a href={href} className={className} data-nav="login-link" rel="noopener">
       {children}
     </a>
   );

--- a/src/features/recruiter/dashboard/components/DashboardHeader.tsx
+++ b/src/features/recruiter/dashboard/components/DashboardHeader.tsx
@@ -1,5 +1,6 @@
 import PageHeader from '@/components/ui/PageHeader';
 import Button from '@/components/ui/Button';
+import Link from 'next/link';
 
 type DashboardHeaderProps = {
   onNewSimulation: () => void;
@@ -10,9 +11,11 @@ export function DashboardHeader({ onNewSimulation }: DashboardHeaderProps) {
     <PageHeader
       title="Dashboard"
       actions={
-        <Button type="button" onClick={onNewSimulation}>
-          New Simulation
-        </Button>
+        <Link href="/dashboard/simulations/new" prefetch>
+          <Button type="button" onClick={onNewSimulation}>
+            New Simulation
+          </Button>
+        </Link>
       }
     />
   );

--- a/src/features/recruiter/simulations/SimulationList.tsx
+++ b/src/features/recruiter/simulations/SimulationList.tsx
@@ -35,6 +35,7 @@ export function SimulationList({ simulations, onInvite }: SimulationListProps) {
             <div className="col-span-4">
               <Link
                 href={`/dashboard/simulations/${sim.id}`}
+                prefetch
                 className="font-medium text-blue-600 hover:underline"
               >
                 {sim.title}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -92,7 +92,7 @@ export async function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
   const authResponse = await auth0.middleware(request);
-
+  if (pathname.startsWith('/api/')) return authResponse;
   if (shouldSkipAuth(pathname)) return authResponse;
 
   const session = await getSessionNormalized(request);
@@ -127,6 +127,6 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
+    '/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
   ],
 };

--- a/tests/unit/lib/recruiterApi.test.ts
+++ b/tests/unit/lib/recruiterApi.test.ts
@@ -188,7 +188,12 @@ describe('recruiterApi', () => {
         seniority: 'Mid',
       });
 
-      expect(result).toEqual({ id: '' });
+      expect(result).toEqual({
+        id: '',
+        ok: false,
+        status: 400,
+        message: 'Missing required fields',
+      });
       expect(mockedPost).not.toHaveBeenCalled();
     });
 
@@ -203,15 +208,24 @@ describe('recruiterApi', () => {
         focus: '  Focus ',
       });
 
-      expect(mockedPost).toHaveBeenCalledWith('/simulations', {
-        title: 'Backend Sim',
-        role: 'Backend',
-        techStack: 'Node',
-        seniority: 'Senior',
-        focus: 'Focus',
-      });
+      expect(mockedPost).toHaveBeenCalledWith(
+        '/simulations',
+        {
+          title: 'Backend Sim',
+          role: 'Backend',
+          techStack: 'Node',
+          seniority: 'Senior',
+          focus: 'Focus',
+        },
+        { cache: 'no-store' },
+      );
 
-      expect(result).toEqual({ id: 'sim_99' });
+      expect(result).toEqual({
+        id: 'sim_99',
+        ok: true,
+        status: 201,
+        message: undefined,
+      });
     });
 
     it('normalizes snake_case id responses', async () => {
@@ -224,7 +238,12 @@ describe('recruiterApi', () => {
         seniority: 'Junior',
       });
 
-      expect(result).toEqual({ id: '42' });
+      expect(result).toEqual({
+        id: '42',
+        ok: true,
+        status: 201,
+        message: undefined,
+      });
     });
 
     it('omits focus field when blank after trimming', async () => {
@@ -238,15 +257,24 @@ describe('recruiterApi', () => {
         focus: '   ',
       });
 
-      expect(mockedPost).toHaveBeenCalledWith('/simulations', {
-        title: 'Sim',
-        role: 'Backend',
-        techStack: 'Node',
-        seniority: 'Junior',
-        focus: undefined,
-      });
+      expect(mockedPost).toHaveBeenCalledWith(
+        '/simulations',
+        {
+          title: 'Sim',
+          role: 'Backend',
+          techStack: 'Node',
+          seniority: 'Junior',
+          focus: undefined,
+        },
+        { cache: 'no-store' },
+      );
 
-      expect(result).toEqual({ id: 'sim_200' });
+      expect(result).toEqual({
+        id: 'sim_200',
+        ok: true,
+        status: 201,
+        message: undefined,
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Enforced deterministic auth flow: middleware now covers /api without redirects, candidate dashboard route redirects server-side, and simulation create page uses full-page auth redirects only.
- Hardened recruiter BFF permission enforcement for simulations and cleaned up implicit permission injection.
- Improved Create Simulation UX/navigation and added loading/prefetch polish, plus formatting fixes.

## Testing
- ./precommit.sh
