### PR TITLE
Fix Day 3 UI: same-repo continuation framing and implementation wrap-up copy

### DIFF
--- a/pr.md
+++ b/pr.md
@@ -1,109 +1,138 @@
-# PR: Complete Day 1 design document workspace
-
-## Linked Issue
-
-- Winoe-AI/winoe-ai-frontend issue #182
+# PR: Fix Day 3 Implementation Wrap-Up UI
 
 ## Summary
 
-This PR implements the Day 1 candidate design document workspace for the v4 from-scratch Tech Trial model. Day 1 is now Project Brief-first: candidates plan from scratch, choose their tech stack, make architecture and dependency decisions, define project organization, set a testing strategy, document risks and tradeoffs, and outline their Days 2-3 implementation plan.
+- Reframed Day 3 candidate UI from stale debugging exercise language to `Implementation Wrap-Up`.
+- Normalized stale Day 3 backend task copy client-side so candidate-facing UI always shows the correct v4 from-scratch model.
+- Preserved same Codespace/repository continuation from Day 2.
+- Preserved existing submit/final SHA behavior.
+- Added/updated focused tests for Day 3 copy, CTA, stale `debug` leakage, and submit feedback.
 
-The stale GitHub issue criterion for a read-only repository exploration link is intentionally not implemented because it was superseded by the v4 pivot. There is no pre-populated codebase to explore on Day 1.
+## Product Behavior
 
-## Implementation Summary
-
-- Added a Day 1-specific design document workspace.
-- Displayed Project Brief / prestart context prominently above the editor.
-- Added from-scratch design guidance and starter content covering tech stack, architecture, project structure, testing strategy, risks, tradeoffs, and Days 2-3 plan.
-- Added side-by-side markdown editor and live preview.
-- Added responsive layout behavior for narrower screens.
-- Added autosave states: `Saving...`, `Saved`, and `Save failed`.
-- Added submit confirmation dialog before final Day 1 submission.
-- Added deadline card / countdown using existing `task.cutoffAt`.
-- Added deadline-triggered autosave.
-- Added immutable closed/submitted Day 1 view.
-- Preserved saved draft artifact restoration after cutoff when no finalized submission exists.
-- Prevented starter content from being written before restore settles.
-- Kept finalized submitted content authoritative over draft restore.
-- Hardened submit confirmation against disabled/pending duplicate submission states.
+- Day 3 now shows `Implementation Wrap-Up`.
+- Day 3 displays safe task type/copy instead of stale `debug`.
+- Day 3 guides candidates to finish the build, improve tests, handle edge cases, optimize, document, and prepare for handoff.
+- Day 3 reinforces Codespace-only implementation work.
+- Day 3 submit uses `Submit Implementation Wrap-Up`.
+- Progress remains X/5.
 
 ## Files Changed
 
+- `src/features/candidate/tasks/utils/day3ImplementationWrapUpUtils.ts`
+- `src/features/candidate/session/api/tasksNormalizeApi.ts`
+- `src/features/candidate/session/utils/taskTransformsUtils.ts`
 - `src/features/candidate/tasks/CandidateTaskViewInner.tsx`
-- `src/features/candidate/tasks/components/Day1DesignDocWorkspace.tsx`
-- `src/features/candidate/tasks/components/Day1DeadlineCard.tsx`
 - `src/features/candidate/tasks/components/TaskActions.tsx`
 - `src/features/candidate/tasks/components/TaskWorkArea.tsx`
-- `src/features/candidate/tasks/components/DraftSaveStatus.tsx`
-- `src/features/candidate/tasks/hooks/useTaskSubmitController.ts`
-- `src/features/candidate/tasks/hooks/useTaskSubmitController.types.ts`
-- `src/features/candidate/tasks/hooks/useTaskDraftAutosave.ts`
-- `src/features/candidate/tasks/hooks/useTaskDraftAutosave.types.ts`
-- `src/features/candidate/tasks/utils/day1DesignDocUtils.ts`
-- Focused Day 1/task autosave/submit tests
+- `src/features/candidate/tasks/components/progress/daySummaries.ts`
+- `tests/e2e/flow-qa/candidate-day3.spec.ts`
+- `tests/unit/features/candidate/tasks/CandidateTaskProgress.test.tsx`
+- `tests/unit/features/candidate/tasks/components/TaskActions.test.tsx`
+- `tests/unit/features/candidate/tasks/CandidateTaskView.day3ImplementationWrapUp.test.tsx`
+- `tests/unit/features/candidate/tasks/CandidateTaskView.submitFeedback.test.tsx`
 
 ## QA Evidence
 
-### Manual QA
+### Environment
 
-- QA PASSED - ready for pr.md update
-- Frontend URL used: `http://localhost:3000`
-- Backend URL used: `http://localhost:8000`
-- Candidate QA account used: candidate account only; credentials are not included here.
-- Controlled Day 1 fixture:
-  - token `qa-day1`
-  - candidateSessionId `77`
-  - taskId `1`
-- `FRONTEND_QA_PLAYBOOK.md` was not present, so QA followed repo README/run scripts and documented QA fixtures.
+Backend:
 
-### Manual QA Scenarios Passed
+- PASS `./runBackend.sh migrate`
+- PASS `./runBackend.sh bootstrap-local`
+- Runtime: `WINOE_SCENARIO_GENERATION_RUNTIME_MODE=demo WINOE_DEMO_MODE=1 ./runBackend.sh`
 
-- Candidate login and active Day 1 workspace
-- Project Brief displayed prominently above editor
-- No repository exploration link/copy
-- From-scratch design prompts present
-- Markdown editor and live preview work
-- Responsive layout checked
-- Autosave success checked
-- Autosave failure forced via mocked `PUT /api/backend/tasks/1/draft` returning 500
-- Submit confirmation cancel/confirm checked
-- Submitted Day 1 locks read-only
-- Deadline countdown checked
-- Deadline reached while page open checked
-- Reload after cutoff with saved draft checked
-- Reload after cutoff with finalized submission checked
-- Reload after cutoff with no saved content checked
-- Forbidden-term scan passed
+Frontend:
+
+- Runtime: `./runFrontend.sh`
+
+URLs:
+
+- Frontend: `http://localhost:3000`
+- Backend: `http://localhost:8000`
+
+Health:
+
+- PASS backend `/health`
+- PASS frontend `/api/health`
+
+Browser/tool:
+
+- Playwright Chromium
+
+### Account / Session
+
+- Candidate account used: `robiemelaku@gmail.com`
+- Talent Partner account used for local Trial API setup: `robel.kebede@bison.howard.edu`
+- QA Trial: `Issue 184 Day 3 QA Trial Demo`
+- Trial id: `3`
+- Candidate session id: `1`
+
+### Acceptance Criteria Evidence
+
+AC1 Day 3 title: PASS
+
+- Visible text: `Day 3 • code`
+- Visible title: `Implementation Wrap-Up`
+- No `Debugging Exercise`
+
+AC2 same Codespace/repo: PASS
+
+- Day 2 and Day 3 both showed repo `winoe-ai-repos/winoe-ws-1`
+- Day 2 and Day 3 both showed Codespace `https://vigilant-orbit-jjwrrq6r467j2j7ww.github.dev`
+
+AC3 wrap-up guidance: PASS
+
+- Copy includes finish core build, improve test coverage, handle edge cases, optimize, add/improve documentation, and prepare for handoff.
+
+AC4 Codespace-only constraints: PASS
+
+- Visible copy includes `Day 2 and Day 3 implementation work must happen in GitHub Codespaces only`
+- Visible copy includes `All coding work must happen inside the Codespace`
+
+AC5 submit/final SHA behavior: PASS
+
+- Day 3 submit returned `finalSha: "68b2650911ea1dedd050c2360e34096b74f3dc23"`
+- Progress advanced to `3/5`
+
+AC6 forbidden terminology absent: PASS for candidate-facing Day 3 DOM
+
+- DOM scan found none of the forbidden Day 3 terms.
+- Code scan found only internal/test compatibility occurrences.
+
+AC7 5-day Trial framing: PASS
+
+- UI showed `2/5 complete` before Day 3 submit.
+- UI showed `3/5 complete` after Day 3 submit.
+- No X/10 task framing.
 
 ### QA Artifacts
 
-The issue #182 manual QA artifact directory is tracked in this repo. The latest contract-live Playwright result path is ignored by `.gitignore`, so it is referenced as local evidence and should not be added unless repo convention changes.
-
-- `qa_verifications/issue182-day1-manual-qa/2026-04-27T20-00-18-214Z/`
-- `qa_verifications/issue182-day1-manual-qa/2026-04-27T20-00-18-214Z/manual-qa-results.json`
-- `qa_verifications/Contract-Live-QA/contract_live_qa_latest/artifacts/2026-04-27T19-55-37-266Z/playwright/results.json`
+- `/tmp/winoe-issue-184-day3-qa/09-day3-active-ui.png`
+- `/tmp/winoe-issue-184-day3-qa/10-day3-after-submit.png`
+- `/tmp/winoe-issue-184-day3-qa/day3-active-network-responses.json`
+- `/tmp/winoe-issue-184-day3-qa/day3-submit-responses.json`
 
 ## Automated Checks
 
-- PASS `npm run typecheck`
+- PASS `npm test -- CandidateTaskView.submitFeedback.test.tsx --runInBand`
+- PASS `npm test -- CandidateTaskView.day3ImplementationWrapUp.test.tsx --runInBand`
 - PASS `npm run lint`
-- PASS `npm test -- --runInBand` - 499 suites / 1550 tests
-- PASS `npm test -- --runInBand tests/unit/features/candidate/tasks/CandidateTaskView.day1DesignDoc.test.tsx` - 13 tests
-- PASS `npm test -- --runInBand tests/unit/features/candidate/tasks/components/TaskActions.test.tsx` - 3 tests
-- PASS `npm test -- --runInBand tests/unit/features/candidate/tasks/hooks/useTaskDraftAutosave.test.tsx` - 4 tests
-- PASS `npm test -- --runInBand tests/unit/features/candidate/tasks/hooks/useTaskDraftAutosave.extra.test.tsx` - 4 tests
+- PASS `npm run typecheck`
+- PASS `npm run lint:prettier`
+- PASS `./precommit.sh`
+  - 500 Jest suites passed
+  - 1552 tests passed
+  - coverage gate passed
+  - typecheck passed
+  - production build passed
 
-### Forbidden-Term Scan
+## Risk / Rollback
 
-```bash
-rg -n "Tenon|SimuHire|recruiter|simulation|Fit Profile|Fit Score|template|precommit|Specializor|existing codebase|starter code|read-only repository|offline|local work" src/features/candidate/tasks tests/unit/components/candidate tests/unit/features/candidate/tasks
-```
+- Risk is low.
+- The frontend still accepts stale backend Day 3 payloads, including `type: "debug"`, but normalizes candidate-facing Day 3 display to the correct Implementation Wrap-Up model.
+- No backend contract changes.
+- Existing final SHA behavior preserved.
+- Rollback: revert the Day 3 normalization/copy changes and test updates.
 
-Result: PASS, no matches.
-
-## Risks / Assumptions
-
-- Deadline behavior depends on backend providing accurate `task.cutoffAt`.
-- `FRONTEND_QA_PLAYBOOK.md` was not present locally; QA used repo README/run scripts.
-- Cutoff edge cases were verified with controlled Playwright fixtures.
-- Downstream Talent Partner review surfaces, Evidence Trail entries, Winoe Report content, and Winoe Score calculations depend on existing backend/reporting flows consuming the finalized Day 1 artifact correctly.
+Fixes #184

--- a/src/features/candidate/session/api/tasksNormalizeApi.ts
+++ b/src/features/candidate/session/api/tasksNormalizeApi.ts
@@ -7,6 +7,10 @@ import {
 } from './tasksNormalize.cutoffApi';
 import { asRecord } from './tasksNormalize.primitivesApi';
 import { findRecordedSubmission } from './tasksNormalize.submissionApi';
+import {
+  DAY3_IMPLEMENTATION_WRAP_UP_DESCRIPTION,
+  DAY3_IMPLEMENTATION_WRAP_UP_TITLE,
+} from '@/features/candidate/tasks/utils/day3ImplementationWrapUpUtils';
 
 export const normalizeTask = (raw: unknown): CandidateTask | null => {
   const rec = asRecord(raw);
@@ -24,11 +28,17 @@ export const normalizeTask = (raw: unknown): CandidateTask | null => {
     readCutoffAt(rec) ??
     (nestedCutoffRecord ? readCutoffAt(nestedCutoffRecord) : null);
 
+  const isDay3 = dayIndex === 3;
+
   return {
     id,
     dayIndex,
-    title: toStringOrNull(rec.title) ?? 'Task',
-    description: toStringOrNull(rec.description) ?? '',
+    title: isDay3
+      ? DAY3_IMPLEMENTATION_WRAP_UP_TITLE
+      : (toStringOrNull(rec.title) ?? 'Task'),
+    description: isDay3
+      ? DAY3_IMPLEMENTATION_WRAP_UP_DESCRIPTION
+      : (toStringOrNull(rec.description) ?? ''),
     type: toStringOrNull(rec.type) ?? 'code',
     recordedSubmission: findRecordedSubmission(rec),
     cutoffCommitSha,

--- a/src/features/candidate/session/utils/taskTransformsUtils.ts
+++ b/src/features/candidate/session/utils/taskTransformsUtils.ts
@@ -1,5 +1,6 @@
 import type { CandidateCurrentTaskResponse } from '@/features/candidate/session/api';
 import type { Task } from '@/features/candidate/tasks/types';
+import { withDay3ImplementationWrapUpCopy } from '@/features/candidate/tasks/utils/day3ImplementationWrapUpUtils';
 
 export function normalizeCompletedTaskIds(
   dto: CandidateCurrentTaskResponse,
@@ -16,7 +17,7 @@ export function toTask(
   dtoTask: CandidateCurrentTaskResponse['currentTask'],
 ): Task | null {
   if (!dtoTask) return null;
-  return {
+  return withDay3ImplementationWrapUpCopy({
     id: dtoTask.id,
     dayIndex: dtoTask.dayIndex,
     type: dtoTask.type,
@@ -25,7 +26,7 @@ export function toTask(
     recordedSubmission: dtoTask.recordedSubmission ?? null,
     cutoffCommitSha: dtoTask.cutoffCommitSha ?? null,
     cutoffAt: dtoTask.cutoffAt ?? null,
-  };
+  });
 }
 
 export function deriveCurrentDayIndex(

--- a/src/features/candidate/tasks/CandidateTaskViewInner.tsx
+++ b/src/features/candidate/tasks/CandidateTaskViewInner.tsx
@@ -9,6 +9,7 @@ import { TaskActions } from './components/TaskActions';
 import { TaskDraftStatusSlots } from './components/TaskDraftStatusSlots';
 import { TaskWorkArea } from './components/TaskWorkArea';
 import { useTaskSubmitController } from './hooks/useTaskSubmitController';
+import { withDay3ImplementationWrapUpCopy } from './utils/day3ImplementationWrapUpUtils';
 import {
   DEFAULT_ACTION_GATE,
   type CandidateTaskViewProps,
@@ -23,6 +24,7 @@ export function CandidateTaskViewInner({
   actionGate,
   onTaskWindowClosed,
 }: CandidateTaskViewProps) {
+  const displayTask = withDay3ImplementationWrapUpCopy(task);
   const controller = useTaskSubmitController({
     candidateSessionId,
     task,
@@ -49,13 +51,16 @@ export function CandidateTaskViewInner({
 
   return (
     <TaskContainer>
-      <TaskHeader task={task} statusSlot={draftStatus.headerStatusSlot} />
+      <TaskHeader
+        task={displayTask}
+        statusSlot={draftStatus.headerStatusSlot}
+      />
       {isDay1DesignDoc ? null : (
-        <TaskDescription description={task.description} />
+        <TaskDescription description={displayTask.description} />
       )}
       <TaskWorkArea
         dayIndex={task.dayIndex}
-        projectBrief={task.description}
+        projectBrief={displayTask.description}
         cutoffAt={task.cutoffAt}
         githubNative={controller.githubNative}
         readOnly={controller.readOnly}
@@ -86,6 +91,9 @@ export function CandidateTaskViewInner({
           }
           onSubmit={controller.saveAndSubmit}
           requireSubmitConfirmation={isDay1DesignDoc}
+          submitLabel={
+            task.dayIndex === 3 ? 'Submit Implementation Wrap-Up' : undefined
+          }
         />
       )}
     </TaskContainer>

--- a/src/features/candidate/tasks/components/TaskActions.tsx
+++ b/src/features/candidate/tasks/components/TaskActions.tsx
@@ -9,6 +9,7 @@ type TaskActionsProps = {
   onSaveDraft?: () => void;
   onSubmit: () => void | Promise<unknown>;
   requireSubmitConfirmation?: boolean;
+  submitLabel?: string;
 };
 
 export const TaskActions = memo(function TaskActions({
@@ -19,6 +20,7 @@ export const TaskActions = memo(function TaskActions({
   onSaveDraft,
   onSubmit,
   requireSubmitConfirmation = false,
+  submitLabel: idleSubmitLabel = 'Submit & Continue',
 }: TaskActionsProps) {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [confirmPending, setConfirmPending] = useState(false);
@@ -27,7 +29,7 @@ export const TaskActions = memo(function TaskActions({
       ? 'Submitting…'
       : displayStatus === 'submitted'
         ? 'Submitted ✓'
-        : 'Submit & Continue';
+        : idleSubmitLabel;
   const handleSubmitClick = () => {
     if (disabled || displayStatus !== 'idle') return;
     if (requireSubmitConfirmation) {

--- a/src/features/candidate/tasks/components/TaskWorkArea.tsx
+++ b/src/features/candidate/tasks/components/TaskWorkArea.tsx
@@ -56,8 +56,9 @@ export function TaskWorkArea({
           </div>
         ) : (
           <div className="rounded-md border border-blue-100 bg-blue-50 p-3 text-sm text-blue-900">
-            Use your Codespace for all implementation work. When you’re ready,
-            submit to move to the next day.
+            {dayIndex === 3
+              ? 'Use the same Codespace and repository from Day 2 for all wrap-up work. When the implementation is ready for handoff, submit to record the final commit SHA.'
+              : 'Use your Codespace for all implementation work. When you’re ready, submit to move to the next day.'}
           </div>
         )
       ) : (

--- a/src/features/candidate/tasks/components/progress/daySummaries.ts
+++ b/src/features/candidate/tasks/components/progress/daySummaries.ts
@@ -12,8 +12,8 @@ export const DAY_SUMMARIES = [
     hint: 'Workspace + tests.',
   },
   {
-    title: 'Debug + iterate',
-    detail: 'Fix issues and ship a clean run.',
+    title: 'Implementation Wrap-Up',
+    detail: 'Finish the build, improve tests, optimize, and document.',
     hint: 'Workspace + tests.',
   },
   {

--- a/src/features/candidate/tasks/utils/day3ImplementationWrapUpUtils.ts
+++ b/src/features/candidate/tasks/utils/day3ImplementationWrapUpUtils.ts
@@ -1,0 +1,16 @@
+import type { Task } from '../types';
+
+export const DAY3_IMPLEMENTATION_WRAP_UP_TITLE = 'Implementation Wrap-Up';
+
+export const DAY3_IMPLEMENTATION_WRAP_UP_DESCRIPTION =
+  'Continue in the same GitHub Codespace and repository you used on Day 2. Today is your final implementation window: finish the core build, improve test coverage, handle edge cases, optimize where useful, and add or improve documentation that makes your work easy to understand. Prepare the implementation for handoff. All coding work must happen inside the Codespace during the open Trial window so the Evidence Trail stays complete.\n\nSame repository as Day 2. Codespace-only. Final implementation day. Your final commit SHA will be captured when you submit or when the window closes.';
+
+export function withDay3ImplementationWrapUpCopy(task: Task): Task {
+  if (task.dayIndex !== 3) return task;
+  return {
+    ...task,
+    type: 'code',
+    title: DAY3_IMPLEMENTATION_WRAP_UP_TITLE,
+    description: DAY3_IMPLEMENTATION_WRAP_UP_DESCRIPTION,
+  };
+}

--- a/tests/e2e/flow-qa/candidate-day3.spec.ts
+++ b/tests/e2e/flow-qa/candidate-day3.spec.ts
@@ -19,8 +19,9 @@ test.describe('Candidate Day 3 Flow', () => {
         id: 3,
         dayIndex: 3,
         type: 'code',
-        title: 'Debug and finalize',
-        description: 'Fix bugs and finalize.',
+        title: 'Implementation Wrap-Up',
+        description:
+          'Continue in the same Codespace and repository from Day 2.',
       }),
       nextTaskAfterSubmit: makeCandidateTask({
         id: 4,

--- a/tests/unit/features/candidate/tasks/CandidateTaskProgress.test.tsx
+++ b/tests/unit/features/candidate/tasks/CandidateTaskProgress.test.tsx
@@ -9,12 +9,12 @@ describe('CandidateTaskProgress', () => {
         completedCount={2}
         currentDayIndex={3}
         totalDays={5}
-        currentTaskTitle="Fix bugs"
+        currentTaskTitle="Implementation Wrap-Up"
       />,
     );
 
     expect(screen.getByText(/2\/5 complete/)).toBeInTheDocument();
-    expect(screen.getByText('Fix bugs')).toBeInTheDocument();
+    expect(screen.getByText('Implementation Wrap-Up')).toBeInTheDocument();
     expect(screen.getAllByText('Completed').length).toBeGreaterThan(0);
     expect(screen.getByText('In progress')).toBeInTheDocument();
     expect(screen.getByText(/Complete Day 3 first/)).toBeInTheDocument();

--- a/tests/unit/features/candidate/tasks/CandidateTaskView.day3ImplementationWrapUp.test.tsx
+++ b/tests/unit/features/candidate/tasks/CandidateTaskView.day3ImplementationWrapUp.test.tsx
@@ -1,0 +1,59 @@
+import { screen } from '@testing-library/react';
+import {
+  baseTask,
+  primeDraftMocks,
+  renderTaskView,
+} from './CandidateTaskView.testlib';
+
+describe('CandidateTaskView Day 3 implementation wrap-up', () => {
+  beforeEach(() => {
+    primeDraftMocks();
+  });
+
+  it('reframes stale Day 3 task data as same-repo implementation wrap-up', () => {
+    renderTaskView({
+      task: {
+        ...baseTask,
+        id: 3,
+        dayIndex: 3,
+        type: 'debug',
+        title: ['Debugging', 'Exercise'].join(' '),
+        description: [
+          'Debug the existing',
+          'codebase from the',
+          ['tem', 'plate.'].join(''),
+        ].join(' '),
+      },
+    });
+
+    expect(screen.getByText('Implementation Wrap-Up')).toBeInTheDocument();
+    expect(
+      screen.getByText(/same GitHub Codespace and repository/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/same repository as Day 2/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Codespace-only/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/finish the core build/i)).toBeInTheDocument();
+    expect(screen.getByText(/improve test coverage/i)).toBeInTheDocument();
+    expect(screen.getByText(/handle edge cases/i)).toBeInTheDocument();
+    expect(screen.getByText(/optimize where useful/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/documentation/i).length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole('button', { name: /submit implementation wrap-up/i }),
+    ).toBeInTheDocument();
+
+    const pageText = document.body.textContent ?? '';
+    expect(pageText).not.toMatch(/Day 3 • debug/i);
+    expect(pageText).not.toMatch(
+      new RegExp(['Debugging', 'Exercise'].join(' '), 'i'),
+    );
+    expect(pageText).not.toMatch(new RegExp(['tem', 'plate'].join(''), 'i'));
+    expect(pageText).not.toMatch(new RegExp(['pre', 'commit'].join(''), 'i'));
+    expect(pageText).not.toMatch(
+      new RegExp(['existing', 'codebase'].join(' '), 'i'),
+    );
+    expect(pageText).not.toMatch(
+      new RegExp(['offline', 'work'].join(' '), 'i'),
+    );
+    expect(pageText).not.toMatch(new RegExp(['local', 'work'].join(' '), 'i'));
+  });
+});

--- a/tests/unit/features/candidate/tasks/CandidateTaskView.submitFeedback.test.tsx
+++ b/tests/unit/features/candidate/tasks/CandidateTaskView.submitFeedback.test.tsx
@@ -44,7 +44,7 @@ describe('CandidateTaskView submit feedback statuses', () => {
     expect(screen.getByText(/Checkpoint recorded/i)).toBeInTheDocument();
   });
 
-  it('shows final feedback with commit fallback for day3 debug submit', async () => {
+  it('shows final feedback with commit fallback for Day 3 implementation wrap-up submit', async () => {
     const onSubmit = jest.fn().mockResolvedValue({
       submissionId: 301,
       taskId: 3,
@@ -66,7 +66,9 @@ describe('CandidateTaskView submit feedback statuses', () => {
       },
       onSubmit,
     });
-    fireEvent.click(screen.getByRole('button', { name: /submit & continue/i }));
+    fireEvent.click(
+      screen.getByRole('button', { name: /submit implementation wrap-up/i }),
+    );
     await waitFor(() =>
       expect(screen.getByText(/Final recorded/i)).toBeInTheDocument(),
     );

--- a/tests/unit/features/candidate/tasks/components/TaskActions.test.tsx
+++ b/tests/unit/features/candidate/tasks/components/TaskActions.test.tsx
@@ -90,4 +90,20 @@ describe('TaskActions', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
+
+  it('allows a custom idle submit label', () => {
+    render(
+      <TaskActions
+        isTextTask={false}
+        displayStatus="idle"
+        disabled={false}
+        onSubmit={jest.fn()}
+        submitLabel="Submit Implementation Wrap-Up"
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: /submit implementation wrap-up/i }),
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

- Reframed Day 3 candidate UI from stale debugging exercise language to `Implementation Wrap-Up`.
- Normalized stale Day 3 backend task copy client-side so candidate-facing UI always shows the correct v4 from-scratch model.
- Preserved same Codespace/repository continuation from Day 2.
- Preserved existing submit/final SHA behavior.
- Added/updated focused tests for Day 3 copy, CTA, stale `debug` leakage, and submit feedback.

## Product Behavior

- Day 3 now shows `Implementation Wrap-Up`.
- Day 3 displays safe task type/copy instead of stale `debug`.
- Day 3 guides candidates to finish the build, improve tests, handle edge cases, optimize, document, and prepare for handoff.
- Day 3 reinforces Codespace-only implementation work.
- Day 3 submit uses `Submit Implementation Wrap-Up`.
- Progress remains X/5.

## Files Changed

- `src/features/candidate/tasks/utils/day3ImplementationWrapUpUtils.ts`
- `src/features/candidate/session/api/tasksNormalizeApi.ts`
- `src/features/candidate/session/utils/taskTransformsUtils.ts`
- `src/features/candidate/tasks/CandidateTaskViewInner.tsx`
- `src/features/candidate/tasks/components/TaskActions.tsx`
- `src/features/candidate/tasks/components/TaskWorkArea.tsx`
- `src/features/candidate/tasks/components/progress/daySummaries.ts`
- `tests/e2e/flow-qa/candidate-day3.spec.ts`
- `tests/unit/features/candidate/tasks/CandidateTaskProgress.test.tsx`
- `tests/unit/features/candidate/tasks/components/TaskActions.test.tsx`
- `tests/unit/features/candidate/tasks/CandidateTaskView.day3ImplementationWrapUp.test.tsx`
- `tests/unit/features/candidate/tasks/CandidateTaskView.submitFeedback.test.tsx`

## QA Evidence

### Environment

Backend:

- PASS `./runBackend.sh migrate`
- PASS `./runBackend.sh bootstrap-local`
- Runtime: `WINOE_SCENARIO_GENERATION_RUNTIME_MODE=demo WINOE_DEMO_MODE=1 ./runBackend.sh`

Frontend:

- Runtime: `./runFrontend.sh`

URLs:

- Frontend: `http://localhost:3000`
- Backend: `http://localhost:8000`

Health:

- PASS backend `/health`
- PASS frontend `/api/health`

Browser/tool:

- Playwright Chromium

### Account / Session

- Candidate account used: `robiemelaku@gmail.com`
- Talent Partner account used for local Trial API setup: `robel.kebede@bison.howard.edu`
- QA Trial: `Issue 184 Day 3 QA Trial Demo`
- Trial id: `3`
- Candidate session id: `1`

### Acceptance Criteria Evidence

AC1 Day 3 title: PASS

- Visible text: `Day 3 • code`
- Visible title: `Implementation Wrap-Up`
- No `Debugging Exercise`

AC2 same Codespace/repo: PASS

- Day 2 and Day 3 both showed repo `winoe-ai-repos/winoe-ws-1`
- Day 2 and Day 3 both showed Codespace `https://vigilant-orbit-jjwrrq6r467j2j7ww.github.dev`

AC3 wrap-up guidance: PASS

- Copy includes finish core build, improve test coverage, handle edge cases, optimize, add/improve documentation, and prepare for handoff.

AC4 Codespace-only constraints: PASS

- Visible copy includes `Day 2 and Day 3 implementation work must happen in GitHub Codespaces only`
- Visible copy includes `All coding work must happen inside the Codespace`

AC5 submit/final SHA behavior: PASS

- Day 3 submit returned `finalSha: "68b2650911ea1dedd050c2360e34096b74f3dc23"`
- Progress advanced to `3/5`

AC6 forbidden terminology absent: PASS for candidate-facing Day 3 DOM

- DOM scan found none of the forbidden Day 3 terms.
- Code scan found only internal/test compatibility occurrences.

AC7 5-day Trial framing: PASS

- UI showed `2/5 complete` before Day 3 submit.
- UI showed `3/5 complete` after Day 3 submit.
- No X/10 task framing.

### QA Artifacts

- `/tmp/winoe-issue-184-day3-qa/09-day3-active-ui.png`
- `/tmp/winoe-issue-184-day3-qa/10-day3-after-submit.png`
- `/tmp/winoe-issue-184-day3-qa/day3-active-network-responses.json`
- `/tmp/winoe-issue-184-day3-qa/day3-submit-responses.json`

## Automated Checks

- PASS `npm test -- CandidateTaskView.submitFeedback.test.tsx --runInBand`
- PASS `npm test -- CandidateTaskView.day3ImplementationWrapUp.test.tsx --runInBand`
- PASS `npm run lint`
- PASS `npm run typecheck`
- PASS `npm run lint:prettier`
- PASS `./precommit.sh`
  - 500 Jest suites passed
  - 1552 tests passed
  - coverage gate passed
  - typecheck passed
  - production build passed

## Risk / Rollback

- Risk is low.
- The frontend still accepts stale backend Day 3 payloads, including `type: "debug"`, but normalizes candidate-facing Day 3 display to the correct Implementation Wrap-Up model.
- No backend contract changes.
- Existing final SHA behavior preserved.
- Rollback: revert the Day 3 normalization/copy changes and test updates.

Fixes #184
