### PR TITLE
Recruiter simulation detail preview shows 5-day plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Next.js App Router (React 19 + TypeScript) UI for Tenon’s 5-day work simulatio
 - Candidate portal: `/candidate/session/[token]` (wrapped by `CandidateSessionProvider` layout; `/candidate-sessions/[token]` redirects here).
 - Candidate dashboard: `/candidate/dashboard`.
 - Recruiter portal: `/dashboard`, `/dashboard/simulations/new`, `/dashboard/simulations/[id]`, `/dashboard/simulations/[id]/candidates/[candidateSessionId]`.
-- API BFF: `/api/simulations` (+ `/[id]/invite`, `/[id]/candidates`), `/api/submissions`, `/api/submissions/[submissionId]`, `/api/dev/access-token`, `/api/auth/me`, `/api/backend/[...path]` proxy to the upstream backend, `/api/health` passthrough.
+- API BFF: `/api/simulations` (+ `/[id]`, `/[id]/invite`, `/[id]/candidates`), `/api/submissions`, `/api/submissions/[submissionId]`, `/api/dev/access-token`, `/api/auth/me`, `/api/backend/[...path]` proxy to the upstream backend, `/api/health` passthrough.
 
 ## Key Components & Features
 
@@ -35,10 +35,10 @@ Next.js App Router (React 19 + TypeScript) UI for Tenon’s 5-day work simulatio
   - `POST /candidate/session/{token}/verification/code/confirm` with `{email, code}` to exchange for `candidateAccessToken`.
   - `GET /candidate/session/{token}` bootstrap/resolve invite (uses `candidateAccessToken`).
   - `GET /candidate/session/{id}/current_task` with header `x-candidate-session-id`.
-  - `POST /tasks/{taskId}/submit` with header `x-candidate-session-id`; body `{contentText?, codeBlob?}`.
+  - `POST /tasks/{taskId}/submit` with header `x-candidate-session-id`; body `{contentText?}` for text tasks. Day2/Day3 run/submit operate on the GitHub repo + workflow artifacts (no code payloads).
 - Recruiter calls (via BFF with Auth0 bearer token):
   - `GET /api/auth/me` (profile).
-  - `GET/POST /api/simulations`.
+  - `GET/POST /api/simulations`, `GET /api/simulations/{id}`.
   - `POST /api/simulations/{id}/invite`.
   - `GET /api/simulations/{id}/candidates`.
   - `GET /api/submissions?candidateSessionId=…`, `GET /api/submissions/{submissionId}`.

--- a/src/app/api/simulations/[id]/route.ts
+++ b/src/app/api/simulations/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest } from 'next/server';
+import { forwardJson } from '@/lib/server/bff';
+import { withRecruiterAuth } from '@/app/api/utils';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
+
+export async function GET(
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  return withRecruiterAuth(
+    req,
+    { tag: 'simulations-detail', requirePermission: 'recruiter:access' },
+    async (auth) =>
+      forwardJson({
+        path: `/api/simulations/${encodeURIComponent(id)}`,
+        accessToken: auth.accessToken,
+        requestId: auth.requestId,
+      }),
+  );
+}

--- a/tests/integration/recruiter/simulations/tests/SimulationDetailContent.test.tsx
+++ b/tests/integration/recruiter/simulations/tests/SimulationDetailContent.test.tsx
@@ -30,6 +30,40 @@ const simulationListResponse = () =>
   jsonResponse([
     { id: '1', title: 'Simulation 1', templateKey: 'python-fastapi' },
   ]);
+const simulationDetailResponse = () =>
+  jsonResponse({
+    id: '1',
+    title: 'Simulation 1',
+    templateKey: 'python-fastapi',
+    role: 'Backend Engineer',
+    techStack: 'Python + FastAPI',
+    focus: 'API design',
+    scenario: 'Build a billing service for a growing marketplace.',
+    tasks: [
+      {
+        dayIndex: 1,
+        title: 'Kickoff',
+        description: 'Review requirements and outline the approach.',
+        rubric: ['Clarity', 'Scope'],
+      },
+      {
+        dayIndex: 2,
+        title: 'Implementation',
+        description: 'Build the payments endpoint.',
+        rubric: 'Matches spec with clean error handling.',
+        repoUrl: 'https://github.com/acme/day2',
+        preProvisioned: true,
+      },
+      {
+        dayIndex: 3,
+        title: 'Debugging',
+        description: 'Fix failing tests in the repo.',
+        rubric: ['Root cause analysis'],
+        repoFullName: 'acme/day3',
+        preProvisioned: false,
+      },
+    ],
+  });
 
 describe('RecruiterSimulationDetailPage', () => {
   beforeEach(() => {
@@ -41,6 +75,9 @@ describe('RecruiterSimulationDetailPage', () => {
         return jsonResponse([
           { id: '1', title: 'Simulation 1', templateKey: 'python-fastapi' },
         ]);
+      }
+      if (url === '/api/simulations/1') {
+        return simulationDetailResponse();
       }
       if (url === '/api/simulations/1/candidates') {
         return jsonResponse([
@@ -101,6 +138,135 @@ describe('RecruiterSimulationDetailPage', () => {
     expect(hrefs).toContain('/dashboard/simulations/1/candidates/3');
   });
 
+  it('renders the generated simulation plan with tasks and repo status', async () => {
+    render(<RecruiterSimulationDetailPage />);
+
+    expect(
+      await screen.findByText(/5-day simulation plan/i),
+    ).toBeInTheDocument();
+    expect(await screen.findByText('Backend Engineer')).toBeInTheDocument();
+    expect(await screen.findByText('Python + FastAPI')).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Build a billing service/i),
+    ).toBeInTheDocument();
+    expect(await screen.findByText('Kickoff')).toBeInTheDocument();
+    expect(await screen.findByText('Clarity')).toBeInTheDocument();
+    expect(await screen.findByText(/Day 2 workspace/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Repo provisioned/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Repo not provisioned yet/i),
+    ).toBeInTheDocument();
+    expect(await screen.findByText(/Day 4/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Day 5/i)).toBeInTheDocument();
+    const placeholders = await screen.findAllByText(/Not generated yet/i);
+    expect(placeholders.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('normalizes plan data from nested task objects', async () => {
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = getRequestUrl(input);
+      if (url === '/api/simulations') return simulationListResponse();
+      if (url === '/api/simulations/1') {
+        return jsonResponse({
+          id: '1',
+          title: 'Simulation 1',
+          template_key: 'python-fastapi',
+          role_name: 'Backend Engineer',
+          tech_stack: ['Python', 'FastAPI'],
+          focus_area: ['Performance', 'Reliability'],
+          scenario: { summary: 'Scenario summary from object.' },
+          tasks: {
+            day_1: {
+              title: 'Discovery',
+              description: 'Review the requirements.',
+              rubric: { summary: 'Clear and concise notes.' },
+            },
+            day_2: {
+              day: '2',
+              title: 'Build',
+              description: 'Ship the API.',
+              pre_provisioned: 'true',
+              repo_url: 'https://github.com/acme/day2',
+            },
+            day_3: {
+              day_index: '3',
+              title: 'Debug',
+              description: 'Fix regressions.',
+              pre_provisioned: 'false',
+            },
+          },
+        });
+      }
+      if (url === '/api/simulations/1/candidates') {
+        return jsonResponse([]);
+      }
+      return textResponse('Not found', 404);
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<RecruiterSimulationDetailPage />);
+
+    expect(
+      await screen.findByText(/Scenario summary from object/i),
+    ).toBeInTheDocument();
+    expect(await screen.findByText('Python, FastAPI')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Performance, Reliability'),
+    ).toBeInTheDocument();
+    expect(await screen.findByText('Discovery')).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Clear and concise notes/i),
+    ).toBeInTheDocument();
+    expect(await screen.findByText(/Day 2 workspace/i)).toBeInTheDocument();
+    const provisioned = await screen.findAllByText(/Repo provisioned/i);
+    expect(provisioned.length).toBeGreaterThan(0);
+    expect(
+      await screen.findByText(/Repo not provisioned yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it('uses neutral copy when provisioning status is unknown', async () => {
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = getRequestUrl(input);
+      if (url === '/api/simulations') return simulationListResponse();
+      if (url === '/api/simulations/1') {
+        return jsonResponse({
+          id: '1',
+          title: 'Simulation 1',
+          templateKey: 'python-fastapi',
+          role: 'Backend Engineer',
+          techStack: 'Python + FastAPI',
+          tasks: [
+            {
+              dayIndex: 2,
+              title: 'Implementation',
+              description: 'Build the payments endpoint.',
+              repoUrl: 'https://github.com/acme/template',
+            },
+          ],
+        });
+      }
+      if (url === '/api/simulations/1/candidates') {
+        return jsonResponse([]);
+      }
+      return textResponse('Not found', 404);
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<RecruiterSimulationDetailPage />);
+
+    expect(
+      await screen.findByText(
+        /Provisioning happens per-candidate after invite/i,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Repo provisioned/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Repo not provisioned yet/i),
+    ).not.toBeInTheDocument();
+    expect(await screen.findByText(/Repository link/i)).toBeInTheDocument();
+  });
+
   it('renders empty state when there are no candidates', async () => {
     const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
       const url = getRequestUrl(input);
@@ -108,6 +274,9 @@ describe('RecruiterSimulationDetailPage', () => {
         return jsonResponse([
           { id: '1', title: 'Simulation 1', templateKey: 'python-fastapi' },
         ]);
+      }
+      if (url === '/api/simulations/1') {
+        return simulationDetailResponse();
       }
       if (url === '/api/simulations/1/candidates') {
         return jsonResponse([]);
@@ -131,6 +300,9 @@ describe('RecruiterSimulationDetailPage', () => {
           { id: '1', title: 'Simulation 1', templateKey: 'python-fastapi' },
         ]);
       }
+      if (url === '/api/simulations/1') {
+        return simulationDetailResponse();
+      }
       if (url === '/api/simulations/1/candidates') {
         return jsonResponse({ message: 'Boom' }, 500);
       }
@@ -153,6 +325,9 @@ describe('RecruiterSimulationDetailPage', () => {
           { id: '1', title: 'Simulation 1', templateKey: 'python-fastapi' },
         ]);
       }
+      if (url === '/api/simulations/1') {
+        return simulationDetailResponse();
+      }
       if (url === '/api/simulations/1/candidates') {
         return textResponse('Plain failure', 500);
       }
@@ -174,6 +349,9 @@ describe('RecruiterSimulationDetailPage', () => {
         return jsonResponse([
           { id: '1', title: 'Simulation 1', templateKey: 'python-fastapi' },
         ]);
+      }
+      if (url === '/api/simulations/1') {
+        return simulationDetailResponse();
       }
       if (url === '/api/simulations/1/candidates') {
         return jsonResponse([
@@ -209,7 +387,8 @@ describe('RecruiterSimulationDetailPage', () => {
 
     render(<RecruiterSimulationDetailPage />);
 
-    expect(await screen.findByText(/network fail/i)).toBeInTheDocument();
+    const errors = await screen.findAllByText(/network fail/i);
+    expect(errors.length).toBeGreaterThan(0);
   });
 
   it('uses default error when fetch throws non-error value', async () => {
@@ -231,6 +410,9 @@ describe('RecruiterSimulationDetailPage', () => {
           { id: '1', title: 'Simulation 1', templateKey: 'python-fastapi' },
         ]);
       }
+      if (url === '/api/simulations/1') {
+        return simulationDetailResponse();
+      }
       if (url === '/api/simulations/1/candidates') {
         return jsonResponse({ detail: 'No access' }, 403);
       }
@@ -248,6 +430,9 @@ describe('RecruiterSimulationDetailPage', () => {
     const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
       const url = getRequestUrl(input);
       if (url === '/api/simulations') return simulationListResponse();
+      if (url === '/api/simulations/1') {
+        return simulationDetailResponse();
+      }
       if (url === '/api/simulations/1/candidates') {
         return jsonResponse([
           {
@@ -292,6 +477,9 @@ describe('RecruiterSimulationDetailPage', () => {
       async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = getRequestUrl(input);
         if (url === '/api/simulations') return simulationListResponse();
+        if (url === '/api/simulations/1') {
+          return simulationDetailResponse();
+        }
         if (url === '/api/simulations/1/candidates') {
           return jsonResponse([
             {
@@ -341,6 +529,9 @@ describe('RecruiterSimulationDetailPage', () => {
       async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = getRequestUrl(input);
         if (url === '/api/simulations') return simulationListResponse();
+        if (url === '/api/simulations/1') {
+          return simulationDetailResponse();
+        }
         if (url === '/api/simulations/1/candidates') {
           return jsonResponse([
             {
@@ -394,6 +585,9 @@ describe('RecruiterSimulationDetailPage', () => {
       async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = getRequestUrl(input);
         if (url === '/api/simulations') return simulationListResponse();
+        if (url === '/api/simulations/1') {
+          return simulationDetailResponse();
+        }
         if (url === '/api/simulations/1/candidates') {
           return jsonResponse([
             {
@@ -456,6 +650,9 @@ describe('RecruiterSimulationDetailPage', () => {
       async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = getRequestUrl(input);
         if (url === '/api/simulations') return simulationListResponse();
+        if (url === '/api/simulations/1') {
+          return simulationDetailResponse();
+        }
         if (url === '/api/simulations/1/candidates') {
           return jsonResponse([
             {
@@ -507,6 +704,9 @@ describe('RecruiterSimulationDetailPage', () => {
     const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
       const url = getRequestUrl(input);
       if (url === '/api/simulations') return simulationListResponse();
+      if (url === '/api/simulations/1') {
+        return simulationDetailResponse();
+      }
       if (url === '/api/simulations/1/candidates') {
         return jsonResponse([
           {
@@ -539,6 +739,9 @@ describe('RecruiterSimulationDetailPage', () => {
     const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
       const url = getRequestUrl(input);
       if (url === '/api/simulations') return simulationListResponse();
+      if (url === '/api/simulations/1') {
+        return simulationDetailResponse();
+      }
       if (url === '/api/simulations/1/candidates') {
         return jsonResponse([
           {


### PR DESCRIPTION
## Context
**Issue:** recruiter-portal: simulation detail view shows generated 5-day scenario + tasks before inviting (#53)  
**Goal:** Give recruiters visibility into the generated simulation before sending invites.

This PR adds a **read-only “5-day simulation plan”** section to the recruiter **simulation detail** page so recruiters can preview Day 1–Day 5 tasks (and associated metadata) before inviting candidates.

> Non-negotiables preserved:
> - GitHub-native execution remains the only Day2/Day3 code execution path (no sandbox / no code payload execution).
> - Frontend calls backend via existing BFF/proxy routes (no hardcoded backend base URLs).
> - Auth/token handling remains safe (no token logging).

---

## What changed

### 1) Simulation detail now fetches plan data via BFF
- Added / integrated a simulation detail fetch (`GET /api/simulations/:id`) from the simulation detail page.
- The UI handles:
  - Loading state
  - Error state
  - 401/403 redirects consistent with recruiter auth flows

### 2) New “5-day simulation plan” section (read-only v1)
On the simulation detail page, recruiters now see:
- **TemplateKey**
- **Role**
- **Tech Stack**
- **Focus**
- **Scenario**
- **Day 1 → Day 5** plan cards, each showing:
  - Day label (Day 1..5)
  - Task title
  - Task type badge (e.g., design / code / debug / handoff / documentation)
  - Prompt (read-only text)
  - Rubric rendering when present (array → bullet list, string/object → text)

**Important note on rubrics (M1 reality):**
- Backend currently returns `rubric: null` because the Task schema does not store rubric data yet.
- UI is resilient: it only renders rubric content when present and does not fabricate rubric text.

### 3) Day 2 / Day 3 workspace status messaging is truthful
- Day 2 and Day 3 cards include a “workspace” subsection.
- If provisioning status is unknown, UI shows neutral copy:
  - “Provisioning happens per-candidate after invite.”
- If backend later supplies an explicit boolean, the UI supports “Repo provisioned” / “Repo not provisioned yet” semantics.
- Repo/Codespace links (if present) open in a new tab with safe rel attributes.

### 4) Data normalization hardening
- Normalizes common backend field shapes while keeping minimal assumptions:
  - Handles string[] values for tech stack/focus by joining with ", "
  - Handles nested task shapes safely
- Always renders Day 1–Day 5 slots; missing days show placeholders:
  - “Not generated yet” / “No task available yet.”

---

## API/BFF
- Uses existing proxy/BFF architecture.
- Simulation detail page calls:
  - `GET /api/simulations/:id` (BFF route, recruiter-authenticated)
  - Existing calls like `GET /api/simulations/:id/candidates` remain unchanged.

---

## Tests
Added/updated tests to cover:
- Plan section renders and is read-only
- Day 1–Day 5 slots always render (placeholders for missing days)
- Array normalization for tech stack/focus values
- Provisioning unknown → neutral copy; no misleading “Repo provisioned”
- Existing invite/candidate UI remains intact (regression protection around fetch mocking)

All checks passed via:
- `./precommit.sh` (lint, formatting, unit tests, typecheck, build)

---

## Manual QA (UI)
1. Recruiter login → `/dashboard`
2. Create a simulation (choose any templateKey).
3. Open simulation detail: `/dashboard/simulations/<id>`
4. Verify **“5-day simulation plan”** section shows:
   - TemplateKey, Role, Tech Stack, Focus
   - Scenario (if provided by backend)
5. Verify Day 1–Day 5 cards render:
   - Prompts show when available
   - Missing days show placeholder card
6. Verify Day 2/3 workspace messaging:
   - Without explicit provisioning boolean → neutral copy shown
7. Regression: Click **Invite candidate**
   - Create invite (new email)
   - Re-invite existing email triggers resend flow
   - Candidate table/actions unchanged

**Evidence:** Manual QA confirmed in local UI (plan card rendering + network 200 for `/api/simulations/:id`).

---

## Screenshots / demo notes
- Capture the “5-day simulation plan” card showing inputs + scenario + multiple day cards.
- Capture Day 2/3 workspace section showing the neutral provisioning copy.

---

## Follow-ups (optional)
- Store and return real rubric data for tasks (requires backend schema/model additions).
- If/when pre-provisioning becomes real, add explicit boolean in backend response to allow stronger UI status labels.


Fixes #53 