### PR TITLE
Candidate invite verification UX (email + OTP) + resend cooldown + lockout states

### DIFF
--- a/src/lib/api/candidate.ts
+++ b/src/lib/api/candidate.ts
@@ -267,19 +267,25 @@ export async function claimCandidateInvite(
 
 export async function sendCandidateVerificationCode(
   inviteToken: string,
+  email?: string,
 ): Promise<CandidateVerificationSendResponse> {
   const safeInviteToken = inviteToken.trim();
   if (!safeInviteToken) {
     throw new HttpError(400, 'Missing invite token.');
   }
+  const trimmedEmail = typeof email === 'string' ? email.trim() : '';
   const path = `/candidate/session/${encodeURIComponent(
     safeInviteToken,
   )}/verification/code/send`;
 
   try {
+    const payload =
+      trimmedEmail && trimmedEmail.includes('@')
+        ? { email: trimmedEmail }
+        : undefined;
     const data = await apiClient.post<CandidateVerificationSendResponse>(
       path,
-      undefined,
+      payload,
       { cache: 'no-store' },
       { ...baseClientOptions, skipAuth: true },
     );

--- a/tests/unit/lib/api/candidate.test.ts
+++ b/tests/unit/lib/api/candidate.test.ts
@@ -78,6 +78,25 @@ describe('candidate api helpers', () => {
     });
   });
 
+  it('sends verification code with email when provided', async () => {
+    apiClient.post.mockResolvedValueOnce({
+      status: 'sent',
+      maskedEmail: 't***@example.com',
+      expiresAt: '2025-01-01T00:00:00Z',
+    });
+
+    const { sendCandidateVerificationCode } =
+      await import('@/lib/api/candidate');
+    await sendCandidateVerificationCode('abc', 'user@example.com');
+
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/candidate/session/abc/verification/code/send',
+      { email: 'user@example.com' },
+      { cache: 'no-store' },
+      expect.objectContaining({ skipAuth: true }),
+    );
+  });
+
   it('attaches otp metadata for resend cooldown', async () => {
     apiClient.post.mockRejectedValueOnce({
       status: 429,


### PR DESCRIPTION
## TL;DR
This PR completes **candidate invite verification** so an invite token alone does **not** unlock a candidate session. Candidates must verify the intended email via a **6‑digit OTP**, with a **resend cooldown**, **rate-limit** and **lockout** handling, and a clean success path that **stores the candidate session token** and proceeds to the timeline.

---

## Problem
- Invite links must be **verification-gated**: the invite token alone should not unlock access.
- Candidates need a **frictionless, mobile-friendly** verification UX that matches backend OTP constraints and error states.
- Prior bugs included:
  - Potential **duplicate send** behavior in React StrictMode / re-render scenarios.
  - Misrouted candidate requests when `NEXT_PUBLIC_TENON_API_BASE_URL=/api`, causing 404s and retry loops.

---

## What changed

### Candidate verification UI
- **6-digit OTP input** UX:
  - Auto-advance per digit
  - Backspace navigation
  - Paste support for full codes (and single-digit paste behavior)
- **Resend OTP** CTA with **cooldown countdown** and disabled states.
- **Inline error copy** + support path copy for failure/invalid sessions.
- **Mobile-friendly layout** (usable at ~375px width).

### Email-required flows (backend-driven)
- When backend indicates **email is required** for sending/verifying:
  - Shows inline guidance: “Enter the email that received the invite…”
  - Disables Send/Verify actions until a minimally valid email is provided.
  - Sends email as part of the OTP send request when present and valid.

### StrictMode-safe “send once” behavior
- Hardened the “auto-send OTP on load” behavior so it triggers **exactly once** per token/session and does not re-fire due to StrictMode or re-renders.
- Added a **sessionStorage-backed sentinel** to prevent double-send in StrictMode while preserving manual resend behavior.

### API client integration + proxy correctness
- `sendCandidateVerificationCode(inviteToken, email?)` now sends `{ email }` payload when provided and valid.
- Candidate requests remain routed through the backend proxy path (`/api/backend/...`) to avoid incorrect `/api/candidate/...` routing and 404 loops.
- Optional proxy debug logging remains **off by default** (guarded by env flags).

---

## Files changed
- `src/features/candidate/session/components/CandidateVerificationPanel.tsx`
  - Email-required send + verify handling
  - Cooldown + lockout + rate-limit UI states
  - StrictMode-safe send-once guard
  - “Send code” vs “Resend code” labeling + hint copy improvements
- `src/lib/api/candidate.ts`
  - `sendCandidateVerificationCode(inviteToken, email?)` posts `{ email }` when provided
- `tests/unit/features/candidate/CandidateVerificationPanel.test.tsx`
  - Regression coverage: paste behavior, resend cooldown, no auto-retry
  - Email-required send path
  - StrictMode single-send on mount
  - Verify-side email-required UX
- `tests/unit/lib/api/candidate.test.ts`
  - Verifies send endpoint receives `{ email }` payload when email provided

---

## How this meets #75 requirements

### Goal
**Invite token alone must NOT unlock the session**
- Verification gate remains intact: candidate must verify before proceeding to timeline.

### UX
- **Enter email (if required) + 6-digit OTP** ✅
- **Resend OTP with countdown** ✅
- **Error states: mismatch, expired, too many attempts, rate limit** ✅
- **Success stores candidate session token and proceeds to timeline** ✅

### Acceptance
- **Full verification flow works end-to-end with backend** ✅ (manual QA confirmed)
- **Mobile-friendly** ✅ (manual QA confirmed)

---

## Tests
Automated:
- `CandidateVerificationPanel.test.tsx`
- `candidate.test.ts`
- `./precommit.sh` (lint + unit tests + typecheck + build)

---

## Manual QA checklist (validated)
1) **Happy path**
   - Open valid invite link → verification screen appears (not timeline)
   - Confirm exactly **one** request on load:
     - `POST /api/backend/candidate/session/<token>/verification/code/send`
   - Enter OTP → Verify → redirected to timeline
2) **Resend cooldown**
   - Resend disabled with countdown
   - After countdown → click Resend → exactly one additional send request
3) **Email-required on send**
   - Backend returns `email_required/email_missing` → “Send code” disabled until valid email
   - Send includes `{ email }` payload → send succeeds
4) **Email-required on verify**
   - Verify triggers inline email-required error
   - Provide email → verify succeeds
5) **Mismatch / expired**
   - Wrong code shows inline mismatch error (no auto-retry)
   - Expired code shows resend guidance
6) **Rate limit (429)**
   - Shows countdown / disables resend appropriately
7) **Lockout**
   - Too many attempts → lockout messaging + disabled inputs
8) **Refresh / StrictMode regression**
   - Refresh does not cause duplicate sends or request storms
9) **Mobile**
   - At ~375px width, inputs/buttons usable without horizontal scrolling

---

## Rollout / notes
- No schema changes; frontend-only changes with stable API integration.
- No secrets logged; debug logging (if present) remains opt-in via env flags.
- Guard rails added specifically to prevent request loops / StrictMode double-send.

---

## Screenshots (optional for PR)
- Verification screen (email + OTP fields)
- Cooldown state (“Resend in 0:XX”)
- Email-required state message
- Lockout state message


Fixes #75 