### PR TITLE
Recruiter Portal — Simulation Creation Supports TemplateKey Selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Next.js App Router (React 19 + TypeScript) UI for Tenon’s 5-day work simulatio
 ## Typical Flows
 
 - Candidate: open invite link → verify OTP → bootstrap session → intro → load current task → auto-save drafts → submit with token/session headers → finish when `isComplete` true.
-- Recruiter: Auth0 login → dashboard loads profile + simulations → create simulation → invite candidate (modal + copy invite URL) → view simulation candidates (status/time) → view per-task submissions (text/code/testResults).
+- Recruiter: Auth0 login → dashboard loads profile + simulations → create simulation (select template stack) → invite candidate (modal + copy invite URL) → view simulation candidates (status/time) → view per-task submissions (text/code/testResults).
 
 ## Planned Roadmap (not yet in code)
 

--- a/src/features/recruiter/simulations/SimulationCreatePage.tsx
+++ b/src/features/recruiter/simulations/SimulationCreatePage.tsx
@@ -10,6 +10,7 @@ import {
   createSimulation,
   type CreateSimulationInput,
 } from '@/lib/api/recruiter';
+import { DEFAULT_TEMPLATE_KEY, TEMPLATE_OPTIONS } from '@/lib/templateCatalog';
 import {
   buildLoginUrl,
   buildNotAuthorizedUrl,
@@ -35,6 +36,8 @@ export default function SimulationCreatePage() {
   const [techStack, setTechStack] = useState<string>('Node.js + Postgres');
   const [seniority, setSeniority] =
     useState<CreateSimulationInput['seniority']>('Mid');
+  const [templateKey, setTemplateKey] =
+    useState<CreateSimulationInput['templateKey']>(DEFAULT_TEMPLATE_KEY);
   const [focus, setFocus] = useState<string>('');
 
   const [errors, setErrors] = useState<FieldErrors>({});
@@ -46,9 +49,10 @@ export default function SimulationCreatePage() {
       role: role.trim(),
       techStack: techStack.trim(),
       seniority,
+      templateKey,
       focus: focus.trim() ? focus.trim() : undefined,
     }),
-    [title, role, techStack, seniority, focus],
+    [title, role, techStack, seniority, templateKey, focus],
   );
 
   function validate(input: CreateSimulationInput): FieldErrors {
@@ -57,6 +61,7 @@ export default function SimulationCreatePage() {
     if (!input.role) next.role = 'Role is required.';
     if (!input.techStack) next.techStack = 'Tech stack is required.';
     if (!input.seniority) next.seniority = 'Seniority is required.';
+    if (!input.templateKey) next.templateKey = 'Template is required.';
     return next;
   }
 
@@ -258,6 +263,45 @@ export default function SimulationCreatePage() {
               role="alert"
             >
               {errors.seniority}
+            </p>
+          ) : null}
+        </div>
+
+        <div>
+          <label
+            htmlFor="templateKey"
+            className="text-xs font-medium uppercase tracking-wide text-gray-500"
+          >
+            Template
+          </label>
+          <select
+            id="templateKey"
+            className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+            value={templateKey}
+            onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+              setTemplateKey(
+                e.target.value as CreateSimulationInput['templateKey'],
+              )
+            }
+            disabled={isSubmitting}
+            aria-invalid={Boolean(errors.templateKey)}
+            aria-describedby={
+              errors.templateKey ? 'templateKey-error' : undefined
+            }
+          >
+            {TEMPLATE_OPTIONS.map((opt) => (
+              <option key={opt.key} value={opt.key}>
+                {opt.label} ({opt.key})
+              </option>
+            ))}
+          </select>
+          {errors.templateKey ? (
+            <p
+              id="templateKey-error"
+              className="mt-1 text-sm text-red-700"
+              role="alert"
+            >
+              {errors.templateKey}
             </p>
           ) : null}
         </div>

--- a/src/features/recruiter/simulations/SimulationList.tsx
+++ b/src/features/recruiter/simulations/SimulationList.tsx
@@ -45,6 +45,9 @@ export function SimulationList({ simulations, onInvite }: SimulationListProps) {
                   {sim.candidateCount} candidate(s)
                 </p>
               ) : null}
+              <p className="text-xs text-gray-500">
+                Template: {sim.templateKey?.trim() ? sim.templateKey : 'N/A'}
+              </p>
             </div>
 
             <div className="col-span-3">

--- a/src/lib/api/recruiter.ts
+++ b/src/lib/api/recruiter.ts
@@ -1,6 +1,7 @@
 import { recruiterBffClient, safeRequest } from './httpClient';
 import { extractBackendMessage, fallbackStatus } from './utils/errors';
 import { getId, getNumber, getString, isRecord } from './utils/normalize';
+import type { TemplateKey } from '@/lib/templateCatalog';
 import type { CandidateSession } from '@/types/recruiter';
 
 export type SimulationListItem = {
@@ -9,6 +10,7 @@ export type SimulationListItem = {
   role: string;
   createdAt: string;
   candidateCount?: number;
+  templateKey?: string | null;
 };
 
 export type InviteCandidateResponse = {
@@ -22,6 +24,7 @@ export type CreateSimulationInput = {
   role: string;
   techStack: string;
   seniority: 'Junior' | 'Mid' | 'Senior';
+  templateKey: TemplateKey;
   focus?: string;
 };
 
@@ -78,7 +81,14 @@ function normalizeSimulation(raw: unknown): SimulationListItem {
     getNumber(raw.num_candidates) ??
     undefined;
 
-  return { id, title, role, createdAt, candidateCount };
+  const templateKey =
+    typeof raw.templateKey === 'string'
+      ? raw.templateKey
+      : typeof raw.template_key === 'string'
+        ? raw.template_key
+        : null;
+
+  return { id, title, role, createdAt, candidateCount, templateKey };
 }
 
 export async function listSimulations(
@@ -372,8 +382,9 @@ export async function createSimulation(
   const safeTitle = input.title.trim();
   const safeRole = input.role.trim();
   const safeTechStack = input.techStack.trim();
+  const safeTemplateKey = input.templateKey.trim();
 
-  if (!safeTitle || !safeRole || !safeTechStack) {
+  if (!safeTitle || !safeRole || !safeTechStack || !safeTemplateKey) {
     return {
       id: '',
       ok: false,
@@ -388,6 +399,7 @@ export async function createSimulation(
       role: safeRole,
       techStack: safeTechStack,
       seniority: input.seniority,
+      templateKey: safeTemplateKey,
       focus: input.focus?.trim() ? input.focus.trim() : undefined,
     };
 

--- a/src/lib/templateCatalog.ts
+++ b/src/lib/templateCatalog.ts
@@ -1,0 +1,26 @@
+export const DEFAULT_TEMPLATE_KEY = 'python-fastapi' as const;
+
+export const TEMPLATE_OPTIONS = [
+  { key: 'python-fastapi', label: 'Python (FastAPI)' },
+  { key: 'node-express-ts', label: 'Node.js (Express, TS)' },
+  { key: 'node-nest-ts', label: 'Node.js (NestJS, TS)' },
+  { key: 'java-springboot', label: 'Java (Spring Boot)' },
+  { key: 'go-gin', label: 'Go (Gin)' },
+  { key: 'dotnet-webapi', label: '.NET (Web API)' },
+  { key: 'monorepo-nextjs-nest', label: 'Monorepo (Next.js + NestJS)' },
+  { key: 'monorepo-nextjs-fastapi', label: 'Monorepo (Next.js + FastAPI)' },
+  { key: 'monorepo-react-express', label: 'Monorepo (React + Express)' },
+  {
+    key: 'monorepo-react-springboot',
+    label: 'Monorepo (React + Spring Boot)',
+  },
+  {
+    key: 'mobile-fullstack-expo-fastapi',
+    label: 'Mobile Fullstack (Expo + FastAPI)',
+  },
+  { key: 'mobile-backend-fastapi', label: 'Mobile Backend (FastAPI)' },
+  { key: 'ml-backend-fastapi', label: 'ML Backend (FastAPI)' },
+  { key: 'ml-infra-mlops', label: 'ML Infra / MLOps' },
+] as const;
+
+export type TemplateKey = (typeof TEMPLATE_OPTIONS)[number]['key'];

--- a/tests/integration/recruiter/simulationList.test.tsx
+++ b/tests/integration/recruiter/simulationList.test.tsx
@@ -27,6 +27,7 @@ describe('Recruiter simulations list (integration)', () => {
           role: 'Backend Engineer',
           createdAt: '2025-12-10T10:00:00Z',
           candidateCount: 3,
+          templateKey: 'python-fastapi',
         },
       ],
       simError: null,
@@ -40,6 +41,7 @@ describe('Recruiter simulations list (integration)', () => {
     expect(screen.getByText('Backend Simulation')).toBeInTheDocument();
     expect(screen.getByText('Backend Engineer')).toBeInTheDocument();
     expect(screen.getByText('3 candidate(s)')).toBeInTheDocument();
+    expect(screen.getByText(/Template: python-fastapi/i)).toBeInTheDocument();
   });
 
   it('shows empty state when no simulations exist', async () => {

--- a/tests/integration/recruiter/simulations/new/CreateSimulationContent.test.tsx
+++ b/tests/integration/recruiter/simulations/new/CreateSimulationContent.test.tsx
@@ -62,6 +62,10 @@ describe('SimulationCreatePage', () => {
     await user.type(screen.getByLabelText(/Role/i), ' Backend Engineer ');
     await user.clear(screen.getByLabelText(/Tech stack/i));
     await user.type(screen.getByLabelText(/Tech stack/i), ' Node + Postgres ');
+    await user.selectOptions(
+      screen.getByLabelText(/Template/i),
+      'node-express-ts',
+    );
     await user.type(screen.getByLabelText(/Focus /i), 'Messaging focus');
 
     await user.click(
@@ -74,6 +78,7 @@ describe('SimulationCreatePage', () => {
         role: 'Backend Engineer',
         techStack: 'Node + Postgres',
         seniority: 'Mid',
+        templateKey: 'node-express-ts',
         focus: 'Messaging focus',
       });
     });

--- a/tests/integration/recruiter/simulations/tests/SimulationDetailContent.test.tsx
+++ b/tests/integration/recruiter/simulations/tests/SimulationDetailContent.test.tsx
@@ -26,12 +26,22 @@ jest.mock('next/link', () => ({
   ),
 }));
 
+const simulationListResponse = () =>
+  jsonResponse([
+    { id: '1', title: 'Simulation 1', templateKey: 'python-fastapi' },
+  ]);
+
 describe('RecruiterSimulationDetailPage', () => {
   beforeEach(() => {
     setMockParams({ id: '1' });
 
     const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
       const url = getRequestUrl(input);
+      if (url === '/api/simulations') {
+        return jsonResponse([
+          { id: '1', title: 'Simulation 1', templateKey: 'python-fastapi' },
+        ]);
+      }
       if (url === '/api/simulations/1/candidates') {
         return jsonResponse([
           {
@@ -94,6 +104,11 @@ describe('RecruiterSimulationDetailPage', () => {
   it('renders empty state when there are no candidates', async () => {
     const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
       const url = getRequestUrl(input);
+      if (url === '/api/simulations') {
+        return jsonResponse([
+          { id: '1', title: 'Simulation 1', templateKey: 'python-fastapi' },
+        ]);
+      }
       if (url === '/api/simulations/1/candidates') {
         return jsonResponse([]);
       }
@@ -111,6 +126,11 @@ describe('RecruiterSimulationDetailPage', () => {
   it('renders error state when candidates request fails', async () => {
     const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
       const url = getRequestUrl(input);
+      if (url === '/api/simulations') {
+        return jsonResponse([
+          { id: '1', title: 'Simulation 1', templateKey: 'python-fastapi' },
+        ]);
+      }
       if (url === '/api/simulations/1/candidates') {
         return jsonResponse({ message: 'Boom' }, 500);
       }
@@ -128,6 +148,11 @@ describe('RecruiterSimulationDetailPage', () => {
   it('uses text fallback when candidates request fails with text/plain', async () => {
     const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
       const url = getRequestUrl(input);
+      if (url === '/api/simulations') {
+        return jsonResponse([
+          { id: '1', title: 'Simulation 1', templateKey: 'python-fastapi' },
+        ]);
+      }
       if (url === '/api/simulations/1/candidates') {
         return textResponse('Plain failure', 500);
       }
@@ -145,6 +170,11 @@ describe('RecruiterSimulationDetailPage', () => {
   it('shows not started status, unnamed fallback, and text error fallback', async () => {
     const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
       const url = getRequestUrl(input);
+      if (url === '/api/simulations') {
+        return jsonResponse([
+          { id: '1', title: 'Simulation 1', templateKey: 'python-fastapi' },
+        ]);
+      }
       if (url === '/api/simulations/1/candidates') {
         return jsonResponse([
           {
@@ -196,6 +226,11 @@ describe('RecruiterSimulationDetailPage', () => {
   it('shows detail error message when provided by backend', async () => {
     const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
       const url = getRequestUrl(input);
+      if (url === '/api/simulations') {
+        return jsonResponse([
+          { id: '1', title: 'Simulation 1', templateKey: 'python-fastapi' },
+        ]);
+      }
       if (url === '/api/simulations/1/candidates') {
         return jsonResponse({ detail: 'No access' }, 403);
       }
@@ -212,6 +247,7 @@ describe('RecruiterSimulationDetailPage', () => {
     const user = userEvent.setup();
     const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
       const url = getRequestUrl(input);
+      if (url === '/api/simulations') return simulationListResponse();
       if (url === '/api/simulations/1/candidates') {
         return jsonResponse([
           {
@@ -255,6 +291,7 @@ describe('RecruiterSimulationDetailPage', () => {
     const fetchMock = jest.fn(
       async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = getRequestUrl(input);
+        if (url === '/api/simulations') return simulationListResponse();
         if (url === '/api/simulations/1/candidates') {
           return jsonResponse([
             {
@@ -303,6 +340,7 @@ describe('RecruiterSimulationDetailPage', () => {
     const fetchMock = jest.fn(
       async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = getRequestUrl(input);
+        if (url === '/api/simulations') return simulationListResponse();
         if (url === '/api/simulations/1/candidates') {
           return jsonResponse([
             {
@@ -355,6 +393,7 @@ describe('RecruiterSimulationDetailPage', () => {
     const fetchMock = jest.fn(
       async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = getRequestUrl(input);
+        if (url === '/api/simulations') return simulationListResponse();
         if (url === '/api/simulations/1/candidates') {
           return jsonResponse([
             {
@@ -416,6 +455,7 @@ describe('RecruiterSimulationDetailPage', () => {
     const fetchMock = jest.fn(
       async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = getRequestUrl(input);
+        if (url === '/api/simulations') return simulationListResponse();
         if (url === '/api/simulations/1/candidates') {
           return jsonResponse([
             {
@@ -466,6 +506,7 @@ describe('RecruiterSimulationDetailPage', () => {
   it('does not get stuck loading under StrictMode navigation', async () => {
     const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
       const url = getRequestUrl(input);
+      if (url === '/api/simulations') return simulationListResponse();
       if (url === '/api/simulations/1/candidates') {
         return jsonResponse([
           {
@@ -497,6 +538,7 @@ describe('RecruiterSimulationDetailPage', () => {
   it('shows copy invite button even when invite URL is missing and surfaces error', async () => {
     const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
       const url = getRequestUrl(input);
+      if (url === '/api/simulations') return simulationListResponse();
       if (url === '/api/simulations/1/candidates') {
         return jsonResponse([
           {

--- a/tests/unit/lib/recruiterApi.test.ts
+++ b/tests/unit/lib/recruiterApi.test.ts
@@ -71,6 +71,7 @@ describe('recruiterApi', () => {
           role: 'Backend Engineer',
           createdAt: '2025-12-10T10:00:00Z',
           candidateCount: 3,
+          templateKey: 'python-fastapi',
         },
       ]);
 
@@ -83,6 +84,7 @@ describe('recruiterApi', () => {
           role: 'Backend Engineer',
           createdAt: '2025-12-10T10:00:00Z',
           candidateCount: 3,
+          templateKey: 'python-fastapi',
         },
       ]);
     });
@@ -95,6 +97,7 @@ describe('recruiterApi', () => {
           role: 'Backend Engineer',
           created_at: '2025-12-11T10:00:00Z',
           candidate_count: 1,
+          template_key: 'node-express-ts',
         },
       ]);
 
@@ -105,6 +108,7 @@ describe('recruiterApi', () => {
       expect(result[0]?.role).toBe('Backend Engineer');
       expect(result[0]?.createdAt).toBe('2025-12-11T10:00:00Z');
       expect(result[0]?.candidateCount).toBe(1);
+      expect(result[0]?.templateKey).toBe('node-express-ts');
     });
 
     it('falls back safely when item is not an object', async () => {
@@ -307,6 +311,7 @@ describe('recruiterApi', () => {
         role: ' ',
         techStack: '',
         seniority: 'Mid',
+        templateKey: 'python-fastapi',
       });
 
       expect(result).toEqual({
@@ -326,6 +331,7 @@ describe('recruiterApi', () => {
         role: ' Backend ',
         techStack: ' Node ',
         seniority: 'Senior',
+        templateKey: 'node-express-ts',
         focus: '  Focus ',
       });
 
@@ -336,6 +342,7 @@ describe('recruiterApi', () => {
           role: 'Backend',
           techStack: 'Node',
           seniority: 'Senior',
+          templateKey: 'node-express-ts',
           focus: 'Focus',
         },
         {
@@ -361,6 +368,7 @@ describe('recruiterApi', () => {
         role: 'Backend',
         techStack: 'Node',
         seniority: 'Junior',
+        templateKey: 'python-fastapi',
       });
 
       expect(result).toEqual({
@@ -379,6 +387,7 @@ describe('recruiterApi', () => {
         role: 'Backend',
         techStack: 'Node',
         seniority: 'Junior',
+        templateKey: 'python-fastapi',
         focus: '   ',
       });
 
@@ -400,6 +409,7 @@ describe('recruiterApi', () => {
         role: 'Backend',
         techStack: 'Node',
         seniority: 'Junior',
+        templateKey: 'python-fastapi',
       });
 
       expect(mockedBffPost).toHaveBeenCalledWith(
@@ -421,6 +431,7 @@ describe('recruiterApi', () => {
         role: 'Backend',
         techStack: 'Node',
         seniority: 'Junior',
+        templateKey: 'python-fastapi',
       });
 
       expect(result).toMatchObject({


### PR DESCRIPTION
## Summary
This PR adds **template stack selection** to simulation creation in the recruiter portal. Recruiters can now pick a **templateKey** from a catalog of **14 supported stacks**, the selection is sent to `POST /api/simulations`, and the chosen template is displayed on the **simulation list** and **simulation detail** views.

This unlocks GitHub-native Day2/Day3 task seeding in the backend by ensuring simulations are created with an explicit `templateKey`.

---

## Requirements coverage

### 1) Add dropdown for templateKey (14 keys)
- Added a **Template** dropdown to the simulation creation UI.
- Options are centralized in a shared catalog with **14 keys**:
  - `python-fastapi`
  - `node-express-ts`
  - `node-nest-ts`
  - `java-springboot`
  - `go-gin`
  - `dotnet-webapi`
  - `monorepo-nextjs-nest`
  - `monorepo-nextjs-fastapi`
  - `monorepo-react-express`
  - `monorepo-react-springboot`
  - `mobile-fullstack-expo-fastapi`
  - `mobile-backend-fastapi`
  - `ml-backend-fastapi`
  - `ml-infra-mlops`
- Default selection: `python-fastapi`.

### 2) Send templateKey to `POST /api/simulations`
- Wired the selected `templateKey` into the simulation creation payload.
- Added minimal validation to ensure `templateKey` is present before submitting.

### 3) Display templateKey on simulation list/detail
- Simulation list (`/dashboard`) shows `Template: <templateKey>` per simulation.
- Simulation detail header shows `Template: <templateKey>` alongside the simulation ID/title.

### Acceptance criteria: “Recruiter selection persists and is visible.”
- Verified via manual QA:
  - Network payload includes `templateKey` on create.
  - Newly created simulation renders the same `templateKey` on list + detail views.

---

## Implementation details

### Shared catalog
- Introduced a shared FE catalog module to centralize supported stacks:
  - `DEFAULT_TEMPLATE_KEY`
  - `TEMPLATE_OPTIONS` (key + label)
  - `TemplateKey` type (union of keys)

### Create simulation UI
- Added Template dropdown to the recruiter simulation creation form.
- Persisted selection by sending it to the backend create endpoint.

### API normalization + types
- Extended recruiter API normalization/types to include `templateKey` from list responses:
  - Supports both `templateKey` (camelCase) and `template_key` (snake_case) fields.
- Ensures create simulation input requires a non-empty `templateKey`.

### Simulation list + detail rendering
- List: renders a small line under each simulation for Template.
- Detail: fetches simulation metadata and renders Template in the header:
  - Uses stable fallback text while loading.
  - Redirect behavior for 401/403 remains intact (no token logging).

---

## Files changed (high level)
- `README.md`
  - Updated recruiter flow to mention template selection on create.
- `RecruiterSimulationDetailPage.tsx`
  - Fetch simulation metadata and display `Template: ...` in header.
- `SimulationCreatePage.tsx`
  - Add template dropdown, include templateKey in create payload, validate.
- `SimulationList.tsx`
  - Display `Template: ...` for each simulation.
- `recruiter.ts` (recruiter API client module)
  - Normalize `templateKey` from backend responses; require/send on create.
- `templateCatalog.ts`
  - New shared template catalog.

### Tests updated/added
- `tests/integration/recruiter/simulations/new/CreateSimulationContent.test.tsx`
  - Select a template option and assert the create payload includes `templateKey`.
- `tests/integration/recruiter/simulationList.test.tsx`
  - Assert templateKey renders in the list UI.
- `tests/integration/recruiter/simulations/tests/SimulationDetailContent.test.tsx`
  - Ensure detail view handles simulation metadata fetch and renders templateKey.
- `tests/integration/recruiter/simulation-detail/SimulationDetailPageClient.test.tsx`
  - Updated mocks to include `/api/simulations` metadata and `Template:` header assertion.
- `tests/unit/lib/recruiterApi.test.ts`
  - Validate normalization for `templateKey` and create payload wiring.

---

## Testing

### Automated
- `./precommit.sh` ✅
  - lint ✅
  - tests ✅
  - typecheck ✅
  - build ✅
- Known/unchanged build warnings:
  - Next.js/Auth0-related deprecation warnings (present before this PR as well).

### Manual QA (UI)
1. Log in as recruiter and open `/dashboard`.
2. Click **New Simulation**.
3. Confirm Template dropdown exists and defaults to `python-fastapi`.
4. Select a non-default template key (e.g. `node-express-ts`) and create simulation.
5. In DevTools → Network, confirm `POST /api/simulations` payload includes:
   - `templateKey: "node-express-ts"`
6. Back on `/dashboard`, confirm the created simulation displays:
   - `Template: node-express-ts`
7. Open simulation detail page and confirm header shows:
   - `Template: node-express-ts`
8. Refresh list + detail pages to confirm the template remains visible (persistence).

### Manual QA (network expectation for detail)
- `GET /api/simulations`
- `GET /api/simulations/:id/candidates`

---

## Rollout notes
- Frontend catalog (`templateCatalog.ts`) is intentionally **hardcoded** for M1 speed.
- Keep this in sync with the backend template catalog when adding/removing templates.
- No migration work required in frontend; older simulations without templateKey render safely as `N/A`.

---

## Screenshots / evidence (optional to attach in PR)
- Network payload showing `templateKey` included on `POST /api/simulations`.
- Dashboard list showing `Template: node-express-ts`.
- Simulation detail header showing `Template: node-express-ts`.


Fixes #47 