### PR TITLE
Candidate invite claim now shows specific invalid, expired, already-claimed, and access-denied states

### DIFF
--- a/pr.md
+++ b/pr.md
@@ -1,61 +1,58 @@
-# Phase 3 frontend ship set
+# 1. Title
 
-## Summary
+Candidate invite claim now shows specific invalid, expired, already-claimed, and access-denied states
 
-This frontend PR supports the Phase 3 verification flow for the Talent Partner golden path.
+## 2. Problem
 
-It is verification support, not product UX work.
+Candidate invite flows were collapsing too many backend outcomes into a generic unavailable-state experience. That made it hard to tell the difference between a malformed token, an expired invite, an already-claimed session, and a real access problem.
 
-The change set covers:
+The old candidate sign-in copy also implied a verification workflow that the product does not own. Auth0 owns email verification, so the frontend should only guide candidates through sign-in, invite-email matching, session ownership, and invite lifecycle errors.
 
-- the contract-live browser harness,
-- the contract-live stack runner,
-- a debug auth evidence route,
-- the invite proxy route,
-- and the corresponding live/unit tests.
+## 3. What Changed
 
-## Why
+- Invite token resolution now maps backend responses to distinct candidate states:
+  - `400` and `404` become an invalid invite response.
+  - `409` becomes an already-claimed invite response, and a recoverable bootstrap payload is treated as a live session.
+  - `410` becomes an expired invite response.
+  - `403` now resolves to access-denied or sign-in guidance instead of verification-flavored copy.
+- Candidate invite error rendering now shows distinct titles and messages for invalid, expired, and already-claimed cases.
+- The candidate error view now sends already-claimed unauthenticated users to sign in, while keeping the home/retry actions for the other invite states.
+- Candidate login copy now says to sign in with the email tied to the invite.
+- Shared invite copy now has separate messages for invalid, expired, already-claimed, and generic unavailable states.
+- Unit coverage was expanded for:
+  - invite token resolution and 409 recovery
+  - candidate bootstrap error mapping
+  - candidate session error routing
+  - invite error message helpers
+  - candidate login copy
+  - the legacy `/candidate-sessions/[token]` redirect path
 
-Phase 3 needed a repeatable live-stack proof path that could:
+## 4. Why This Is Correct
 
-- validate storage state before browser execution,
-- capture candidate scheduling proof including GitHub username handling,
-- verify termination and post-termination behavior,
-- and expose enough auth evidence to support the verification report.
+The candidate runtime now matches the intended contract:
 
-## Implementation Notes
+- sign-in state
+- invite email match
+- session ownership
+- already-claimed handling
+- invalid and expired invite handling
 
-### Live QA harness
+There is no shipped frontend email-verification workflow here because Auth0 owns that concern. The frontend should only surface the invite/session state that the backend returns.
 
-- `live_flow_driver.mjs` now fails fast when the expected storage-state file is missing.
-- Navigation and load handling were tightened to rely on `domcontentloaded` instead of overusing network-idle assumptions.
-- Candidate scheduling proof capture now records the GitHub username field and persisted schedule state.
-- The harness explicitly checks that an empty GitHub username blocks continue, then fills a valid value and verifies the confirmed state includes it.
-- Termination flow coverage was added so the live QA run can capture cleanup and post-termination evidence.
+Treating a recoverable `409` payload as the active session is correct because it represents an already-claimed invite that can continue instead of a dead-end error.
 
-### Stack runner
+## 5. Validation / QA
 
-- `run_contract_live_stack.sh` now wires explicit scenario-generation environment values into the live verification stack.
-- The runner can reuse `gh auth token` when available so the harness can execute with the operator's existing GitHub auth context.
+- Updated unit tests cover the new invite-status mapping and error-copy paths.
+- Route coverage now includes the legacy redirect-only `/candidate-sessions/[token]` behavior.
+- The candidate login page behavior test now verifies the invite-email sign-in subtitle.
 
-### API routes
+## 6. Risks / Follow-Ups
 
-- The debug auth evidence route now returns `email` and `emailVerified` in addition to the existing user metadata.
-- The trial invite route now forwards the request with a 90 second timeout, which matches the live invite/bootstrap path budget.
+- Issue `#179` still mentions unverified-email verification instructions. That wording is stale relative to the actual product contract and should not be treated as shipped candidate behavior.
+- The already-claimed recovery path depends on the backend returning a recoverable bootstrap payload for `409`; otherwise the user sees already-claimed guidance.
+- If backend invite error shapes drift, the status-to-copy mapping will need to be kept in sync.
 
-### Tests
+## 7. Final Result
 
-- Contract-live E2E coverage was updated to use the more reliable load handling.
-- Unit tests were updated for the debug auth route and invite route behavior.
-
-## Test / Verification
-
-- Updated contract-live and unit tests cover the verification-specific route and harness changes.
-- The live QA harness itself was exercised against the real local stack as part of the Phase 3 verification work.
-
-## Risks / Limitations
-
-- The harness is verification support, not end-user product UX.
-- Cleanup/job anomaly remains documented in evidence, not hidden.
-- This PR does not change candidate auth policy.
-- The route timeout change improves the live invite path, but it does not guarantee upstream GitHub latency will never exceed the budget.
+The frontend candidate invite flow now gives candidates clear, specific recovery paths for invalid, expired, already-claimed, and access-denied invite states, without introducing a frontend-owned email-verification flow.

--- a/src/features/auth/LoginPage.tsx
+++ b/src/features/auth/LoginPage.tsx
@@ -24,7 +24,7 @@ export default function LoginPage({
     ? 'Sign in to continue your trial'
     : 'Talent Partner login';
   const subtitle = isCandidate
-    ? 'Sign in to verify your invite and continue.'
+    ? 'Sign in with the email tied to your invite to continue.'
     : `Sign in to access your ${BRAND_NAME} dashboard.`;
   const missingCandidateConnection =
     process.env.NODE_ENV !== 'production' &&

--- a/src/features/candidate/session/CandidateSessionAccessRoute.tsx
+++ b/src/features/candidate/session/CandidateSessionAccessRoute.tsx
@@ -1,5 +1,6 @@
 import { StateMessage } from './components/StateMessage';
 import Button from '@/shared/ui/Button';
+import { INVITE_EXPIRED_MESSAGE } from '@/platform/copy/invite';
 import type {
   CandidateSessionViewProps as Props,
   ViewState,
@@ -22,7 +23,7 @@ export function CandidateSessionAccessRoute({
         title="Access denied"
         description={
           errorMessage ??
-          'You do not have access to this invite. Please confirm you are signed in with the matching email.'
+          'You do not have access to this invite. Please sign in with the email tied to the invite.'
         }
         action={
           <a href={props.loginHref}>
@@ -37,10 +38,7 @@ export function CandidateSessionAccessRoute({
     return (
       <StateMessage
         title="Invite expired"
-        description={
-          errorMessage ??
-          'This invite has expired. Please contact your Talent Partner for a new link.'
-        }
+        description={errorMessage ?? INVITE_EXPIRED_MESSAGE}
       />
     );
   }

--- a/src/features/candidate/session/CandidateSessionErrorRoute.tsx
+++ b/src/features/candidate/session/CandidateSessionErrorRoute.tsx
@@ -16,10 +16,18 @@ export function CandidateSessionErrorRoute({
   errorStatus,
   inviteErrorCopy,
 }: CandidateSessionErrorRouteProps) {
-  const inviteLinkError = [400, 404, 409, 410].includes(errorStatus ?? 0);
-  const errorTitle = inviteLinkError
-    ? 'Invite link unavailable'
-    : 'Unable to load trial';
+  const inviteErrorStatus = errorStatus ?? 0;
+  const inviteLinkError = [400, 404, 409, 410].includes(inviteErrorStatus);
+  const errorTitle =
+    inviteErrorStatus === 400 || inviteErrorStatus === 404
+      ? 'Invalid invite'
+      : inviteErrorStatus === 409
+        ? 'Invite already claimed'
+        : inviteErrorStatus === 410
+          ? 'Invite expired'
+          : inviteLinkError
+            ? 'Invite link unavailable'
+            : 'Unable to load trial';
   const errorCopy = inviteLinkError
     ? inviteErrorCopy
     : (errorMessage ?? 'Something went wrong loading your trial.');
@@ -27,6 +35,7 @@ export function CandidateSessionErrorRoute({
   return (
     <ErrorView
       authStatus={authStatus}
+      errorStatus={errorStatus}
       errorTitle={errorTitle}
       errorCopy={errorCopy}
       inviteLinkError={inviteLinkError}

--- a/src/features/candidate/session/api/invitesApi.ts
+++ b/src/features/candidate/session/api/invitesApi.ts
@@ -1,6 +1,7 @@
 import {
+  INVITE_ALREADY_CLAIMED_MESSAGE,
   INVITE_EXPIRED_MESSAGE,
-  INVITE_UNAVAILABLE_MESSAGE,
+  INVITE_INVALID_MESSAGE,
 } from '@/platform/copy/invite';
 import { apiClient } from '@/platform/api-client/client';
 import {
@@ -14,6 +15,44 @@ import type {
   CandidateInvite,
   CandidateSessionBootstrapResponse,
 } from './typesApi';
+
+function isBootstrapLike(
+  value: unknown,
+): value is CandidateSessionBootstrapResponse {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    'candidateSessionId' in value &&
+    'trial' in value
+  );
+}
+
+function recoverInviteBootstrap(
+  details: unknown,
+): CandidateSessionBootstrapResponse | null {
+  if (isBootstrapLike(details)) return details;
+  if (!details || typeof details !== 'object') return null;
+
+  const record = details as Record<string, unknown>;
+  const candidates = [record.bootstrap, record.session, record.recovery];
+  for (const candidate of candidates) {
+    if (isBootstrapLike(candidate)) return candidate;
+  }
+
+  return null;
+}
+
+function inviteHttpError(
+  status: number,
+  message: string,
+  details?: unknown,
+): HttpError {
+  const error = new HttpError(status, message);
+  if (typeof details !== 'undefined') {
+    (error as HttpError & { details?: unknown }).details = details;
+  }
+  return error;
+}
 
 export async function listCandidateInvites(options?: {
   signal?: AbortSignal;
@@ -61,26 +100,26 @@ export async function resolveCandidateInviteToken(
       const backendMsg = extractBackendMessage(details, true) ?? '';
       const lowerMsg = backendMsg.toLowerCase();
 
-      if (status === 400 || status === 404 || status === 409)
-        throw new HttpError(status, INVITE_UNAVAILABLE_MESSAGE);
+      if (status === 409) {
+        const recovered = recoverInviteBootstrap(details);
+        if (recovered) return recovered;
+      }
+      if (status === 400 || status === 404)
+        throw inviteHttpError(status, INVITE_INVALID_MESSAGE, details);
+      if (status === 409)
+        throw inviteHttpError(409, INVITE_ALREADY_CLAIMED_MESSAGE, details);
       if (status === 401) throw new HttpError(401, 'Please sign in again.');
       if (status === 403) {
-        if (
-          lowerMsg.includes('verify') ||
-          lowerMsg.includes('email verification') ||
-          lowerMsg.includes('email_verified')
-        ) {
-          throw new HttpError(403, 'Please verify your email, then try again.');
-        }
         if (lowerMsg.includes('email claim') || lowerMsg.includes('email')) {
           throw new HttpError(
             403,
-            'We could not confirm your email. Please sign in again.',
+            'We could not confirm your sign-in. Please sign in again.',
           );
         }
         throw new HttpError(403, 'You do not have access to this invite.');
       }
-      if (status === 410) throw new HttpError(410, INVITE_EXPIRED_MESSAGE);
+      if (status === 410)
+        throw inviteHttpError(410, INVITE_EXPIRED_MESSAGE, details);
 
       const fallbackMsg =
         extractBackendMessage(details, false) ?? backendMsg ?? '';

--- a/src/features/candidate/session/hooks/useInviteInitRunner.error.ts
+++ b/src/features/candidate/session/hooks/useInviteInitRunner.error.ts
@@ -9,6 +9,15 @@ export function handleInviteInitError(params: InviteInitParams, err: unknown) {
     return;
   }
 
+  if (status === 409) {
+    params.setErrorStatus(409);
+    params.setErrorMessage(null);
+    params.setAuthMessage(friendlyBootstrapError(err));
+    params.setView('auth');
+    params.markEnd('candidate:init', { status: 'already_claimed' });
+    return;
+  }
+
   if (status === 403) {
     params.setErrorStatus(403);
     params.setErrorMessage(friendlyBootstrapError(err));

--- a/src/features/candidate/session/hooks/useInviteInitRunner.ts
+++ b/src/features/candidate/session/hooks/useInviteInitRunner.ts
@@ -1,7 +1,9 @@
 import { resolveCandidateInviteToken } from '@/features/candidate/session/api';
 import type { CandidateSessionBootstrapResponse } from '@/features/candidate/session/api/typesApi';
 import {
+  INVITE_ALREADY_CLAIMED_MESSAGE,
   INVITE_EXPIRED_MESSAGE,
+  INVITE_INVALID_MESSAGE,
   INVITE_UNAVAILABLE_MESSAGE,
 } from '@/platform/copy/invite';
 import {
@@ -14,7 +16,14 @@ import type { InviteInitParams } from './useInviteInitRunner.types';
 export type { InviteInitParams } from './useInviteInitRunner.types';
 
 export const inviteErrorCopy = (status: number | null, msg: string | null) =>
-  msg ?? (status === 410 ? INVITE_EXPIRED_MESSAGE : INVITE_UNAVAILABLE_MESSAGE);
+  msg ??
+  (status === 410
+    ? INVITE_EXPIRED_MESSAGE
+    : status === 409
+      ? INVITE_ALREADY_CLAIMED_MESSAGE
+      : status === 400 || status === 404
+        ? INVITE_INVALID_MESSAGE
+        : INVITE_UNAVAILABLE_MESSAGE);
 
 const hasSchedulePayload = (resp: CandidateSessionBootstrapResponse): boolean =>
   'scheduledStartAt' in resp ||

--- a/src/features/candidate/session/utils/errorMessagesUtils.ts
+++ b/src/features/candidate/session/utils/errorMessagesUtils.ts
@@ -1,7 +1,8 @@
 import { HttpError } from '@/platform/api-client/errors/errors';
 import {
+  INVITE_ALREADY_CLAIMED_MESSAGE,
   INVITE_EXPIRED_MESSAGE,
-  INVITE_UNAVAILABLE_MESSAGE,
+  INVITE_INVALID_MESSAGE,
 } from '@/platform/copy/invite';
 import { toUserMessage } from '@/platform/errors/errors';
 
@@ -20,53 +21,59 @@ function messageFromUnknown(err: unknown): string | undefined {
 
 export function friendlyBootstrapError(err: unknown): string {
   const status = statusFromUnknown(err);
+  const message = messageFromUnknown(err);
+  const lowerMsg = message?.toLowerCase() ?? '';
 
-  if (status === 400 || status === 404 || status === 409)
-    return INVITE_UNAVAILABLE_MESSAGE;
+  if (status === 400 || status === 404) return INVITE_INVALID_MESSAGE;
+  if (status === 409) return INVITE_ALREADY_CLAIMED_MESSAGE;
   if (status === 401) return 'Please sign in again.';
   if (status === 403) {
-    return 'We could not confirm your email. Please sign in again.';
+    return lowerMsg.includes('email')
+      ? 'We could not confirm your sign-in. Please sign in again.'
+      : 'You do not have access to this invite.';
   }
   if (status === 410) return INVITE_EXPIRED_MESSAGE;
   if (!status || status === 0)
     return 'Network error. Please check your connection and try again.';
 
-  const msg = messageFromUnknown(err);
-  if (msg && msg.trim().length > 0) return msg;
+  if (message && message.trim().length > 0) return message;
 
   return 'Something went wrong loading your trial.';
 }
 
 export function friendlyTaskError(err: unknown): string {
   const status = statusFromUnknown(err);
+  const message = messageFromUnknown(err);
 
-  if (status === 400 || status === 404 || status === 409)
-    return INVITE_UNAVAILABLE_MESSAGE;
+  if (status === 400 || status === 404) return INVITE_INVALID_MESSAGE;
+  if (status === 409) return INVITE_ALREADY_CLAIMED_MESSAGE;
   if (status === 410) return INVITE_EXPIRED_MESSAGE;
   if (!status || status === 0)
     return 'Network error. Please check your connection and try again.';
 
-  const msg = messageFromUnknown(err);
-  if (msg && msg.trim().length > 0) return msg;
+  if (message && message.trim().length > 0) return message;
 
   return 'Something went wrong loading your current task.';
 }
 
 export function friendlyClaimError(err: unknown): string {
   const status = statusFromUnknown(err);
+  const message = messageFromUnknown(err);
+  const lowerMsg = message?.toLowerCase() ?? '';
 
-  if (status === 400 || status === 404 || status === 409)
-    return INVITE_UNAVAILABLE_MESSAGE;
+  if (status === 400 || status === 404) return INVITE_INVALID_MESSAGE;
+  if (status === 409) return INVITE_ALREADY_CLAIMED_MESSAGE;
   if (status === 410) return INVITE_EXPIRED_MESSAGE;
   if (status === 401) return 'Please sign in again.';
   if (status === 403) {
-    return 'We could not confirm your email. Please sign in again.';
+    return lowerMsg.includes('email')
+      ? 'We could not confirm your sign-in. Please sign in again.'
+      : 'You do not have access to this invite.';
   }
   if (!status || status === 0)
     return 'Network error. Please check your connection and try again.';
 
-  const msg = messageFromUnknown(err);
-  if (msg && msg.trim().length > 0) return msg;
+  if (message && message.trim().length > 0) return message;
 
   return 'Unable to claim your invite right now. Please try again.';
 }

--- a/src/features/candidate/session/views/ErrorView.tsx
+++ b/src/features/candidate/session/views/ErrorView.tsx
@@ -3,6 +3,7 @@ import { StateMessage } from '../components/StateMessage';
 
 type Props = {
   authStatus: 'idle' | 'loading' | 'ready' | 'unauthenticated' | 'error';
+  errorStatus: number | null;
   errorTitle: string;
   errorCopy: string;
   inviteLinkError: boolean;
@@ -13,6 +14,7 @@ type Props = {
 
 export function ErrorView({
   authStatus,
+  errorStatus,
   errorTitle,
   errorCopy,
   inviteLinkError,
@@ -20,9 +22,11 @@ export function ErrorView({
   onRetry,
   onGoHome,
 }: Props) {
+  const shouldGoToSignIn =
+    inviteLinkError && errorStatus === 409 && authStatus === 'unauthenticated';
   const action = inviteLinkError ? (
     <div className="flex gap-3">
-      {authStatus === 'unauthenticated' ? (
+      {shouldGoToSignIn ? (
         <a href={loginHref}>
           <Button>Go to sign in</Button>
         </a>

--- a/src/platform/copy/invite.ts
+++ b/src/platform/copy/invite.ts
@@ -1,5 +1,11 @@
 export const INVITE_UNAVAILABLE_MESSAGE =
   'This invite link is no longer valid. Please contact your Talent Partner to request a new invitation.';
 
+export const INVITE_INVALID_MESSAGE =
+  'This invite link is invalid. Please open the latest invite email or contact your Talent Partner for help.';
+
 export const INVITE_EXPIRED_MESSAGE =
-  'This invite link has expired or was already used. Please contact your Talent Partner to request a new invitation.';
+  'This invite link has expired. Please contact your Talent Partner to request a new invitation.';
+
+export const INVITE_ALREADY_CLAIMED_MESSAGE =
+  'This invite has already been claimed. Sign in with the same email to continue your existing trial session.';

--- a/tests/unit/app/(candidate)/(legacy)/candidate-sessions/[token]/page.test.ts
+++ b/tests/unit/app/(candidate)/(legacy)/candidate-sessions/[token]/page.test.ts
@@ -1,0 +1,21 @@
+import LegacyCandidateSessionRoute from '@/app/(candidate)/(legacy)/candidate-sessions/[token]/page';
+
+const redirectMock = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  redirect: (...args: unknown[]) => redirectMock(...args),
+}));
+
+describe('legacy candidate-sessions route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('redirects to the canonical candidate session route', async () => {
+    await LegacyCandidateSessionRoute({
+      params: Promise.resolve({ token: 'tok_123' }),
+    });
+
+    expect(redirectMock).toHaveBeenCalledWith('/candidate/session/tok_123');
+  });
+});

--- a/tests/unit/app/public/LoginPage.test.tsx
+++ b/tests/unit/app/public/LoginPage.test.tsx
@@ -35,6 +35,11 @@ describe('LoginPage', () => {
     expect(
       screen.getByText(/Sign in to continue your trial/i),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Sign in with the email tied to your invite to continue\./i,
+      ),
+    ).toBeInTheDocument();
     const authLink = screen.getByRole('link', { name: 'Continue with Auth0' });
     expect(authLink).toHaveAttribute(
       'href',

--- a/tests/unit/features/auth/LoginPage.behavior.test.tsx
+++ b/tests/unit/features/auth/LoginPage.behavior.test.tsx
@@ -34,6 +34,11 @@ describe('LoginPage', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
+        /Sign in with the email tied to your invite to continue\./i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
         /Dev warning: set NEXT_PUBLIC_WINOE_AUTH0_CANDIDATE_CONNECTION/i,
       ),
     ).toBeInTheDocument();

--- a/tests/unit/features/candidate/errorMessages.test.ts
+++ b/tests/unit/features/candidate/errorMessages.test.ts
@@ -5,21 +5,31 @@ import {
   friendlyTaskError,
 } from '@/features/candidate/session/utils/errorMessagesUtils';
 import { HttpError } from '@/features/candidate/session/api';
+import {
+  INVITE_ALREADY_CLAIMED_MESSAGE,
+  INVITE_EXPIRED_MESSAGE,
+  INVITE_INVALID_MESSAGE,
+} from '@/platform/copy/invite';
 
 describe('candidate error messages', () => {
   it('maps bootstrap statuses to friendly messages', () => {
     [
-      [400, 'no longer valid'],
-      [404, 'no longer valid'],
-      [409, 'no longer valid'],
+      [400, INVITE_INVALID_MESSAGE],
+      [404, INVITE_INVALID_MESSAGE],
+      [409, INVITE_ALREADY_CLAIMED_MESSAGE],
       [401, 'sign in'],
-      [403, 'sign in'],
-      [410, 'expired or was already used'],
+      [410, INVITE_EXPIRED_MESSAGE],
     ].forEach(([status, expected]) => {
       expect(
         friendlyBootstrapError(new HttpError(status as number, 'x')),
       ).toContain(expected as string);
     });
+    expect(friendlyBootstrapError(new HttpError(403, 'email claim'))).toBe(
+      'We could not confirm your sign-in. Please sign in again.',
+    );
+    expect(friendlyBootstrapError(new HttpError(403, 'forbidden'))).toBe(
+      'You do not have access to this invite.',
+    );
     expect(friendlyBootstrapError(new Error('Backend fail'))).toContain(
       'Network error',
     );
@@ -37,17 +47,24 @@ describe('candidate error messages', () => {
   it('maps claim errors and defaults', () => {
     expect(friendlyClaimError(new HttpError(401, ''))).toContain('sign in');
     expect(friendlyClaimError(new HttpError(410, 'x'))).toContain('expired');
-    expect(friendlyClaimError(new HttpError(403, 'use this'))).toContain(
-      'sign in',
+    expect(friendlyClaimError(new HttpError(403, 'email claim'))).toBe(
+      'We could not confirm your sign-in. Please sign in again.',
+    );
+    expect(friendlyClaimError(new HttpError(403, 'use this'))).toBe(
+      'You do not have access to this invite.',
     );
     expect(friendlyClaimError(new HttpError(500, ''))).toContain(
       'Unable to claim',
     );
-    [400, 404, 409].forEach((status) => {
-      expect(friendlyClaimError(new HttpError(status, ''))).toContain(
-        'no longer valid',
-      );
-    });
+    expect(friendlyClaimError(new HttpError(400, ''))).toBe(
+      INVITE_INVALID_MESSAGE,
+    );
+    expect(friendlyClaimError(new HttpError(404, ''))).toBe(
+      INVITE_INVALID_MESSAGE,
+    );
+    expect(friendlyClaimError(new HttpError(409, ''))).toBe(
+      INVITE_ALREADY_CLAIMED_MESSAGE,
+    );
     expect(friendlyClaimError(new HttpError(0, ''))).toContain('Network error');
     expect(friendlyClaimError(new HttpError(502, 'Custom claim error'))).toBe(
       'Custom claim error',
@@ -58,16 +75,18 @@ describe('candidate error messages', () => {
   });
 
   it('maps task errors for session mismatch, network, and defaults', () => {
-    expect(friendlyTaskError(new HttpError(400, 'x'))).toContain(
-      'no longer valid',
+    expect(friendlyTaskError(new HttpError(400, 'x'))).toBe(
+      INVITE_INVALID_MESSAGE,
     );
-    expect(friendlyTaskError(new HttpError(404, 'x'))).toContain(
-      'no longer valid',
+    expect(friendlyTaskError(new HttpError(404, 'x'))).toBe(
+      INVITE_INVALID_MESSAGE,
     );
-    expect(friendlyTaskError(new HttpError(409, ''))).toContain(
-      'no longer valid',
+    expect(friendlyTaskError(new HttpError(409, ''))).toBe(
+      INVITE_ALREADY_CLAIMED_MESSAGE,
     );
-    expect(friendlyTaskError(new HttpError(410, 'x'))).toContain('expired');
+    expect(friendlyTaskError(new HttpError(410, 'x'))).toBe(
+      INVITE_EXPIRED_MESSAGE,
+    );
     expect(friendlyTaskError(new HttpError(0, 'offline'))).toContain(
       'Network error',
     );

--- a/tests/unit/features/candidate/hooks/useCandidateBootstrap.test.tsx
+++ b/tests/unit/features/candidate/hooks/useCandidateBootstrap.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import { useCandidateBootstrap } from '@/features/candidate/session/hooks/useCandidateBootstrap';
+import {
+  INVITE_ALREADY_CLAIMED_MESSAGE,
+  INVITE_INVALID_MESSAGE,
+} from '@/platform/copy/invite';
 
 jest.mock('@/features/candidate/session/api', () => {
   const actual = jest.requireActual('@/features/candidate/session/api');
@@ -67,22 +71,27 @@ describe('useCandidateBootstrap', () => {
     expect(screen.getByTestId('state').textContent).toBe('ready');
   });
 
-  it('surfaces error on failure', async () => {
-    const onResolved = jest.fn();
-    resolveMock.mockRejectedValue(
-      Object.assign(new Error('bad'), { status: 404 }),
-    );
+  it.each([
+    [400, INVITE_INVALID_MESSAGE],
+    [404, INVITE_INVALID_MESSAGE],
+    [409, INVITE_ALREADY_CLAIMED_MESSAGE],
+  ])(
+    'surfaces the correct invite error for status %s',
+    async (status, expected) => {
+      const onResolved = jest.fn();
+      resolveMock.mockRejectedValue(
+        Object.assign(new Error('bad'), { status }),
+      );
 
-    render(<Harness inviteToken="tok_err" onResolved={onResolved} />);
+      render(<Harness inviteToken="tok_err" onResolved={onResolved} />);
 
-    await act(async () => {
-      screen.getByText('load').click();
-    });
+      await act(async () => {
+        screen.getByText('load').click();
+      });
 
-    expect(onResolved).not.toHaveBeenCalled();
-    expect(screen.getByTestId('state').textContent).toBe('error');
-    expect(screen.getByTestId('error').textContent).toContain(
-      'no longer valid',
-    );
-  });
+      expect(onResolved).not.toHaveBeenCalled();
+      expect(screen.getByTestId('state').textContent).toBe('error');
+      expect(screen.getByTestId('error').textContent).toBe(expected);
+    },
+  );
 });

--- a/tests/unit/features/candidate/session/CandidateSessionErrorRoute.test.tsx
+++ b/tests/unit/features/candidate/session/CandidateSessionErrorRoute.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { CandidateSessionErrorRoute } from '@/features/candidate/session/CandidateSessionErrorRoute';
+import {
+  INVITE_EXPIRED_MESSAGE,
+  INVITE_INVALID_MESSAGE,
+} from '@/platform/copy/invite';
+
+const props = {
+  loginHref: '/auth/login?mode=candidate',
+  onRetryInit: jest.fn(),
+  onGoHome: jest.fn(),
+} as never;
+
+describe('CandidateSessionErrorRoute', () => {
+  it('renders a distinct invalid invite state', () => {
+    render(
+      <CandidateSessionErrorRoute
+        props={props}
+        authStatus="ready"
+        errorMessage={null}
+        errorStatus={400}
+        inviteErrorCopy={INVITE_INVALID_MESSAGE}
+      />,
+    );
+
+    expect(screen.getByText('Invalid invite')).toBeInTheDocument();
+    expect(screen.getByText(INVITE_INVALID_MESSAGE)).toBeInTheDocument();
+  });
+
+  it('renders a distinct expired invite state', () => {
+    render(
+      <CandidateSessionErrorRoute
+        props={props}
+        authStatus="ready"
+        errorMessage={null}
+        errorStatus={410}
+        inviteErrorCopy={INVITE_EXPIRED_MESSAGE}
+      />,
+    );
+
+    expect(screen.getByText('Invite expired')).toBeInTheDocument();
+    expect(screen.getByText(INVITE_EXPIRED_MESSAGE)).toBeInTheDocument();
+    expect(screen.queryByText(/already used/i)).toBeNull();
+  });
+});

--- a/tests/unit/features/candidate/session/CandidateSessionPage.error.authInvite.test.tsx
+++ b/tests/unit/features/candidate/session/CandidateSessionPage.error.authInvite.test.tsx
@@ -51,17 +51,31 @@ describe('CandidateSessionPage error states - auth and invite paths', () => {
     expect(screen.queryByRole('button', { name: /Go to sign in/i })).toBeNull();
   });
 
-  it('shows invite error with go home action when authenticated', async () => {
+  it('shows invalid invite state with go home action when authenticated', async () => {
     resolveInviteMock.mockRejectedValue(new HttpError(404));
     useCandidateSessionMock.mockReturnValue(buildState());
     await act(async () => render(<CandidateSessionPage token="inv" />));
     await waitFor(() =>
       expect(screen.getByTestId('state-message')).toHaveTextContent(
-        'Invite link unavailable',
+        'Invalid invite',
       ),
     );
     fireEvent.click(screen.getByRole('button', { name: /Go to Home/i }));
     expect(routerMock.push).toHaveBeenCalledWith('/');
+  });
+
+  it('routes 403 invite errors to access denied guidance', async () => {
+    resolveInviteMock.mockRejectedValue(new HttpError(403, 'Forbidden'));
+    useCandidateSessionMock.mockReturnValue(buildState());
+    await act(async () => render(<CandidateSessionPage token="inv" />));
+    await waitFor(() =>
+      expect(screen.getByTestId('state-message')).toHaveTextContent(
+        'Access denied',
+      ),
+    );
+    expect(
+      screen.getByText(/You do not have access to this invite/i),
+    ).toBeInTheDocument();
   });
 
   it('redirects to login when resolve fails with 401', async () => {

--- a/tests/unit/features/candidate/session/CandidateSessionPage.error.inviteVariants.test.tsx
+++ b/tests/unit/features/candidate/session/CandidateSessionPage.error.inviteVariants.test.tsx
@@ -6,6 +6,10 @@ import {
   waitFor,
 } from '@testing-library/react';
 import {
+  INVITE_ALREADY_CLAIMED_MESSAGE,
+  INVITE_INVALID_MESSAGE,
+} from '@/platform/copy/invite';
+import {
   CandidateSessionPage,
   buildState,
   primeErrorApiMocks,
@@ -52,25 +56,34 @@ describe('CandidateSessionPage error states - invite error variants', () => {
     await waitFor(() => expect(resolveInviteMock).toHaveBeenCalledTimes(2));
   });
 
-  it('handles 400 status as invite unavailable', async () => {
+  it('handles 400 status as invalid invite', async () => {
     resolveInviteMock.mockRejectedValue({ status: 400 });
     useCandidateSessionMock.mockReturnValue(buildState());
     await act(async () => render(<CandidateSessionPage token="inv" />));
     await waitFor(() =>
       expect(screen.getByTestId('state-message')).toHaveTextContent(
-        'Invite link unavailable',
+        'Invalid invite',
       ),
+    );
+    expect(screen.getByTestId('state-message')).toHaveTextContent(
+      INVITE_INVALID_MESSAGE,
     );
   });
 
-  it('handles 409 status as invite unavailable', async () => {
+  it('handles 409 status as already claimed invite guidance', async () => {
     resolveInviteMock.mockRejectedValue({ status: 409 });
     useCandidateSessionMock.mockReturnValue(buildState());
     await act(async () => render(<CandidateSessionPage token="inv" />));
     await waitFor(() =>
       expect(screen.getByTestId('state-message')).toHaveTextContent(
-        'Invite link unavailable',
+        'Sign in to continue',
       ),
     );
+    expect(screen.getByTestId('state-message')).toHaveTextContent(
+      INVITE_ALREADY_CLAIMED_MESSAGE,
+    );
+    expect(
+      screen.getByRole('button', { name: /Continue to sign in/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/tests/unit/features/candidate/session/CandidateSessionPage.unit.test.tsx
+++ b/tests/unit/features/candidate/session/CandidateSessionPage.unit.test.tsx
@@ -17,9 +17,7 @@ describe('CandidateSessionPage unit flow', () => {
     mockUseCandidateSession.mockReturnValue(buildSession());
     render(<CandidateSessionPage token="" />);
 
-    expect(
-      await screen.findByText(/Invite link unavailable/i),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/Invalid invite/i)).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /Go to Home/i }),
     ).toBeInTheDocument();
@@ -46,22 +44,30 @@ describe('CandidateSessionPage unit flow', () => {
     expect(await screen.findByText('Access denied')).toBeInTheDocument();
   });
 
-  it.each([400, 404, 409])(
-    'shows invite-unavailable guidance for status %s',
+  it.each([400, 404])(
+    'shows invalid invite guidance for status %s',
     async (status) => {
       mockUseCandidateSession.mockReturnValue(buildSession());
       mockResolveInvite.mockRejectedValueOnce({ status });
 
       render(<CandidateSessionPage token="invite-token" />);
-      expect(
-        await screen.findByText(/Invite link unavailable/i),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole('button', { name: /Go to Home/i }),
-      ).toBeInTheDocument();
+      expect(await screen.findByText(/Invalid invite/i)).toBeInTheDocument();
       expect(screen.queryByText(/Retry/i)).not.toBeInTheDocument();
     },
   );
+
+  it('routes already-claimed invite errors into sign-in recovery guidance', async () => {
+    mockUseCandidateSession.mockReturnValue(buildSession());
+    mockResolveInvite.mockRejectedValueOnce({ status: 409 });
+
+    render(<CandidateSessionPage token="invite-token" />);
+    expect(
+      await screen.findByText(/already been claimed/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Continue to sign in/i }),
+    ).toBeInTheDocument();
+  });
 
   it('shows expired invite state for 410', async () => {
     mockUseCandidateSession.mockReturnValue(buildSession());

--- a/tests/unit/features/candidate/session/api/invitesApi.test.ts
+++ b/tests/unit/features/candidate/session/api/invitesApi.test.ts
@@ -1,0 +1,34 @@
+import { resolveCandidateInviteToken } from '@/features/candidate/session/api/invitesApi';
+
+const apiGetMock = jest.fn();
+
+jest.mock('@/platform/api-client/client', () => ({
+  apiClient: {
+    get: (...args: unknown[]) => apiGetMock(...args),
+  },
+}));
+
+describe('resolveCandidateInviteToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reuses recoverable 409 session payloads as bootstrap data', async () => {
+    const recoveredSession = {
+      candidateSessionId: 88,
+      status: 'in_progress',
+      trial: { title: 'Recovered Trial', role: 'Candidate' },
+      aiNoticeText: 'Notice',
+      aiNoticeVersion: 'v1',
+      evalEnabledByDay: {},
+    };
+    apiGetMock.mockRejectedValue({
+      status: 409,
+      details: { session: recoveredSession },
+    });
+
+    await expect(resolveCandidateInviteToken('invite-token')).resolves.toEqual(
+      recoveredSession,
+    );
+  });
+});

--- a/tests/unit/features/candidate/session/hooks/inviteInitRunner.test.ts
+++ b/tests/unit/features/candidate/session/hooks/inviteInitRunner.test.ts
@@ -1,4 +1,5 @@
 import { createInviteInit } from '@/features/candidate/session/hooks/useInviteInitRunner';
+import { INVITE_ALREADY_CLAIMED_MESSAGE } from '@/platform/copy/invite';
 
 const resolveCandidateInviteTokenMock = jest.fn();
 
@@ -54,6 +55,65 @@ describe('inviteInitRunner auth handling', () => {
     expect(params.setView).toHaveBeenCalledWith('accessDenied');
     expect(params.markEnd).toHaveBeenCalledWith('candidate:init', {
       status: 'access_denied',
+    });
+  });
+
+  it('routes 403 invite errors to access denied guidance', async () => {
+    resolveCandidateInviteTokenMock.mockRejectedValue({
+      status: 403,
+      message: 'Forbidden',
+    });
+    const params = buildParams();
+    const runInit = createInviteInit(params);
+
+    await runInit('invite-token');
+
+    expect(params.setErrorStatus).toHaveBeenCalledWith(403);
+    expect(params.setView).toHaveBeenCalledWith('accessDenied');
+    expect(params.setErrorMessage).toHaveBeenCalledWith(
+      'You do not have access to this invite.',
+    );
+    expect(params.redirectToLogin).not.toHaveBeenCalled();
+  });
+
+  it('falls back to sign-in guidance for a bare 409 without recovery payload', async () => {
+    resolveCandidateInviteTokenMock.mockRejectedValue({ status: 409 });
+    const params = buildParams();
+    const runInit = createInviteInit(params);
+
+    await runInit('invite-token');
+
+    expect(params.setErrorStatus).toHaveBeenCalledWith(409);
+    expect(params.setView).toHaveBeenCalledWith('auth');
+    expect(params.setAuthMessage).toHaveBeenCalledWith(
+      INVITE_ALREADY_CLAIMED_MESSAGE,
+    );
+    expect(params.redirectToLogin).not.toHaveBeenCalled();
+  });
+
+  it('treats a recovered invite payload as the normal running flow', async () => {
+    resolveCandidateInviteTokenMock.mockResolvedValue({
+      candidateSessionId: 101,
+      status: 'in_progress',
+      trial: { title: 'Recovered Trial', role: 'Candidate' },
+      aiNoticeText: 'Notice',
+      aiNoticeVersion: 'v1',
+      evalEnabledByDay: {},
+    });
+    const params = buildParams();
+    const runInit = createInviteInit(params);
+
+    await runInit('invite-token');
+
+    expect(params.setBootstrap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        candidateSessionId: 101,
+        trial: { title: 'Recovered Trial', role: 'Candidate' },
+      }),
+    );
+    expect(params.setView).toHaveBeenCalledWith('running');
+    expect(params.markEnd).toHaveBeenCalledWith('candidate:init', {
+      status: 'success',
     });
   });
 });

--- a/tests/unit/features/candidate/session/utils/errorMessages.test.ts
+++ b/tests/unit/features/candidate/session/utils/errorMessages.test.ts
@@ -11,7 +11,9 @@ const httpErr = (status: number, message?: string) =>
 describe('candidate error messages', () => {
   it('handles bootstrap errors by status', () => {
     expect(friendlyBootstrapError(httpErr(401))).toMatch(/sign in/i);
-    expect(friendlyBootstrapError(httpErr(403))).toMatch(/confirm your email/i);
+    expect(friendlyBootstrapError(httpErr(403))).toBe(
+      'You do not have access to this invite.',
+    );
     expect(friendlyBootstrapError(httpErr(410))).toMatch(/expired/i);
     expect(friendlyBootstrapError(httpErr(0))).toMatch(/Network/i);
     expect(friendlyBootstrapError(httpErr(500, 'boom'))).toBe('boom');
@@ -25,7 +27,9 @@ describe('candidate error messages', () => {
 
   it('handles claim errors by status', () => {
     expect(friendlyClaimError(httpErr(401))).toMatch(/sign in again/i);
-    expect(friendlyClaimError(httpErr(403))).toMatch(/confirm your email/i);
+    expect(friendlyClaimError(httpErr(403))).toBe(
+      'You do not have access to this invite.',
+    );
     expect(friendlyClaimError(httpErr(410))).toMatch(/expired/i);
     expect(friendlyClaimError(httpErr(0))).toMatch(/Network/i);
     expect(friendlyClaimError(httpErr(500, 'y'))).toBe('y');

--- a/tests/unit/lib/api/candidate.invites.test.ts
+++ b/tests/unit/lib/api/candidate.invites.test.ts
@@ -53,13 +53,33 @@ describe('candidate api invite helpers', () => {
 
   it('maps resolveCandidateInviteToken auth and access statuses', async () => {
     const { resolveCandidateInviteToken } = await importCandidateApi();
+    mockGet.mockRejectedValueOnce({ status: 400 });
+    await expect(resolveCandidateInviteToken('tok')).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining('invalid'),
+    });
     mockGet.mockRejectedValueOnce({ status: 404 });
     await expect(resolveCandidateInviteToken('tok')).rejects.toMatchObject({
       status: 404,
+      message: expect.stringContaining('invalid'),
     });
     mockGet.mockRejectedValueOnce({ status: 410 });
     await expect(resolveCandidateInviteToken('tok')).rejects.toMatchObject({
       status: 410,
+      message: expect.stringContaining('expired'),
+    });
+    mockGet.mockRejectedValueOnce({
+      status: 409,
+      details: {
+        candidateSessionId: 77,
+        status: 'in_progress',
+        trial: { title: 'Existing trial', role: 'Role' },
+      },
+    });
+    await expect(resolveCandidateInviteToken('tok')).resolves.toMatchObject({
+      candidateSessionId: 77,
+      status: 'in_progress',
+      trial: { title: 'Existing trial', role: 'Role' },
     });
     mockGet.mockRejectedValueOnce({ status: 401 });
     await expect(resolveCandidateInviteToken('tok')).rejects.toMatchObject({
@@ -68,11 +88,11 @@ describe('candidate api invite helpers', () => {
     });
     mockGet.mockRejectedValueOnce({
       status: 403,
-      details: { message: 'Email verification required' },
+      details: { message: 'email claim missing' },
     });
     await expect(resolveCandidateInviteToken('tok')).rejects.toMatchObject({
       status: 403,
-      message: 'Please verify your email, then try again.',
+      message: 'We could not confirm your sign-in. Please sign in again.',
     });
     mockGet.mockRejectedValueOnce({
       status: 403,
@@ -80,7 +100,7 @@ describe('candidate api invite helpers', () => {
     });
     await expect(resolveCandidateInviteToken('tok')).rejects.toMatchObject({
       status: 403,
-      message: 'We could not confirm your email. Please sign in again.',
+      message: 'We could not confirm your sign-in. Please sign in again.',
     });
     mockGet.mockRejectedValueOnce({
       status: 403,


### PR DESCRIPTION
## 2. Problem

Candidate invite flows were collapsing too many backend outcomes into a generic unavailable-state experience. That made it hard to tell the difference between a malformed token, an expired invite, an already-claimed session, and a real access problem.

The old candidate sign-in copy also implied a verification workflow that the product does not own. Auth0 owns email verification, so the frontend should only guide candidates through sign-in, invite-email matching, session ownership, and invite lifecycle errors.

## 3. What Changed

- Invite token resolution now maps backend responses to distinct candidate states:
  - `400` and `404` become an invalid invite response.
  - `409` becomes an already-claimed invite response, and a recoverable bootstrap payload is treated as a live session.
  - `410` becomes an expired invite response.
  - `403` now resolves to access-denied or sign-in guidance instead of verification-flavored copy.
- Candidate invite error rendering now shows distinct titles and messages for invalid, expired, and already-claimed cases.
- The candidate error view now sends already-claimed unauthenticated users to sign in, while keeping the home/retry actions for the other invite states.
- Candidate login copy now says to sign in with the email tied to the invite.
- Shared invite copy now has separate messages for invalid, expired, already-claimed, and generic unavailable states.
- Unit coverage was expanded for:
  - invite token resolution and 409 recovery
  - candidate bootstrap error mapping
  - candidate session error routing
  - invite error message helpers
  - candidate login copy
  - the legacy `/candidate-sessions/[token]` redirect path

## 4. Why This Is Correct

The candidate runtime now matches the intended contract:

- sign-in state
- invite email match
- session ownership
- already-claimed handling
- invalid and expired invite handling

There is no shipped frontend email-verification workflow here because Auth0 owns that concern. The frontend should only surface the invite/session state that the backend returns.

Treating a recoverable `409` payload as the active session is correct because it represents an already-claimed invite that can continue instead of a dead-end error.

## 5. Validation / QA

- Updated unit tests cover the new invite-status mapping and error-copy paths.
- Route coverage now includes the legacy redirect-only `/candidate-sessions/[token]` behavior.
- The candidate login page behavior test now verifies the invite-email sign-in subtitle.

## 6. Risks / Follow-Ups

- Issue `#179` still mentions unverified-email verification instructions. That wording is stale relative to the actual product contract and should not be treated as shipped candidate behavior.
- The already-claimed recovery path depends on the backend returning a recoverable bootstrap payload for `409`; otherwise the user sees already-claimed guidance.
- If backend invite error shapes drift, the status-to-copy mapping will need to be kept in sync.

## 7. Final Result

The frontend candidate invite flow now gives candidates clear, specific recovery paths for invalid, expired, already-claimed, and access-denied invite states, without introducing a frontend-owned email-verification flow.

Fixes #179 