### PR TITLE
Patch: Harden BFF dashboard & backend proxy + improve dashboard LCP + fix invite crash

### DIFF
--- a/src/app/(recruiter)/dashboard/loading.tsx
+++ b/src/app/(recruiter)/dashboard/loading.tsx
@@ -1,12 +1,49 @@
 export default function Loading() {
   return (
-    <div className="py-8">
-      <div className="h-6 w-40 animate-pulse rounded bg-gray-200" />
-      <div className="mt-4 space-y-3">
-        <div className="h-4 w-64 animate-pulse rounded bg-gray-200" />
-        <div className="h-4 w-56 animate-pulse rounded bg-gray-200" />
-        <div className="h-4 w-48 animate-pulse rounded bg-gray-200" />
+    <main className="flex flex-col gap-5 py-8">
+      <div className="flex items-center justify-between gap-4">
+        <div className="h-7 w-36 animate-pulse rounded bg-gray-200" />
+        <div className="h-9 w-32 animate-pulse rounded bg-gray-200" />
       </div>
-    </div>
+
+      <div className="rounded border border-gray-200 bg-white p-4 shadow-sm">
+        <div className="h-4 w-32 animate-pulse rounded bg-gray-200" />
+        <div className="mt-2 h-3 w-48 animate-pulse rounded bg-gray-100" />
+      </div>
+
+      <section className="flex flex-col gap-3">
+        <div className="h-5 w-32 animate-pulse rounded bg-gray-200" />
+        <div className="rounded border border-gray-200 bg-white">
+          <div className="grid grid-cols-12 gap-3 border-b border-gray-200 bg-gray-50 p-3 text-xs font-medium uppercase tracking-wide text-gray-500">
+            <div className="h-3 w-20 animate-pulse rounded bg-gray-200" />
+            <div className="h-3 w-16 animate-pulse rounded bg-gray-200" />
+            <div className="h-3 w-16 animate-pulse rounded bg-gray-200" />
+            <div className="h-3 w-16 animate-pulse rounded bg-gray-200" />
+          </div>
+          {Array.from({ length: 3 }).map((_, idx) => (
+            <div
+              key={idx}
+              className="border-b border-gray-200 p-3 last:border-b-0"
+            >
+              <div className="grid grid-cols-12 items-center gap-3">
+                <div className="col-span-4">
+                  <div className="h-4 w-40 animate-pulse rounded bg-gray-200" />
+                  <div className="mt-1 h-3 w-24 animate-pulse rounded bg-gray-100" />
+                </div>
+                <div className="col-span-3">
+                  <div className="h-4 w-28 animate-pulse rounded bg-gray-200" />
+                </div>
+                <div className="col-span-3">
+                  <div className="h-4 w-24 animate-pulse rounded bg-gray-200" />
+                </div>
+                <div className="col-span-2 flex justify-end">
+                  <div className="h-8 w-28 animate-pulse rounded bg-gray-200" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </main>
   );
 }

--- a/src/features/recruiter/dashboard/RecruiterDashboardPage.tsx
+++ b/src/features/recruiter/dashboard/RecruiterDashboardPage.tsx
@@ -1,9 +1,13 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import DashboardView from '@/features/recruiter/dashboard/DashboardView';
 import { useDashboardData } from './hooks/useDashboardData';
+import { logPerf, nowMs } from './utils/perf';
 
 export default function RecruiterDashboardPage() {
+  const renderStartRef = useRef(nowMs());
+
   const {
     profile,
     profileError,
@@ -13,6 +17,10 @@ export default function RecruiterDashboardPage() {
     loadingSimulations,
     refresh,
   } = useDashboardData();
+
+  useEffect(() => {
+    logPerf('dashboard-shell-first-render', renderStartRef.current);
+  }, []);
 
   return (
     <DashboardView

--- a/src/features/recruiter/dashboard/components/DashboardHeader.tsx
+++ b/src/features/recruiter/dashboard/components/DashboardHeader.tsx
@@ -3,7 +3,7 @@ import Button from '@/components/ui/Button';
 import Link from 'next/link';
 
 type DashboardHeaderProps = {
-  onNewSimulation: () => void;
+  onNewSimulation?: () => void;
 };
 
 export function DashboardHeader({ onNewSimulation }: DashboardHeaderProps) {

--- a/src/features/recruiter/dashboard/components/SimulationSection.tsx
+++ b/src/features/recruiter/dashboard/components/SimulationSection.tsx
@@ -21,7 +21,36 @@ export function SimulationSection({
       <h2 className="text-lg font-semibold">Simulations</h2>
 
       {loading && !hasSimulations ? (
-        <p className="text-sm text-gray-600">Loading simulations…</p>
+        <div className="rounded border border-gray-200 bg-white">
+          <div className="grid grid-cols-12 gap-3 border-b border-gray-200 bg-gray-50 p-3 text-xs font-medium uppercase tracking-wide text-gray-500">
+            <div className="h-3 w-20 animate-pulse rounded bg-gray-200" />
+            <div className="h-3 w-16 animate-pulse rounded bg-gray-200" />
+            <div className="h-3 w-16 animate-pulse rounded bg-gray-200" />
+            <div className="h-3 w-16 animate-pulse rounded bg-gray-200" />
+          </div>
+          {Array.from({ length: 3 }).map((_, idx) => (
+            <div
+              key={idx}
+              className="border-b border-gray-200 p-3 last:border-b-0"
+            >
+              <div className="grid grid-cols-12 items-center gap-3">
+                <div className="col-span-4">
+                  <div className="h-4 w-40 animate-pulse rounded bg-gray-200" />
+                  <div className="mt-1 h-3 w-24 animate-pulse rounded bg-gray-100" />
+                </div>
+                <div className="col-span-3">
+                  <div className="h-4 w-28 animate-pulse rounded bg-gray-200" />
+                </div>
+                <div className="col-span-3">
+                  <div className="h-4 w-24 animate-pulse rounded bg-gray-200" />
+                </div>
+                <div className="col-span-2 flex justify-end">
+                  <div className="h-8 w-28 animate-pulse rounded bg-gray-200" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
       ) : null}
 
       {!loading && error ? (

--- a/src/features/recruiter/dashboard/hooks/useDashboardData.ts
+++ b/src/features/recruiter/dashboard/hooks/useDashboardData.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/auth/routing';
 import { toUserMessage } from '@/lib/utils/errors';
 import type { RecruiterProfile, SimulationListItem } from '@/types/recruiter';
+import { dashboardPerfDebugEnabled, logPerf, nowMs } from '../utils/perf';
 
 type Options = {
   initialProfile?: RecruiterProfile | null;
@@ -65,6 +66,7 @@ export function useDashboardData(options?: Options) {
     controllersRef.current.dashboard?.abort();
     const controller = new AbortController();
     controllersRef.current.dashboard = controller;
+    const startedAt = nowMs();
 
     const promise = (async () => {
       const res = await fetch('/api/dashboard', {
@@ -73,6 +75,9 @@ export function useDashboardData(options?: Options) {
         signal: controller.signal,
       });
       const parsed: unknown = await res.json().catch(() => null);
+      if (dashboardPerfDebugEnabled) {
+        logPerf('/api/dashboard response', startedAt, { status: res.status });
+      }
 
       if (!res.ok) {
         const status = res.status;

--- a/src/features/recruiter/dashboard/utils/perf.ts
+++ b/src/features/recruiter/dashboard/utils/perf.ts
@@ -1,0 +1,32 @@
+const rawFlag =
+  process.env.NEXT_PUBLIC_TENON_DEBUG_PERF ??
+  process.env.TENON_DEBUG_PERF ??
+  '';
+
+export const dashboardPerfDebugEnabled =
+  rawFlag === '1' || rawFlag.toLowerCase() === 'true';
+
+export function nowMs(): number | null {
+  if (typeof performance === 'undefined') return null;
+  if (typeof performance.now !== 'function') return null;
+  return performance.now();
+}
+
+export function logPerf(
+  label: string,
+  startedAt?: number | null,
+  extra?: Record<string, unknown>,
+) {
+  if (!dashboardPerfDebugEnabled) return;
+  const now = nowMs();
+  if (now === null) return;
+
+  const payload: Record<string, unknown> = extra ? { ...extra } : {};
+  if (typeof startedAt === 'number') {
+    payload.durationMs = Math.round(now - startedAt);
+  }
+  payload.atMs = Math.round(now);
+
+  // eslint-disable-next-line no-console
+  console.info(`[tenon][perf] ${label}`, payload);
+}

--- a/src/lib/api/recruiter.ts
+++ b/src/lib/api/recruiter.ts
@@ -108,9 +108,14 @@ export async function inviteCandidate(
   candidateName: string,
   inviteEmail: string,
 ): Promise<InviteCandidateResponse> {
-  const safeId = simulationId.trim();
-  const safeName = candidateName.trim();
-  const safeEmail = inviteEmail.trim();
+  const safeTrim = (value: unknown) =>
+    typeof value === 'string' || typeof value === 'number'
+      ? String(value).trim()
+      : '';
+
+  const safeId = safeTrim(simulationId);
+  const safeName = safeTrim(candidateName);
+  const safeEmail = safeTrim(inviteEmail).toLowerCase();
 
   if (!safeId || !safeName || !safeEmail) {
     return { candidateSessionId: '', token: '', inviteUrl: '' };

--- a/tests/unit/lib/recruiterApi.test.ts
+++ b/tests/unit/lib/recruiterApi.test.ts
@@ -210,6 +210,21 @@ describe('recruiterApi', () => {
       });
       expect(mockedBffPost).not.toHaveBeenCalled();
     });
+
+    it('guards against non-string inputs without throwing', async () => {
+      const result = await inviteCandidate(
+        { bad: true } as unknown as string,
+        { value: 'Name' } as unknown as string,
+        { value: 'Email' } as unknown as string,
+      );
+
+      expect(result).toEqual({
+        candidateSessionId: '',
+        token: '',
+        inviteUrl: '',
+      });
+      expect(mockedBffPost).not.toHaveBeenCalled();
+    });
   });
 
   describe('createSimulation', () => {

--- a/tests/unit/recruiter/InviteCandidateModal.test.tsx
+++ b/tests/unit/recruiter/InviteCandidateModal.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { InviteCandidateModal } from '@/features/recruiter/invitations/InviteCandidateModal';
+
+describe('InviteCandidateModal', () => {
+  it('passes string values to submit handler', () => {
+    const onSubmit = jest.fn();
+    render(
+      <InviteCandidateModal
+        open
+        title="Test Simulation"
+        state={{ status: 'idle' }}
+        onClose={() => undefined}
+        onSubmit={onSubmit}
+        initialName=""
+        initialEmail=""
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Candidate name/i), {
+      target: { value: '  Jane Doe  ' },
+    });
+    fireEvent.change(screen.getByLabelText(/Candidate email/i), {
+      target: { value: '  JANE@EXAMPLE.COM  ' },
+    });
+
+    fireEvent.click(screen.getByText('Create invite'));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const [name, email] = onSubmit.mock.calls[0] as [unknown, unknown];
+    expect(typeof name).toBe('string');
+    expect(typeof email).toBe('string');
+    expect(name).toBe('  Jane Doe  ');
+    expect(email).toBe('  JANE@EXAMPLE.COM  ');
+  });
+});

--- a/tests/unit/recruiter/inviteFlow.test.tsx
+++ b/tests/unit/recruiter/inviteFlow.test.tsx
@@ -1,0 +1,70 @@
+import { act, renderHook } from '@testing-library/react';
+import { useInviteCandidateFlow } from '@/features/recruiter/dashboard/hooks/useInviteCandidateFlow';
+import { inviteCandidate } from '@/lib/api/recruiter';
+
+jest.mock('@/lib/api/recruiter', () => ({
+  inviteCandidate: jest.fn(),
+}));
+
+describe('useInviteCandidateFlow', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('normalizes invite inputs safely before submitting', async () => {
+    (inviteCandidate as jest.Mock).mockResolvedValueOnce({
+      inviteUrl: '/invite/url',
+      candidateSessionId: 'cs_1',
+      token: 'tok',
+    });
+
+    const { result } = renderHook(() =>
+      useInviteCandidateFlow({
+        open: true,
+        simulationId: ' sim-123 ',
+        simulationTitle: 'Sim 123',
+      }),
+    );
+
+    let response;
+    await act(async () => {
+      response = await result.current.submit(
+        { currentTarget: { value: ' Jane ' } } as unknown as string,
+        { value: 'USER@Example.com ' } as unknown as string,
+      );
+    });
+
+    expect(inviteCandidate).toHaveBeenCalledWith(
+      'sim-123',
+      'Jane',
+      'user@example.com',
+    );
+    expect(response).toEqual({
+      inviteUrl: '/invite/url',
+      simulationId: 'sim-123',
+      candidateName: 'Jane',
+      candidateEmail: 'user@example.com',
+    });
+  });
+
+  it('shows a friendly error message when the API throws non-string data', async () => {
+    (inviteCandidate as jest.Mock).mockRejectedValueOnce({ boom: true });
+
+    const { result } = renderHook(() =>
+      useInviteCandidateFlow({
+        open: true,
+        simulationId: 'sim-123',
+        simulationTitle: 'Sim 123',
+      }),
+    );
+
+    await act(async () => {
+      await result.current.submit('Jane', 'jane@example.com');
+    });
+
+    expect(result.current.state.status).toBe('error');
+    expect(result.current.state.message).toContain(
+      'Failed to invite candidate',
+    );
+  });
+});


### PR DESCRIPTION
## Why
Hosted QA surfaced two classes of issues:

1) **Reliability / safety**
- Transient upstream failures (429/5xx/timeouts) needed predictable retries + budgets.
- Partial upstream availability (profile ok, simulations down) should not break the dashboard.
- Redirect/header safety and request/response body-size caps were needed for security + stability.
- Correlation (`x-tenon-request-id`) must survive *all* paths.

2) **User experience**
- Recruiter `/dashboard` had poor **Largest Contentful Paint (LCP)** due to a thin loading shell and unnecessary initial JS.
- Invite creation could fail with **`e.trim is not a function`** due to unsafe input normalization.

This PR hardens the BFF layer end-to-end (dashboard + backend proxy), adds observability + optional load testing, and ships targeted UI/perf + invite-flow fixes.

---

## What changed

### 1) Upstream fetch hardening (`src/lib/server/bff.ts`)
**Robust upstream fetch (`robustFetch` / `upstreamRequest`)**
- Retries for idempotent methods (**GET/HEAD**) on `502/503/504/429`.
- **Retry-safe body handling**: cancel/drain upstream bodies before retrying so connections aren’t held open.
- **429 Retry-After** respected (supports seconds + HTTP-date parsing).
- **Abort-aware backoff**: route abort cancels retry delays immediately.
- **Timeout + total budget**:
  - `timeoutMs` per attempt.
  - `maxTotalTimeMs` caps the *entire* request across retries (defaults to `timeoutMs` in `upstreamRequest`).
- **Abort listener hygiene**: abort listeners are removed after completion/error to avoid leaks.
- **Request-id propagation**: always inject `x-tenon-request-id` upstream.
- Attach `_tenonMeta = { attempts, durationMs }` to responses for downstream timing/reporting.

**Optional keep-alive dispatcher (undici)**
- Dispatcher is now **opt-in**: `TENON_USE_FETCH_DISPATCHER=1|true`.
- Runtime guards ensure dispatcher only activates when the environment supports it.
- Test coverage for default-off + opt-in paths.

**`forwardJson` improvements**
- Default `Content-Type: application/json` only when sending a JSON body and the caller did not already set a content-type.
- Preserve caller content-type and raw string bodies.
- Adds spec-friendly `Server-Timing` when upstream meta exists:
  - `Server-Timing: bff;dur=..., retry;desc="count=N"`
- Keeps `redirect: 'manual'` and strips any `Location` header.

---

### 2) `/api/dashboard` partial-failure behavior + richer headers (`src/app/api/dashboard/route.ts`)
**True partial failures**
- Calls upstream profile (`/api/auth/me`) + simulations (`/api/simulations`) using `Promise.allSettled`.
- If one fails, return a stable payload:
  - `profile` and/or `simulations` preserved when available.
  - `profileError` / `simulationsError` provide stable, user-facing messages.

**Auth passthrough**
- If either upstream returns `401/403`, return that status immediately with upstream body.

**Abort signal propagation**
- Threads `req.signal` into upstream calls so navigation aborts stop work quickly.

**Headers**
- Always sets:
  - `x-tenon-request-id`
  - `x-tenon-bff: dashboard`
  - `x-tenon-upstream-status` (worst upstream status)
  - `x-tenon-upstream-status-profile`
  - `x-tenon-upstream-status-simulations`
- Adds `Server-Timing` for total duration + retry counts.
- Ensures `Location` is never leaked.

---

### 3) Backend proxy hardening (`src/app/api/backend/[...path]/route.ts`)
**Request size cap**
- Short-circuit **413** if request is too large (and **do not read the body** when `content-length` exceeds limit).
- Stable JSON error with `x-tenon-request-id`.

**Response size cap**
- If `content-length` exceeds cap → return JSON **502** without reading.
- If streamed body exceeds cap while reading → cancel upstream stream and return JSON **502**.

**Parsing safeguards**
- Prevent double-reading upstream bodies.
- Invalid JSON now falls back to a stable message without re-parsing consumed streams.

**Security / correctness**
- Redirects remain blocked; `Location` never leaks.
- Always sets `x-tenon-upstream-status` + `x-tenon-request-id`.
- Propagates `req.signal`.
- Uses spec-friendly `Server-Timing: ... retry;desc="count=N"`.

---

### 4) Observability: perf debug flag (client)
Files:
- `src/features/recruiter/dashboard/utils/perf.ts`
- `src/features/recruiter/dashboard/RecruiterDashboardPage.tsx`
- `src/features/recruiter/dashboard/hooks/useDashboardData.ts`

Behavior:
- When `NEXT_PUBLIC_TENON_DEBUG_PERF=true|1` (or `TENON_DEBUG_PERF=true|1`), logs:
  - shell first render timing
  - `/api/dashboard` response timing + status
- Silent by default.

---

### 5) Load testing utility
Files:
- `scripts/loadtest-dashboard.mjs`
- `package.json`, `package-lock.json`
- `README.md`

Changes:
- Added `npm run loadtest:dashboard` (autocannon).
- Supports authenticated runs via `LOADTEST_COOKIE` or `LOADTEST_AUTH_HEADER`.
- Warns when unauthenticated to avoid benchmarking 401/403.
- README updated with dispatcher opt-in + load-test notes.

---

### 6) Dashboard LCP improvements
Files:
- `src/app/(recruiter)/dashboard/loading.tsx`
- `src/features/recruiter/dashboard/components/SimulationSection.tsx`
- `src/features/recruiter/dashboard/DashboardView.tsx`
- `src/features/recruiter/dashboard/components/DashboardHeader.tsx`

Changes:
- Loading shell now renders a **realistic header + table skeleton** immediately so LCP improves.
- Simulation section renders a skeleton table during initial load.
- Invite-only UI is **lazy-loaded** via `next/dynamic`:
  - `InviteCandidateModal`
  - `InviteToast`
- Only render invite components when needed (modal open / toast open).
- Removed router wiring from header to reduce initial chunk.

---

### 7) Invite bugfix: `e.trim is not a function`
Root cause:
- Non-string values (e.g., event objects) reached `.trim()` paths.

Fixes:
- `src/features/recruiter/dashboard/hooks/useInviteCandidateFlow.ts`
  - Added `toSafeString()` that supports:
    - strings / numbers
    - event-like shapes (`target.value`, `currentTarget.value`, `value`)
  - Normalizes:
    - name → `trim()`
    - email → `trim().toLowerCase()`
  - Blocks API calls on invalid inputs; returns friendly validation errors.
- `src/lib/api/recruiter.ts`
  - Added `safeTrim()` guarding against non-string inputs; returns empty response object instead of throwing.
  - Lowercases email.

---

## Tests added / updated
- BFF:
  - retries (503/429), Retry-After parsing (seconds + HTTP-date)
  - cancel/drain safety (including cancel rejection)
  - abort listener cleanup on success and on errors
  - max total budget behavior
  - dispatcher default-off + opt-in
- Dashboard route:
  - partial-failure payload + headers (worst + per-upstream + request-id)
  - signal threading to upstream calls
  - Server-Timing presence/format
- Backend proxy:
  - request oversize 413 without reading body
  - response cap via content-length + streaming overflow
  - invalid JSON path without double-read
- Invite flow:
  - hook normalization and safe submission
  - modal submission passes string values
  - API client guard against non-string inputs

Commands run:
- `npm test -- --runInBand`
- `npm run lint`
- `npm run build`

---

## Manual QA checklist

### Dashboard LCP
- Open `/dashboard` with DevTools Performance:
  - confirm skeleton header + table paint immediately
  - compare LCP before/after

### Network hygiene
- Recruiter dashboard should only fire **one request**: `GET /api/dashboard`
- Response headers include:
  - `x-tenon-request-id`
  - `x-tenon-bff: dashboard`
  - `x-tenon-upstream-status`
  - `x-tenon-upstream-status-profile`
  - `x-tenon-upstream-status-simulations`
  - `Server-Timing: bff;dur=..., retry;desc="count=N"`
- No `Location` header present on API responses.

### Abort behavior
- Navigate away mid-load:
  - upstream work cancels quickly (signal propagated; backoff is abort-aware)

### Invite flow
- From dashboard → **Invite candidate**
- Enter name/email → **Create invite**
  - no `e.trim is not a function`
  - email normalizes to lowercase
  - empty fields show validation error (no API call)

### Backend proxy
- Oversize request:
  - returns `413` without reading request body
- Oversize upstream response:
  - returns `502` with JSON error + request-id
- Redirects:
  - never leak `Location`

### Optional perf logs
- Set `NEXT_PUBLIC_TENON_DEBUG_PERF=true` and watch console:
  - `dashboard-shell-first-render`
  - `/api/dashboard response`

### Optional load test
- `npm run loadtest:dashboard`
  - set `LOADTEST_COOKIE` or `LOADTEST_AUTH_HEADER` for authenticated benchmarking

---

## Env / config notes
- `TENON_BACKEND_BASE_URL` (existing)
- Optional:
  - `TENON_USE_FETCH_DISPATCHER=1` (opt-in keep-alive pooling)
  - `TENON_PROXY_MAX_BODY_BYTES` (request cap, default 2MB)
  - `TENON_PROXY_MAX_RESPONSE_BYTES` (response cap, default 2MB)
  - `NEXT_PUBLIC_TENON_DEBUG_PERF=true` (client perf logs)

---

## Files touched (high-level)
- BFF:
  - `src/lib/server/bff.ts`
- API routes:
  - `src/app/api/dashboard/route.ts`
  - `src/app/api/backend/[...path]/route.ts`
- Dashboard UI/perf:
  - `src/app/(recruiter)/dashboard/loading.tsx`
  - `src/features/recruiter/dashboard/DashboardView.tsx`
  - `src/features/recruiter/dashboard/RecruiterDashboardPage.tsx`
  - `src/features/recruiter/dashboard/components/DashboardHeader.tsx`
  - `src/features/recruiter/dashboard/components/SimulationSection.tsx`
  - `src/features/recruiter/dashboard/hooks/useDashboardData.ts`
  - `src/features/recruiter/dashboard/hooks/useInviteCandidateFlow.ts`
  - `src/features/recruiter/dashboard/utils/perf.ts`
- Recruiter API client:
  - `src/lib/api/recruiter.ts`
- Load test + docs:
  - `scripts/loadtest-dashboard.mjs`
  - `README.md`
  - `package.json`, `package-lock.json`
- Tests:
  - `tests/unit/apiDashboardRoute.test.ts`
  - `tests/unit/backendProxyRoute.test.ts`
  - `tests/unit/lib/bff.test.ts` (and/or `tests/unit/lib/server/bff.test.ts`)
  - `tests/unit/lib/recruiterApi.test.ts`
  - `tests/unit/inviteFlow.test.tsx`
  - `tests/unit/InviteCandidateModal.test.tsx`

---

## Screenshots / recordings
- (Optional) attach Performance panel before/after for LCP, and hosted QA invite success flow.
