### PR TITLE
Stabilize Winoe Report page with dimensional sub-scores, Evidence Trail drill-down, and persona compliance

### DIFF
--- a/pr.md
+++ b/pr.md
@@ -1,168 +1,199 @@
-# Complete Day 4 Handoff + Demo upload flow
+# Stabilize Winoe Report page with dimensional sub-scores, Evidence Trail drill-down, and persona compliance
 
 ## Summary
 
-This PR completes the Day 4 candidate Handoff + Demo UI for issue #185.
+This PR stabilizes the Talent Partner Winoe Report page into a demo-ready artifact for issue #188.
 
-Core implementation:
+It delivers the full report experience expected for YC-demo readiness:
 
-- Max 15-minute demo video duration validation before upload.
-- Browser preview before finalization.
-- Resubmit flow before cutoff, with the latest valid submission used.
-- Optional supplemental materials upload through the backend signed URL flow.
-- Transcript status rendering for not-started, processing, ready, and failed states.
-- Day 4 9 AM-5 PM local window messaging and countdown.
-- Handoff + Demo terminology cleanup.
-- Backend endpoint alignment from stale `/presentation/upload/*` paths to current `/handoff/*` paths.
-- Countdown fallback from `currentWindow.windowEndAt` when `currentTask.cutoffAt` is unavailable.
+- prominent Winoe Score hero
+- canonical dimensional sub-scores
+- from-scratch dimensions visible
+- Evidence Trail drill-down
+- per-day scores
+- reviewer sub-agent summaries
+- persona-compliant narrative language
+- print-to-PDF support
+- evidence-first recommendation language
+- backend evidence linkage preservation
 
-## Product / Terminology Notes
+The report now reads as a trustworthy evidence review surface rather than a thin placeholder view.
 
-User-facing copy follows Winoe AI terminology:
+## Product / UX Changes
 
-- Trial
-- Candidate
-- Handoff + Demo
-- demo video
-- supplemental materials
-- Evidence Trail
-- Winoe Score / Winoe Report only where relevant
+- Winoe Score now displays prominently as `X / 100`.
+- Dimensional breakdown always includes the canonical from-scratch dimensions:
+  - Project scaffolding quality
+  - Architectural coherence
+  - Development process
+  - Code quality
+  - Testing discipline
+  - Communication / Handoff + Demo
+  - Reflection & self-awareness
+- Dimension cards are clickable and keyboard-accessible.
+- The drill-down panel shows linked Evidence Trail artifacts for each selected dimension.
+- Dimensions without returned artifacts show honest empty states instead of fabricated content.
+- Per-day scores show Day 1 through Day 5 with correct labels.
+- Day 4 user-facing copy says `Handoff + Demo`.
+- Reviewer sub-agent summaries are visible in the report.
+- The Winoe narrative is evidence-first and non-determinative.
+- The print-to-PDF layout is demo-safe.
 
-Touched candidate-facing Day 4 surfaces avoid retired terms:
+## Backend Changes
 
-- presentation
-- recruiter
-- simulation
-- Fit Profile
-- Fit Score
-- Tenon
-- SimuHire
-- template
-- starter code
-- precommit
-- Specializor
-- existing codebase
-- offline/local work
+Real QA initially failed because backend evidence sanitization stripped linkage fields needed for frontend association.
 
-Backend route/function names or internal component names may still have legacy words only where they are not candidate-facing and are outside this issue's scope.
+Root cause:
 
-## Acceptance Criteria Checklist
+- Evidence artifacts existed in the DB and in report composition.
+- The backend report composer/schema stripped the fields needed by the frontend to map evidence into dimensions.
+- This caused all dimensions to render `0 linked artifacts`.
 
-- [x] Video upload with max 15-minute duration enforcement
-- [x] Preview capability before final submission
-- [x] Resubmit allowed until Day 4 cutoff, with most recent submission used
-- [x] Optional supplemental materials upload
-- [x] Transcript processing status indicator
-- [x] All copy uses Handoff + Demo, not presentation, in touched Day 4 candidate-facing surfaces
-- [x] Day 4 window: 9 AM-5 PM local with countdown
+Backend fix:
+
+- Preserve evidence linkage fields in the Winoe Report API payload:
+  - `dimensionKey`
+  - `dimensionLabel`
+  - `dayLabel`
+  - `sourceLabel`
+  - `label`
+  - `title`
+  - `description`
+  - `anchor`
+- Extend the backend Winoe Report evidence schema.
+- Add backend tests proving evidence linkage survives the sanitizer/composer/API shape.
+
+## Frontend Changes
+
+- Report normalization now handles older and newer payload aliases.
+- Explicit backend dimensions override derived dimensions when both are present.
+- Derived day-level rubric and evidence fill gaps where the backend response is partial.
+- Canonical fallback dimensions remain visible with truthful pending/empty states.
+- Evidence rendering supports:
+  - commits
+  - commit ranges
+  - docs
+  - transcript timestamps
+  - file timelines
+  - code structure
+  - tests
+  - coverage
+  - reflection excerpts
+  - reviewer excerpts
+- Deterministic recommendation helpers were removed and replaced with evidence-language formatting.
+- Candidate compare row recommendation copy now uses evidence-language copy.
+
+## Persona / Terminology Compliance
+
+Confirmed user-facing copy avoids these retired or disallowed terms:
+
+- `Tenon`
+- `SimuHire`
+- `recruiter`
+- `simulation`
+- `Fit Profile`
+- `Fit Score`
+- `template`
+- `precommit`
+- `Specializor`
+
+Confirmed the UI does not use deterministic recommendation labels like:
+
+- `Hire`
+- `Reject`
+- `Pass`
+- `Fail`
+- `Proceed`
+- `Do not proceed`
+- `Recommended hire`
+- `Not recommended`
+
+Confirmed the UI uses the intended Winoe vocabulary:
+
+- `Winoe`
+- `Winoe AI`
+- `Trial`
+- `Winoe Report`
+- `Winoe Score`
+- `Evidence Trail`
+- `Talent Partner`
+- `Handoff + Demo`
 
 ## QA Evidence
 
-### Manual QA Environment
+### Local E2E QA
 
-- Frontend branch/commit: `feature/complete-day4-handoff-demo-ui-video-upload-preview-resubmit-and-transcript-status`, base `7513383c2acd20b958d784afa25b6301ddd840f1` plus local QA fixes
-- Backend branch/commit: `main`, `7cefc1f213b1b5e0b8b547ad615c8b390d92eef3`
 - Frontend URL: `http://localhost:3000`
 - Backend URL: `http://localhost:8000`
-- Browser: Playwright Chromium, headless
-- Backend startup:
-  - `bash scripts/local_qa_backend.sh migrate`
-  - `bash scripts/local_qa_backend.sh`
-  - `curl -sS http://localhost:8000/health`
-  - `curl -sS http://localhost:8000/ready`
-- Frontend startup:
-  - `./runFrontend.sh`
-- Note: `FRONTEND_QA_PLAYBOOK.md` was not found under `/Users/robelmelaku/Desktop/Winoe-AI`; README/run scripts were used as fallback.
+- Route tested: `http://localhost:3000/dashboard/trials/1/candidates/1/winoe-report`
+- Account used: `robel.kebede@bison.howard.edu`
+- Auth confirmed via `/api/debug/auth`
+  - `roles: ["talent_partner"]`
+  - `permissions: ["talent_partner:access"]`
+- Onboarding completed for:
+  - `companyId: 1`
+  - `companyName: "Winoe Demo Company"`
+- Live payload endpoint: `/api/candidate_sessions/1/winoe_report`
+- Live payload status: `ready`
+- Evidence linkage present in payload and rendered in UI.
+- Winoe Score observed: `81 / 100`
+- QA target note: the original Iteration 5 note referenced `trial 2`, but the current local seed snapshot contains the valid ready report at `trial 1 / candidate session 1`.
 
-### Manual QA Test Data
+### Artifacts
 
-- Candidate account used: `robiemelaku@gmail.com`
-- Talent Partner local DB user: `robel.kebede@bison.howard.edu`
-- Trial/session: Trial `13`, candidate session `12`, token `issue185-day4-qa-final-20260428`, Day 4 task `64`
-- Setup: local backend DB setup created Trial, CandidateSession, Day 1-3 submissions, Day 4 windows, and transcript/window states for scenario coverage
-- Media fixtures:
-  - `/tmp/winoe-day4-valid-demo.mp4` - `5.000000s`
-  - `/tmp/winoe-day4-valid-demo-2.mp4` - `6.000000s`
-  - `/tmp/winoe-day4-too-long-demo.mp4` - `901.000000s`
-  - `/tmp/winoe-day4-architecture-notes.pdf` - valid 1-page PDF
+```text
+test-results/iteration-7-winoe-report.png
+test-results/iteration-7-evidence-drilldown.png
+test-results/iteration-7-winoe-report.pdf
+test-results/iteration-7-browser-qa.json
+```
 
-### Manual QA Results
+## Validation Commands
 
-- PASS: Candidate reached Day 4 Handoff + Demo open state.
-- PASS: Long 901s video was blocked before upload/init.
-- PASS: Valid video uploaded after browser duration validation.
-- PASS: Preview appeared before finalization.
-- PASS: Supplemental PDF uploaded via signed URL and persisted.
-- PASS: Resubmit before cutoff worked; latest DB submission pointed to second recording.
-- PASS: Transcript not-started, processing, ready, and failed states rendered.
-- PASS: Closed and before-open states blocked upload/resubmit.
-- PASS: Runtime terminology scan was clean.
-- PASS: Candidate progress remained X/5, not X/10.
-- PASS: No failed network requests or console errors during the final happy path.
+### Frontend
 
-Key backend/network evidence:
+```bash
+npm run lint
+npm run typecheck
+npx jest --runInBand tests/unit/features/talent-partner/winoe-report tests/integration/talent-partner/trials/candidates/WinoeReportPage.rendering.test.tsx tests/integration/talent-partner/trials/candidates/WinoeReportPage.interactions.test.tsx tests/integration/talent-partner/trials/candidates/WinoeReportPage.printProof.test.tsx tests/integration/talent-partner/trials/candidates/WinoeReportPage.errorStates.test.tsx tests/integration/talent-partner/trials/candidates/WinoeReportPage.pollingGenerate.test.tsx
+npx jest --runInBand tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.rows.test.tsx tests/integration/talent-partner/TrialDetailPageClient.compareStates.test.tsx
+./precommit.sh
+```
 
-- Demo init body: `{"contentType":"video/mp4","sizeBytes":5992,"filename":"winoe-day4-valid-demo.mp4","durationSeconds":5}`
-- Demo signed upload: `PUT http://localhost:8000/api/recordings/storage/fake/upload?...durationSeconds=5` -> `204`
-- Demo complete: `POST /api/backend/tasks/64/handoff/upload/complete`, body `{"recordingId":"rec_17"}` -> `200`
-- Supplemental init body: `{"contentType":"application/pdf","sizeBytes":378,"filename":"winoe-day4-architecture-notes.pdf","assetType":"supplemental"}`
-- Supplemental signed upload -> `204`
-- Supplemental complete: `{"recordingId":"rec_18"}` -> `200`
-- Resubmit complete: `{"recordingId":"rec_19"}` -> `200`
-- Latest DB evidence: recordings `17` and `19`; task submission points to `19`; supplemental material `18` persisted
+Results:
 
-Screenshots/evidence paths:
+- `npm run lint` — pass
+- `npm run typecheck` — pass
+- Winoe Report focused tests — pass
+- Compare regression tests — failed once, then passed on rerun in a fresh Jest process
+- `./precommit.sh` — pass
+- Full frontend gate — `502/502` test suites passed, `1565/1565` tests passed, build passed
 
-- `qa_verifications/issue185/final-a-open.png`
-- `qa_verifications/issue185/final-b-invalid.png`
-- `qa_verifications/issue185/final-c-preview.png`
-- `qa_verifications/issue185/final-d-after-finalize.png`
-- `qa_verifications/issue185/final-e-after-resubmit.png`
-- `qa_verifications/issue185/final-f-processing.png`
-- `qa_verifications/issue185/final-f-ready.png`
-- `qa_verifications/issue185/final-f-failed.png`
-- `qa_verifications/issue185/final-g-closed.png`
-- `qa_verifications/issue185/final-g-before-open.png`
-- `qa_verifications/issue185/final-countdown-after-fix.png`
-- `qa_verifications/issue185/final-manual-qa-evidence.json`
+### Backend
 
-## Bugs Found and Fixed During QA
+```bash
+set -a && source .env && set +a && PYTHONPATH=. ./.venv/bin/pytest -q --no-cov tests/evaluations/services/test_evaluations_winoe_report_composer_sanitize_evidence_service.py tests/evaluations/services/test_evaluations_winoe_report_composer_service.py tests/shared/http/routes/test_shared_http_routes_winoe_report_and_jobs_routes.py
 
-1. BLOCKING - fixed
-   - Frontend was calling stale `/presentation/upload/*` endpoints.
-   - Backend returned 404 for status/init.
-   - Fixed to current `/handoff/status` and `/handoff/upload/{init,complete}` endpoints.
+set -a && source .env && set +a && PYTHONPATH=. ./.venv/bin/pytest -q --no-cov tests/evaluations/services/test_evaluations_winoe_report_api_fetch_service.py
+```
 
-2. NON-BLOCKING - fixed
-   - Completed-review copy said `Demo presentation recording`.
-   - Changed to `Handoff + Demo recording`.
+Results:
 
-3. NON-BLOCKING - fixed
-   - Handoff panel did not use `currentWindow.windowEndAt` when `currentTask.cutoffAt` was null.
-   - Added fallback during task transform so countdown appears from the backend window end.
+- backend Winoe Report composer/sanitizer/routes tests — pass
+- backend API fetch service tests — pass
+- `./runBackend.sh migrate` — pass
+- `./runBackend.sh bootstrap-local` — pass
+- `./runBackend.sh` — pass
+- `curl -i http://localhost:8000/health` — pass
+- `curl -i http://localhost:8000/ready` — pass
 
-## Backend Boundary / Risks
+## Risks / Notes
 
-- Backend #290 remains the broader media/transcript pipeline dependency, but this frontend now uses the available backend signed-upload contract for demo and supplemental materials.
-- Backend #287 enforcement is backend-side. Frontend renders failed transcript status and retry guidance; it does not own Winoe scoring enforcement.
-- QA set transcript processing/ready/failed states through local DB setup to cover state rendering, then verified through the real backend/frontend.
+- The compare regression test showed one transient flake, then passed on rerun and passed in full precommit.
+- Local seed data currently validates against `trial 1 / candidate session 1`, not stale `trial 2`.
+- Backend evidence linkage is preserved now, but future backend taxonomy changes may require frontend alias updates.
+- No remaining blocker for #188.
 
-## Automated Validation
+## Ready Status
 
-- PASS `npm test -- --runInBand tests/unit/features/candidate/tasks/handoff`
-- PASS `npm test -- --runInBand tests/unit/features/candidate/tasks/utils/day5Reflection.test.ts`
-- PASS `npm run typecheck`
-- PASS `npm run lint:eslint`
-- PASS `npm run lint:prettier`
-- PASS `npm run build`
-- PASS `./precommit.sh`
-
-Precommit summary:
-
-- 501 suites passed
-- 1558 tests passed
-- Coverage check passed
-- Typecheck passed
-- Build passed
-
-QA PASS — issue #185 is ready for PR review.
+Fixes #188

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -59,4 +59,22 @@ body {
     break-inside: avoid;
     page-break-inside: avoid;
   }
+
+  body.winoe-report-print-mode .winoe-report-hero {
+    background: #fff !important;
+    color: #111827 !important;
+    border-color: #d1d5db !important;
+  }
+
+  body.winoe-report-print-mode .winoe-report-hero *,
+  body.winoe-report-print-mode .winoe-report-hero *::before,
+  body.winoe-report-print-mode .winoe-report-hero *::after {
+    background: transparent !important;
+    color: #111827 !important;
+    box-shadow: none !important;
+  }
+
+  body.winoe-report-print-mode .winoe-report-hero [class*='border'] {
+    border-color: #d1d5db !important;
+  }
 }

--- a/src/features/talent-partner/trial-management/detail/components/CandidateCompareTableRow.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/CandidateCompareTableRow.tsx
@@ -5,7 +5,7 @@ import Button from '@/shared/ui/Button';
 import { StatusPill } from '@/shared/ui/StatusPill';
 import { statusMeta } from '@/shared/status/statusMeta';
 import {
-  formatRecommendationLabel,
+  formatRecommendationEvidenceLanguage,
   formatScorePercent,
 } from '@/features/talent-partner/winoe-report/winoeReportFormatting';
 import type { CandidateCompareRow } from '@/features/talent-partner/api/candidatesCompareApi';
@@ -64,7 +64,7 @@ export function CandidateCompareTableRow({
       </td>
       <td className="px-4 py-3 align-top text-gray-700">
         {row.recommendation
-          ? formatRecommendationLabel(row.recommendation)
+          ? formatRecommendationEvidenceLanguage(row.recommendation)
           : '—'}
       </td>
       <td className="px-4 py-3 align-top">

--- a/src/features/talent-partner/winoe-report/DayScoreCard.tsx
+++ b/src/features/talent-partner/winoe-report/DayScoreCard.tsx
@@ -2,10 +2,13 @@ import { Card } from '@/shared/ui/Card';
 import type { WinoeReportDayScore } from './winoeReport.types';
 import { EvidenceList } from './EvidenceList';
 import {
+  formatCountLabel,
+  formatStatusLabel,
   formatRubricKey,
   formatRubricValue,
-  formatScorePercent,
+  formatScoreOutOf100,
 } from './winoeReportFormatting';
+import { formatDayLabel } from './winoeReport.catalog';
 
 type DayScoreCardProps = {
   dayScore: WinoeReportDayScore;
@@ -15,50 +18,93 @@ export function DayScoreCard({ dayScore }: DayScoreCardProps) {
   const rubricRows = Object.entries(dayScore.rubricBreakdown);
   const isAiEvaluationDisabled = !dayScore.aiEvaluationEnabled;
   const isNotEvaluated = dayScore.evaluationStatus === 'not_evaluated';
+  const dayLabel = dayScore.dayLabel ?? formatDayLabel(dayScore.dayIndex);
+  const scoreLabel =
+    isAiEvaluationDisabled || isNotEvaluated
+      ? 'Score pending'
+      : formatScoreOutOf100(dayScore.score);
 
   return (
-    <Card className="winoe-report-avoid-break space-y-3">
-      <div className="flex items-center justify-between gap-3">
-        <h2 className="text-lg font-semibold text-gray-900">
-          Day {dayScore.dayIndex}
-        </h2>
+    <Card className="winoe-report-avoid-break space-y-4 border-slate-200 bg-white">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Day {dayScore.dayIndex}
+          </p>
+          <h2 className="mt-1 text-lg font-semibold text-slate-950">
+            {dayLabel}
+          </h2>
+        </div>
         <div
           className={
-            isAiEvaluationDisabled
-              ? 'rounded border border-gray-300 bg-gray-100 px-3 py-1 text-sm font-semibold text-gray-700'
-              : isNotEvaluated
-                ? 'rounded border border-gray-300 bg-gray-100 px-3 py-1 text-sm font-semibold text-gray-700'
-                : 'rounded border border-blue-200 bg-blue-50 px-3 py-1 text-sm font-semibold text-blue-700'
+            isAiEvaluationDisabled || isNotEvaluated
+              ? 'rounded-full border border-slate-300 bg-slate-100 px-3 py-1 text-sm font-semibold text-slate-700'
+              : 'rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm font-semibold text-blue-800'
           }
         >
           {isAiEvaluationDisabled
-            ? 'AI Evaluation: Disabled'
+            ? 'AI evaluation disabled'
             : isNotEvaluated
               ? 'Not evaluated'
-              : formatScorePercent(dayScore.score ?? 0)}
+              : scoreLabel}
         </div>
       </div>
 
+      <div className="flex flex-wrap gap-2 text-xs text-slate-600">
+        <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-1">
+          {formatStatusLabel(dayScore.statusLabel ?? dayScore.evaluationStatus)}
+        </span>
+        {dayScore.reviewerSummary ? (
+          <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-1">
+            Reviewer summary available
+          </span>
+        ) : null}
+        <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-1">
+          {formatCountLabel(dayScore.evidence.length, 'linked artifact')}
+        </span>
+      </div>
+
       {isAiEvaluationDisabled ? (
-        <div className="space-y-1 text-sm text-gray-700">
+        <div className="space-y-1 rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
           <p>AI evaluation disabled for this day.</p>
-          <p className="font-medium text-gray-800">Human review required.</p>
+          <p className="font-medium text-slate-900">Human review required.</p>
         </div>
       ) : null}
 
       {!isAiEvaluationDisabled && isNotEvaluated ? (
-        <p className="text-sm text-gray-600">
-          This day was not evaluated and does not affect overall winoe score.
+        <p className="text-sm text-slate-600">
+          This day was not evaluated and does not affect the overall Winoe
+          Score.
         </p>
+      ) : null}
+
+      {dayScore.summary ? (
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+          <p className="text-sm font-semibold text-slate-950">Day summary</p>
+          <p className="mt-2 text-sm leading-6 text-slate-700">
+            {dayScore.summary}
+          </p>
+        </div>
+      ) : null}
+
+      {dayScore.reviewerSummary ? (
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+          <p className="text-sm font-semibold text-slate-950">
+            Sub-agent summary
+          </p>
+          <p className="mt-2 text-sm leading-6 text-slate-700">
+            {dayScore.reviewerSummary}
+          </p>
+        </div>
       ) : null}
 
       {!isAiEvaluationDisabled ? (
         <div>
-          <h3 className="text-sm font-semibold text-gray-900">
+          <h3 className="text-sm font-semibold text-slate-950">
             Rubric Breakdown
           </h3>
           {rubricRows.length === 0 ? (
-            <p className="mt-1 text-sm text-gray-500">
+            <p className="mt-1 text-sm text-slate-500">
               No rubric breakdown provided.
             </p>
           ) : (
@@ -68,10 +114,10 @@ export function DayScoreCard({ dayScore }: DayScoreCardProps) {
                   key={key}
                   className="grid grid-cols-[minmax(120px,1fr)_2fr] gap-2"
                 >
-                  <dt className="text-xs font-medium text-gray-600">
+                  <dt className="text-xs font-medium text-slate-600">
                     {formatRubricKey(key)}
                   </dt>
-                  <dd className="text-sm text-gray-800">
+                  <dd className="text-sm text-slate-800">
                     {formatRubricValue(value)}
                   </dd>
                 </div>
@@ -83,11 +129,14 @@ export function DayScoreCard({ dayScore }: DayScoreCardProps) {
 
       {!isAiEvaluationDisabled ? (
         <div>
-          <h3 className="text-sm font-semibold text-gray-900">
+          <h3 className="text-sm font-semibold text-slate-950">
             Evidence Trail
           </h3>
           <div className="mt-2">
-            <EvidenceList evidence={dayScore.evidence} />
+            <EvidenceList
+              evidence={dayScore.evidence}
+              emptyMessage="No linked artifacts were returned for this day yet."
+            />
           </div>
         </div>
       ) : null}

--- a/src/features/talent-partner/winoe-report/EvidenceList.tsx
+++ b/src/features/talent-partner/winoe-report/EvidenceList.tsx
@@ -4,74 +4,88 @@ import {
   printableEvidenceUrl,
   safeExternalUrl,
 } from './winoeReportFormatting';
+import { formatEvidenceKindLabel } from './winoeReport.catalog';
 
 type EvidenceListProps = {
   evidence: WinoeReportEvidence[];
+  emptyMessage?: string;
 };
 
-function formatEvidenceTitle(kind: string): string {
-  const normalized = kind.trim().toLowerCase();
-  if (normalized === 'commit') return 'Commit Evidence';
-  if (normalized === 'diff') return 'Diff Evidence';
-  if (normalized === 'test') return 'Test Evidence';
-  if (normalized === 'transcript') return 'Transcript Evidence';
-  return `${kind.replace(/[_-]/g, ' ')} evidence`;
-}
-
-export function EvidenceList({ evidence }: EvidenceListProps) {
+export function EvidenceList({
+  evidence,
+  emptyMessage = 'No linked artifacts were returned for this dimension yet.',
+}: EvidenceListProps) {
   if (evidence.length === 0) {
-    return (
-      <p className="text-sm text-gray-500">
-        No evidence recorded for this day.
-      </p>
-    );
+    return <p className="text-sm text-slate-600">{emptyMessage}</p>;
   }
 
   return (
-    <ul className="space-y-3">
+    <ul className="space-y-3" data-winoe-report-evidence-list="true">
       {evidence.map((item, index) => {
         const url = safeExternalUrl(item.url);
         const printableUrl = url ? printableEvidenceUrl(url) : null;
         const startLabel = formatTranscriptTime(item.startMs);
         const endLabel = formatTranscriptTime(item.endMs);
+        const evidenceLabel = formatEvidenceKindLabel(item.kind);
 
         return (
           <li
             key={`${item.kind}-${item.ref ?? 'evidence'}-${index}`}
-            className="rounded border border-gray-200 bg-gray-50 p-3"
+            className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
           >
-            <div className="text-sm font-semibold text-gray-900">
-              {formatEvidenceTitle(item.kind)}
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div>
+                <div className="text-sm font-semibold text-slate-950">
+                  {item.label ?? evidenceLabel}
+                </div>
+                {item.title ? (
+                  <div className="mt-1 text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
+                    {item.title}
+                  </div>
+                ) : null}
+              </div>
+              {item.dayLabel || item.sourceLabel ? (
+                <div className="rounded-full border border-slate-200 bg-slate-50 px-2 py-1 text-xs font-medium text-slate-700">
+                  {item.dayLabel ?? item.sourceLabel}
+                </div>
+              ) : null}
             </div>
-            {item.ref ? (
-              <p className="mt-1 break-all font-mono text-xs text-gray-600">
-                Ref: {item.ref}
+            {item.description ? (
+              <p className="mt-2 text-sm leading-6 text-slate-700">
+                {item.description}
               </p>
             ) : null}
             {item.excerpt ? (
-              <p className="mt-2 whitespace-pre-wrap text-sm text-gray-700">
+              <p className="mt-2 whitespace-pre-wrap text-sm text-slate-700">
                 {item.excerpt}
               </p>
             ) : null}
-            {startLabel || endLabel ? (
-              <p className="mt-2 text-xs text-gray-600">
-                Timestamp:{' '}
-                {startLabel && endLabel
-                  ? `${startLabel} - ${endLabel}`
-                  : (startLabel ?? endLabel)}
-              </p>
-            ) : null}
+            <div className="mt-3 flex flex-wrap gap-3 text-xs text-slate-500">
+              {item.ref ? (
+                <span className="break-all">Ref: {item.ref}</span>
+              ) : null}
+              {item.dayIndex ? <span>Day {item.dayIndex}</span> : null}
+              {startLabel || endLabel ? (
+                <span>
+                  Timestamp:{' '}
+                  {startLabel && endLabel
+                    ? `${startLabel} - ${endLabel}`
+                    : (startLabel ?? endLabel)}
+                </span>
+              ) : null}
+              {item.anchor ? <span>Anchor: {item.anchor}</span> : null}
+            </div>
             {url ? (
-              <div className="mt-2">
+              <div className="mt-3">
                 <a
                   href={url}
                   target="_blank"
                   rel="noreferrer noopener"
-                  className="text-sm text-blue-700 hover:underline"
+                  className="text-sm font-medium text-blue-700 hover:underline"
                 >
                   Open evidence link
                 </a>
-                <p className="mt-1 break-all font-mono text-xs text-gray-600">
+                <p className="mt-1 break-all font-mono text-xs text-slate-500">
                   URL: {printableUrl}
                 </p>
               </div>

--- a/src/features/talent-partner/winoe-report/WinoeDimensionBreakdown.tsx
+++ b/src/features/talent-partner/winoe-report/WinoeDimensionBreakdown.tsx
@@ -1,0 +1,142 @@
+import { useMemo, useState } from 'react';
+import { Card } from '@/shared/ui/Card';
+import type { WinoeReportDimension } from './winoeReport.types';
+import { EvidenceList } from './EvidenceList';
+import { formatCountLabel, formatScoreOutOf100 } from './winoeReportFormatting';
+
+type Props = {
+  dimensions: WinoeReportDimension[];
+};
+
+function dimensionScoreLabel(score: number | null): string {
+  return score === null ? 'Score pending' : formatScoreOutOf100(score);
+}
+
+export function WinoeDimensionBreakdown({ dimensions }: Props) {
+  const initialKey = dimensions[0]?.key ?? null;
+  const [selectedKey, setSelectedKey] = useState<string | null>(initialKey);
+
+  const selectedDimension = useMemo(() => {
+    if (!selectedKey) return dimensions[0] ?? null;
+    return (
+      dimensions.find((item) => item.key === selectedKey) ??
+      dimensions[0] ??
+      null
+    );
+  }, [dimensions, selectedKey]);
+
+  if (dimensions.length === 0) {
+    return (
+      <Card className="winoe-report-avoid-break border-slate-200 bg-white">
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold text-slate-950">
+            Dimensional sub-scores
+          </h2>
+          <p className="text-sm text-slate-600">
+            No dimensional sub-scores were returned yet.
+          </p>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-semibold tracking-tight text-slate-950">
+            Dimensional sub-scores
+          </h2>
+          <p className="mt-1 text-sm text-slate-600">
+            Select a dimension to inspect the linked Evidence Trail artifacts.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-3 lg:grid-cols-2 xl:grid-cols-3">
+        {dimensions.map((dimension) => {
+          const selected = selectedDimension?.key === dimension.key;
+          return (
+            <button
+              key={dimension.key}
+              type="button"
+              aria-pressed={selected}
+              onClick={() => setSelectedKey(dimension.key)}
+              className={[
+                'text-left rounded-2xl border p-4 transition',
+                selected
+                  ? 'border-blue-400 bg-blue-50 shadow-sm'
+                  : 'border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50',
+              ].join(' ')}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-slate-950">
+                    {dimension.label}
+                  </p>
+                  {dimension.description ? (
+                    <p className="mt-1 text-xs leading-5 text-slate-500">
+                      {dimension.description}
+                    </p>
+                  ) : null}
+                </div>
+                <div className="rounded-full border border-slate-200 bg-white px-3 py-1 text-sm font-semibold text-slate-900">
+                  {dimensionScoreLabel(dimension.score)}
+                </div>
+              </div>
+
+              <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-600">
+                <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-1">
+                  {formatCountLabel(dimension.evidenceCount, 'linked artifact')}
+                </span>
+                <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-1">
+                  {formatCountLabel(
+                    dimension.linkedArtifactCount,
+                    'artifact source',
+                  )}
+                </span>
+              </div>
+
+              <p className="mt-3 text-sm leading-6 text-slate-700">
+                {dimension.summary ??
+                  dimension.emptyStateMessage ??
+                  'No linked artifacts were returned for this dimension yet.'}
+              </p>
+            </button>
+          );
+        })}
+      </div>
+
+      {selectedDimension ? (
+        <Card className="winoe-report-avoid-break border-slate-200 bg-slate-50 shadow-none">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                Evidence Trail drill-down
+              </p>
+              <h3 className="mt-1 text-lg font-semibold text-slate-950">
+                {selectedDimension.label}
+              </h3>
+            </div>
+            <div className="rounded-full border border-slate-200 bg-white px-3 py-1 text-sm font-semibold text-slate-900">
+              {dimensionScoreLabel(selectedDimension.score)}
+            </div>
+          </div>
+
+          <p className="mt-3 text-sm leading-6 text-slate-700">
+            {selectedDimension.summary ??
+              selectedDimension.emptyStateMessage ??
+              'No linked artifacts were returned for this dimension yet.'}
+          </p>
+
+          <div className="mt-4">
+            <EvidenceList
+              evidence={selectedDimension.evidence}
+              emptyMessage={selectedDimension.emptyStateMessage ?? undefined}
+            />
+          </div>
+        </Card>
+      ) : null}
+    </section>
+  );
+}

--- a/src/features/talent-partner/winoe-report/WinoeReportPage.tsx
+++ b/src/features/talent-partner/winoe-report/WinoeReportPage.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useParams } from 'next/navigation';
-import { Card } from '@/shared/ui/Card';
 import { WinoeReportPageToolbar } from './WinoeReportPageToolbar';
 import { WinoeReportReadySection } from './WinoeReportReadySection';
 import { WinoeReportStatusPanel } from './WinoeReportStatusPanel';
 import { WinoeReportWarningBanner } from './WinoeReportWarningBanner';
+import { useWinoeReportContext } from './useWinoeReportContext';
 import { useWinoeReport } from './useWinoeReport';
 import { useWinoeReportPrintMode } from './useWinoeReportPrintMode';
 
@@ -13,6 +13,10 @@ export default function WinoeReportPage() {
   const params = useParams<{ id: string; candidateSessionId: string }>();
   const trialId = params.id;
   const candidateSessionId = params.candidateSessionId ?? '';
+  const { trialTitle, candidateName, candidateStatus } = useWinoeReportContext({
+    trialId,
+    candidateSessionId,
+  });
   const { state, loading, generatePending, generate, reload } =
     useWinoeReport(candidateSessionId);
   useWinoeReportPrintMode();
@@ -23,19 +27,16 @@ export default function WinoeReportPage() {
     <div className="winoe-report-print-root flex flex-col gap-4 py-8">
       <WinoeReportPageToolbar
         submissionsHref={submissionsHref}
+        candidateSessionId={candidateSessionId}
+        trialTitle={trialTitle}
+        candidateName={candidateName}
+        candidateStatus={candidateStatus}
+        reportStatus={state.status}
+        generatedAt={state.generatedAt}
         loading={loading}
         showPrint={state.status === 'ready'}
         onReload={() => void reload()}
       />
-
-      <Card className="winoe-report-avoid-break">
-        <h1 className="text-2xl font-semibold tracking-tight text-gray-900">
-          Winoe Report
-        </h1>
-        <p className="mt-1 text-sm text-gray-600">
-          Talent Partner report for candidate session {candidateSessionId}.
-        </p>
-      </Card>
 
       <WinoeReportWarningBanner warnings={state.warnings} />
 

--- a/src/features/talent-partner/winoe-report/WinoeReportPageToolbar.tsx
+++ b/src/features/talent-partner/winoe-report/WinoeReportPageToolbar.tsx
@@ -1,8 +1,16 @@
 import Link from 'next/link';
 import Button from '@/shared/ui/Button';
+import { Card } from '@/shared/ui/Card';
+import { formatStatusLabel, formatGeneratedAt } from './winoeReportFormatting';
 
 type Props = {
   submissionsHref: string;
+  candidateSessionId: string;
+  trialTitle: string;
+  candidateName: string | null;
+  candidateStatus: string | null;
+  reportStatus: string;
+  generatedAt: string | null;
   loading: boolean;
   showPrint: boolean;
   onReload: () => void;
@@ -10,36 +18,79 @@ type Props = {
 
 export function WinoeReportPageToolbar({
   submissionsHref,
+  candidateSessionId,
+  trialTitle,
+  candidateName,
+  candidateStatus,
+  reportStatus,
+  generatedAt,
   loading,
   showPrint,
   onReload,
 }: Props) {
   return (
-    <div
-      className="flex flex-wrap items-center justify-between gap-2"
-      data-winoe-report-no-print="true"
-    >
-      <Link
-        className="text-sm text-blue-600 hover:underline"
-        href={submissionsHref}
-      >
-        &larr; Back to submissions
-      </Link>
-      <div className="flex flex-wrap items-center gap-2">
-        <Button
-          variant="secondary"
-          size="sm"
-          onClick={onReload}
-          loading={loading}
+    <Card className="winoe-report-avoid-break border-slate-200 bg-slate-50/80 shadow-none">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Talent Partner artifact
+            </p>
+            <h1 className="mt-1 text-3xl font-semibold tracking-tight text-slate-950">
+              Winoe Report
+            </h1>
+            <p className="mt-2 text-sm text-slate-700">
+              {candidateName
+                ? candidateName
+                : `Candidate session ${candidateSessionId}`}{' '}
+              | {trialTitle}
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-2 text-xs font-medium text-slate-700">
+            <span className="rounded-full border border-slate-300 bg-white px-3 py-1">
+              Candidate session status: {formatStatusLabel(candidateStatus)}
+            </span>
+            <span className="rounded-full border border-slate-300 bg-white px-3 py-1">
+              Report status: {formatStatusLabel(reportStatus)}
+            </span>
+            {generatedAt ? (
+              <span className="rounded-full border border-slate-300 bg-white px-3 py-1">
+                Generated: {formatGeneratedAt(generatedAt)}
+              </span>
+            ) : null}
+          </div>
+        </div>
+
+        <div
+          className="flex flex-wrap items-center gap-2 lg:justify-end"
+          data-winoe-report-no-print="true"
         >
-          Reload
-        </Button>
-        {showPrint ? (
-          <Button variant="secondary" size="sm" onClick={() => window.print()}>
-            Print / Save PDF
+          <Link
+            className="text-sm text-blue-600 hover:underline"
+            href={submissionsHref}
+          >
+            &larr; Back to submissions
+          </Link>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={onReload}
+            loading={loading}
+          >
+            Reload
           </Button>
-        ) : null}
+          {showPrint ? (
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => window.print()}
+            >
+              Print / Save PDF
+            </Button>
+          ) : null}
+        </div>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/src/features/talent-partner/winoe-report/WinoeReportReadySection.tsx
+++ b/src/features/talent-partner/winoe-report/WinoeReportReadySection.tsx
@@ -1,6 +1,8 @@
 import { Card } from '@/shared/ui/Card';
 import { DayScoreCard } from './DayScoreCard';
+import { WinoeDimensionBreakdown } from './WinoeDimensionBreakdown';
 import { WinoeScoreHeader } from './WinoeScoreHeader';
+import { WinoeReviewerSummaries } from './WinoeReviewerSummaries';
 import type { WinoeReportReport } from './winoeReport.types';
 
 type Props = {
@@ -12,6 +14,8 @@ export function WinoeReportReadySection({ report, generatedAt }: Props) {
   const scoredDayCount = report.dayScores.filter(
     (item) => item.evaluationStatus === 'evaluated',
   ).length;
+  const narrativeAssessment =
+    report.narrativeAssessment ?? report.summary ?? report.personaVoice ?? null;
 
   return (
     <>
@@ -22,22 +26,39 @@ export function WinoeReportReadySection({ report, generatedAt }: Props) {
         calibrationText={report.calibrationText}
         generatedAt={generatedAt}
         disabledDayIndexes={report.disabledDayIndexes}
+        dimensionCount={report.dimensionScores.length}
         scoredDayCount={scoredDayCount}
+        narrativeAssessment={narrativeAssessment}
       />
-      {report.dayScores.length === 0 ? (
-        <Card className="winoe-report-avoid-break text-sm text-gray-600">
-          No day-level scores are available for this report.
-        </Card>
-      ) : (
-        <section className="space-y-3">
-          {report.dayScores.map((dayScore) => (
-            <DayScoreCard
-              key={`winoe-report-day-${dayScore.dayIndex}`}
-              dayScore={dayScore}
-            />
-          ))}
-        </section>
-      )}
+      <WinoeDimensionBreakdown dimensions={report.dimensionScores} />
+
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-xl font-semibold tracking-tight text-slate-950">
+            Per-day scores
+          </h2>
+          <p className="mt-1 text-sm text-slate-600">
+            Day 2 and Day 3 reflect the from-scratch build sequence, repository
+            structure, commit history, tests, and implementation progression.
+          </p>
+        </div>
+        {report.dayScores.length === 0 ? (
+          <Card className="winoe-report-avoid-break border-slate-200 text-sm text-slate-600">
+            No day-level scores are available for this report yet.
+          </Card>
+        ) : (
+          <div className="space-y-3">
+            {report.dayScores.map((dayScore) => (
+              <DayScoreCard
+                key={`winoe-report-day-${dayScore.dayIndex}`}
+                dayScore={dayScore}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <WinoeReviewerSummaries reviewerSummaries={report.reviewerSummaries} />
     </>
   );
 }

--- a/src/features/talent-partner/winoe-report/WinoeReviewerSummaries.tsx
+++ b/src/features/talent-partner/winoe-report/WinoeReviewerSummaries.tsx
@@ -1,0 +1,117 @@
+import { Card } from '@/shared/ui/Card';
+import type { WinoeReportReviewerSummary } from './winoeReport.types';
+import { EvidenceList } from './EvidenceList';
+import { formatCountLabel, formatScoreOutOf100 } from './winoeReportFormatting';
+import { formatDayLabel } from './winoeReport.catalog';
+
+type Props = {
+  reviewerSummaries: WinoeReportReviewerSummary[];
+};
+
+function formatDays(dayIndexes: number[]): string {
+  if (dayIndexes.length === 0) return 'All days';
+  return dayIndexes.map((dayIndex) => formatDayLabel(dayIndex)).join(', ');
+}
+
+export function WinoeReviewerSummaries({ reviewerSummaries }: Props) {
+  if (reviewerSummaries.length === 0) {
+    return (
+      <Card className="winoe-report-avoid-break border-slate-200 bg-white">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold tracking-tight text-slate-950">
+            Reviewer sub-agent summaries
+          </h2>
+          <p className="text-sm text-slate-600">
+            No reviewer summaries were returned yet.
+          </p>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <section className="space-y-3">
+      <div>
+        <h2 className="text-xl font-semibold tracking-tight text-slate-950">
+          Reviewer sub-agent summaries
+        </h2>
+        <p className="mt-1 text-sm text-slate-600">
+          Concise summary cards from the reviewer sub-agents and Winoe
+          synthesis.
+        </p>
+      </div>
+
+      <div className="grid gap-3 xl:grid-cols-2">
+        {reviewerSummaries.map((summary) => (
+          <Card
+            key={`${summary.reviewerName}-${summary.sourceLabel ?? 'summary'}`}
+            className="winoe-report-avoid-break border-slate-200 bg-white"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h3 className="text-base font-semibold text-slate-950">
+                  {summary.reviewerName}
+                </h3>
+                <p className="mt-1 text-xs uppercase tracking-[0.18em] text-slate-500">
+                  {formatDays(summary.dayIndexes)}
+                </p>
+              </div>
+              <div className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-sm font-semibold text-slate-900">
+                {summary.score === null
+                  ? 'Score pending'
+                  : formatScoreOutOf100(summary.score)}
+              </div>
+            </div>
+
+            {summary.summary ? (
+              <p className="mt-3 text-sm leading-6 text-slate-700">
+                {summary.summary}
+              </p>
+            ) : null}
+
+            {summary.strengths.length > 0 ? (
+              <div className="mt-3">
+                <p className="text-sm font-semibold text-slate-950">
+                  Key strengths
+                </p>
+                <ul className="mt-2 space-y-1 text-sm text-slate-700">
+                  {summary.strengths.map((strength) => (
+                    <li key={strength}>- {strength}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+
+            {summary.concerns.length > 0 ? (
+              <div className="mt-3">
+                <p className="text-sm font-semibold text-slate-950">
+                  Areas to follow up
+                </p>
+                <ul className="mt-2 space-y-1 text-sm text-slate-700">
+                  {summary.concerns.map((concern) => (
+                    <li key={concern}>- {concern}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+
+            <div className="mt-3">
+              <p className="text-sm font-semibold text-slate-950">
+                Linked artifacts
+              </p>
+              <p className="mt-1 text-xs text-slate-500">
+                {formatCountLabel(summary.evidence.length, 'artifact')}
+              </p>
+              <div className="mt-2">
+                <EvidenceList
+                  evidence={summary.evidence}
+                  emptyMessage="No linked artifacts were returned for this reviewer summary yet."
+                />
+              </div>
+            </div>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/features/talent-partner/winoe-report/WinoeScoreHeader.tsx
+++ b/src/features/talent-partner/winoe-report/WinoeScoreHeader.tsx
@@ -2,9 +2,9 @@ import { Card } from '@/shared/ui/Card';
 import {
   formatCalibrationText,
   formatGeneratedAt,
-  formatRecommendationLabel,
-  formatScorePercent,
-  recommendationToneClass,
+  formatRecommendationEvidenceLanguage,
+  formatNarrativeSummary,
+  formatScoreOutOf100,
 } from './winoeReportFormatting';
 
 type WinoeScoreHeaderProps = {
@@ -14,7 +14,9 @@ type WinoeScoreHeaderProps = {
   calibrationText: string | null;
   generatedAt: string | null;
   disabledDayIndexes: number[];
+  dimensionCount: number;
   scoredDayCount: number;
+  narrativeAssessment: string | null;
 };
 
 export function WinoeScoreHeader({
@@ -24,7 +26,9 @@ export function WinoeScoreHeader({
   calibrationText,
   generatedAt,
   disabledDayIndexes,
+  dimensionCount,
   scoredDayCount,
+  narrativeAssessment,
 }: WinoeScoreHeaderProps) {
   const generatedAtLabel = formatGeneratedAt(generatedAt);
   const calibration = formatCalibrationText(
@@ -32,37 +36,74 @@ export function WinoeScoreHeader({
     confidence,
     scoredDayCount,
   );
-  const recommendationLabel = formatRecommendationLabel(recommendation);
+  const recommendationLanguage =
+    formatRecommendationEvidenceLanguage(recommendation);
+  const narrative = formatNarrativeSummary(
+    overallWinoeScore,
+    narrativeAssessment ?? calibrationText,
+    recommendation,
+    dimensionCount,
+  );
 
   return (
-    <Card className="winoe-report-avoid-break space-y-3">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <p className="text-sm font-medium text-gray-600">
-            Overall Winoe Score
-          </p>
-          <p className="text-4xl font-bold tracking-tight text-gray-900">
-            {formatScorePercent(overallWinoeScore)}
-          </p>
+    <Card className="winoe-report-avoid-break winoe-report-hero border-slate-200 bg-gradient-to-br from-slate-950 to-slate-900 text-white shadow-none">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)] lg:items-start">
+        <div className="space-y-4">
+          <div>
+            <p className="text-sm font-medium uppercase tracking-[0.24em] text-slate-300">
+              Winoe Score
+            </p>
+            <p className="mt-2 text-6xl font-semibold tracking-tight text-white">
+              {formatScoreOutOf100(overallWinoeScore)}
+            </p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+            <p className="text-sm font-semibold text-slate-100">
+              Winoe&apos;s narrative assessment
+            </p>
+            <p className="mt-2 text-base leading-7 text-slate-100">
+              {narrative}
+            </p>
+            <p className="mt-3 text-sm leading-6 text-slate-300">
+              {recommendationLanguage}
+            </p>
+            <p className="mt-3 text-sm text-slate-300">
+              Winoe provides evidence, context, and calibration. The Talent
+              Partner decides.
+            </p>
+          </div>
         </div>
-        <div
-          className={`rounded border px-3 py-1 text-sm font-semibold ${recommendationToneClass(recommendation)}`}
-        >
-          {recommendationLabel}
+
+        <div className="space-y-4">
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+            <p className="text-sm font-semibold text-slate-100">
+              Evidence-backed calibration
+            </p>
+            <p className="mt-2 text-sm leading-6 text-slate-200">
+              {calibration}
+            </p>
+            <div className="mt-4 flex flex-wrap gap-2 text-xs text-slate-200">
+              <span className="rounded-full border border-white/10 bg-slate-900/80 px-3 py-1">
+                {dimensionCount} dimension{dimensionCount === 1 ? '' : 's'}{' '}
+                linked
+              </span>
+              <span className="rounded-full border border-white/10 bg-slate-900/80 px-3 py-1">
+                {scoredDayCount} day{scoredDayCount === 1 ? '' : 's'} scored
+              </span>
+              {disabledDayIndexes.length > 0 ? (
+                <span className="rounded-full border border-white/10 bg-slate-900/80 px-3 py-1">
+                  Disabled days: {disabledDayIndexes.join(', ')}
+                </span>
+              ) : null}
+              {generatedAtLabel ? (
+                <span className="rounded-full border border-white/10 bg-slate-900/80 px-3 py-1">
+                  Generated {generatedAtLabel}
+                </span>
+              ) : null}
+            </div>
+          </div>
         </div>
       </div>
-
-      <p className="text-sm text-gray-700">{calibration}</p>
-
-      {generatedAtLabel ? (
-        <p className="text-xs text-gray-500">Generated: {generatedAtLabel}</p>
-      ) : null}
-
-      {disabledDayIndexes.length > 0 ? (
-        <p className="text-xs text-gray-500">
-          Disabled days excluded from scoring: {disabledDayIndexes.join(', ')}
-        </p>
-      ) : null}
     </Card>
   );
 }

--- a/src/features/talent-partner/winoe-report/useWinoeReportContext.ts
+++ b/src/features/talent-partner/winoe-report/useWinoeReportContext.ts
@@ -1,0 +1,57 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@/shared/query';
+import {
+  fetchTrialCandidatesQuery,
+  fetchTrialDetailQuery,
+} from '../trial-management/detail/queries';
+
+type UseWinoeReportContextArgs = {
+  trialId: string;
+  candidateSessionId: string;
+};
+
+export function useWinoeReportContext({
+  trialId,
+  candidateSessionId,
+}: UseWinoeReportContextArgs) {
+  const trialQuery = useQuery({
+    queryKey: queryKeys.talentPartner.trialDetail(trialId),
+    queryFn: ({ signal }) => fetchTrialDetailQuery(trialId, signal, true),
+    enabled: Boolean(trialId),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const candidatesQuery = useQuery({
+    queryKey: queryKeys.talentPartner.trialCandidates(trialId),
+    queryFn: ({ signal }) => fetchTrialCandidatesQuery(trialId, signal, true),
+    enabled: Boolean(trialId),
+    staleTime: 60_000,
+  });
+
+  const metadata = useMemo(() => {
+    const trialTitle =
+      trialQuery.data?.plan?.title?.trim() ||
+      trialQuery.data?.plan?.scenario?.trim() ||
+      `Trial ${trialId}`;
+    const trialStatus = trialQuery.data?.status ?? null;
+    const candidate = candidatesQuery.data?.find(
+      (item) => String(item.candidateSessionId) === candidateSessionId,
+    );
+    return {
+      trialTitle,
+      trialStatus,
+      candidateName: candidate?.candidateName?.trim() || null,
+      candidateStatus: candidate?.status ?? null,
+    };
+  }, [candidateSessionId, candidatesQuery.data, trialId, trialQuery.data]);
+
+  return {
+    ...metadata,
+    loading:
+      trialQuery.isLoading ||
+      trialQuery.isFetching ||
+      candidatesQuery.isLoading ||
+      candidatesQuery.isFetching,
+  };
+}

--- a/src/features/talent-partner/winoe-report/winoeReport.catalog.ts
+++ b/src/features/talent-partner/winoe-report/winoeReport.catalog.ts
@@ -1,0 +1,162 @@
+const normalizeKey = (value: string): string =>
+  value.toLowerCase().replace(/[^a-z0-9]+/g, '');
+
+type DimensionDefinition = {
+  key: string;
+  label: string;
+  aliases: string[];
+  description: string;
+};
+
+const DIMENSIONS: DimensionDefinition[] = [
+  {
+    key: 'project_scaffolding_quality',
+    label: 'Project scaffolding quality',
+    aliases: ['scaffolding', 'project_scaffolding_quality', 'scaffold'],
+    description:
+      'How clearly the repository was structured before feature work accelerated.',
+  },
+  {
+    key: 'architectural_coherence',
+    label: 'Architectural coherence',
+    aliases: [
+      'architecture',
+      'architectural_coherence',
+      'architecture_coherence',
+    ],
+    description:
+      'How well the implementation boundaries, data flow, and module shape fit together.',
+  },
+  {
+    key: 'development_process',
+    label: 'Development process',
+    aliases: [
+      'process',
+      'development_process',
+      'commit_history',
+      'commit_history_analysis',
+    ],
+    description:
+      'How the commit trail, iteration sequence, and build progression were managed.',
+  },
+  {
+    key: 'code_quality',
+    label: 'Code quality',
+    aliases: ['code_quality', 'quality', 'implementation_quality'],
+    description:
+      'How readable, maintainable, and consistent the candidate’s code landed.',
+  },
+  {
+    key: 'testing_discipline',
+    label: 'Testing discipline',
+    aliases: ['testing', 'testing_discipline', 'tests', 'coverage'],
+    description:
+      'How consistently the candidate added or improved tests and coverage signals.',
+  },
+  {
+    key: 'communication_handoff_demo',
+    label: 'Communication / Handoff + Demo',
+    aliases: [
+      'demo',
+      'communication',
+      'handoff',
+      'handoff_demo',
+      'presentation',
+    ],
+    description:
+      'How clearly the candidate explained the work, tradeoffs, and next steps.',
+  },
+  {
+    key: 'reflection_self_awareness',
+    label: 'Reflection & self-awareness',
+    aliases: ['reflection', 'reflection_essay', 'self_awareness'],
+    description:
+      'How honestly the candidate described tradeoffs, mistakes, and areas for improvement.',
+  },
+];
+
+const DIMENSION_LOOKUP = new Map<string, DimensionDefinition>();
+for (const dimension of DIMENSIONS) {
+  DIMENSION_LOOKUP.set(normalizeKey(dimension.key), dimension);
+  DIMENSION_LOOKUP.set(normalizeKey(dimension.label), dimension);
+  dimension.aliases.forEach((alias) =>
+    DIMENSION_LOOKUP.set(normalizeKey(alias), dimension),
+  );
+}
+
+const DAY_LABELS: Record<number, string> = {
+  1: 'Design Doc',
+  2: 'Implementation Kickoff',
+  3: 'Implementation Wrap-Up',
+  4: 'Handoff + Demo',
+  5: 'Reflection Essay',
+};
+
+const EVIDENCE_KIND_LABELS: Record<string, string> = {
+  commit: 'Commit evidence',
+  commit_range: 'Commit range evidence',
+  design_doc: 'Design doc evidence',
+  design_doc_section: 'Design doc evidence',
+  rubric: 'Design doc evidence',
+  file_creation_timeline: 'File timeline evidence',
+  file_timeline: 'File timeline evidence',
+  code_structure: 'Code structure evidence',
+  file_reference: 'Code structure evidence',
+  test: 'Test evidence',
+  tests: 'Test evidence',
+  test_result: 'Test evidence',
+  coverage: 'Coverage progression evidence',
+  coverage_progression: 'Coverage progression evidence',
+  dependency_choice: 'Dependency choice evidence',
+  readme: 'README/documentation evidence',
+  documentation: 'README/documentation evidence',
+  doc: 'README/documentation evidence',
+  transcript: 'Handoff + Demo transcript',
+  handoff_transcript: 'Handoff + Demo transcript',
+  demo_transcript: 'Handoff + Demo transcript',
+  supplemental_material: 'Supplemental material evidence',
+  reflection: 'Reflection excerpt',
+  reflection_excerpt: 'Reflection excerpt',
+  submission: 'Reflection excerpt',
+  sub_agent_report: 'Sub-agent report excerpt',
+  reviewer_report: 'Sub-agent report excerpt',
+};
+
+export type WinoeDimensionDefinition = DimensionDefinition;
+
+export function formatDayLabel(dayIndex: number): string {
+  return DAY_LABELS[dayIndex] ?? `Day ${dayIndex}`;
+}
+
+export function getDimensionDefinition(
+  value: string | null,
+): DimensionDefinition | null {
+  if (!value) return null;
+  return DIMENSION_LOOKUP.get(normalizeKey(value)) ?? null;
+}
+
+export function humanizeKey(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function formatEvidenceKindLabel(kind: string | null): string {
+  if (!kind) return 'Evidence';
+  const normalized = normalizeKey(kind);
+  return EVIDENCE_KIND_LABELS[normalized] ?? `${humanizeKey(kind)} evidence`;
+}
+
+export function getDayLabel(
+  dayIndex: number | null | undefined,
+): string | null {
+  if (typeof dayIndex !== 'number' || !Number.isFinite(dayIndex)) return null;
+  return formatDayLabel(dayIndex);
+}
+
+export function getDimensionCatalog(): DimensionDefinition[] {
+  return DIMENSIONS;
+}

--- a/src/features/talent-partner/winoe-report/winoeReport.normalizeDayScore.ts
+++ b/src/features/talent-partner/winoe-report/winoeReport.normalizeDayScore.ts
@@ -5,10 +5,12 @@ import type {
 import {
   asRecord,
   normalizeStatus,
+  toNullableString,
   toNumberOrNull,
   toUnitIntervalOrNull,
 } from './winoeReport.normalize.base';
 import { normalizeEvidence } from './winoeReport.normalizeEvidence';
+import { formatDayLabel } from './winoeReport.catalog';
 
 export function normalizeDayEvaluationStatus(
   record: Record<string, unknown>,
@@ -65,7 +67,12 @@ export function normalizeDayScore(
   const rubricBreakdown = asRecord(
     record.rubricBreakdown ?? record.rubric_breakdown,
   );
-  const evidenceRaw = Array.isArray(record.evidence) ? record.evidence : [];
+  const evidenceRaw =
+    (Array.isArray(record.evidence) ? record.evidence : null) ??
+    (Array.isArray(record.artifacts) ? record.artifacts : null) ??
+    (Array.isArray(record.evidenceItems) ? record.evidenceItems : null) ??
+    (Array.isArray(record.evidence_items) ? record.evidence_items : null) ??
+    [];
   const evidence = evidenceRaw
     .map(normalizeEvidence)
     .filter((item): item is WinoeReportEvidence => Boolean(item));
@@ -81,11 +88,34 @@ export function normalizeDayScore(
       : (normalizedScore ?? 0);
   return {
     dayIndex: normalizedDayIndex,
+    dayLabel: formatDayLabel(normalizedDayIndex),
     score,
     rubricBreakdown: rubricBreakdown ?? {},
     evidence,
     evaluationStatus,
     reason,
     aiEvaluationEnabled,
+    summary:
+      toNullableString(
+        record.summary ??
+          record.daySummary ??
+          record.day_summary ??
+          record.overview ??
+          record.notes,
+      ) ?? null,
+    statusLabel:
+      toNullableString(
+        record.statusLabel ??
+          record.status_label ??
+          record.evaluationLabel ??
+          record.evaluation_label,
+      ) ?? null,
+    reviewerSummary:
+      toNullableString(
+        record.reviewerSummary ??
+          record.reviewer_summary ??
+          record.subAgentSummary ??
+          record.sub_agent_summary,
+      ) ?? null,
   };
 }

--- a/src/features/talent-partner/winoe-report/winoeReport.normalizeEvidence.ts
+++ b/src/features/talent-partner/winoe-report/winoeReport.normalizeEvidence.ts
@@ -1,23 +1,83 @@
 import type { WinoeReportEvidence } from './winoeReport.types';
 import {
   asRecord,
+  normalizeStatus,
   toNullableString,
   toNumberOrNull,
 } from './winoeReport.normalize.base';
+import {
+  formatDayLabel,
+  formatEvidenceKindLabel,
+  getDimensionDefinition,
+} from './winoeReport.catalog';
 
 export function normalizeEvidence(value: unknown): WinoeReportEvidence | null {
   const record = asRecord(value);
   if (!record) return null;
-  const kind = toNullableString(record.kind);
-  if (!kind) return null;
+  const kind =
+    toNullableString(
+      record.kind ??
+        record.type ??
+        record.artifactType ??
+        record.artifact_type ??
+        record.label ??
+        record.title,
+    ) ?? 'evidence';
   const startMs = toNumberOrNull(record.startMs ?? record.start_ms);
   const endMs = toNumberOrNull(record.endMs ?? record.end_ms);
+  const dayIndex = toNumberOrNull(
+    record.dayIndex ??
+      record.day_index ??
+      record.sourceDay ??
+      record.source_day,
+  );
+  const normalizedDayIndex =
+    dayIndex === null ? null : Math.max(0, Math.round(dayIndex));
+  const dimensionValue =
+    toNullableString(
+      record.dimensionKey ??
+        record.dimension_key ??
+        record.dimension ??
+        record.rubricKey ??
+        record.rubric_key ??
+        record.category,
+    ) ?? null;
+  const dimensionDefinition = getDimensionDefinition(dimensionValue);
+  const sourceLabel =
+    toNullableString(
+      record.sourceLabel ??
+        record.source_label ??
+        record.source ??
+        record.origin ??
+        record.dayLabel ??
+        record.day_label,
+    ) ?? null;
+  const dayLabel =
+    sourceLabel ??
+    (normalizedDayIndex === null ? null : formatDayLabel(normalizedDayIndex));
   return {
     kind,
+    label:
+      toNullableString(
+        record.label ?? record.title ?? record.name ?? record.summary,
+      ) ?? formatEvidenceKindLabel(kind),
+    title: toNullableString(record.title ?? record.name),
+    description:
+      toNullableString(
+        record.description ?? record.detail ?? record.details ?? record.note,
+      ) ?? null,
     ref: toNullableString(record.ref),
     url: toNullableString(record.url),
     excerpt: toNullableString(record.excerpt),
     startMs: startMs === null ? null : Math.max(0, Math.round(startMs)),
     endMs: endMs === null ? null : Math.max(0, Math.round(endMs)),
+    dayIndex: normalizedDayIndex,
+    dayLabel,
+    sourceDay: normalizedDayIndex,
+    sourceType: normalizeStatus(record.sourceType ?? record.source_type),
+    sourceLabel,
+    dimensionKey: dimensionDefinition?.key ?? dimensionValue,
+    dimensionLabel: dimensionDefinition?.label ?? dimensionValue,
+    anchor: toNullableString(record.anchor ?? record.fragment ?? record.hash),
   };
 }

--- a/src/features/talent-partner/winoe-report/winoeReport.normalizePayload.ts
+++ b/src/features/talent-partner/winoe-report/winoeReport.normalizePayload.ts
@@ -34,8 +34,11 @@ export function normalizeWinoeReportPayload(
 
   const reportCandidate =
     asRecord(record.report) ??
+    asRecord(record.reportData) ??
     (record.overallWinoeScore !== undefined ? record : null) ??
-    (record.overall_winoe_score !== undefined ? record : null);
+    (record.overall_winoe_score !== undefined ? record : null) ??
+    (record.dimensionScores !== undefined ? record : null) ??
+    (record.dimension_scores !== undefined ? record : null);
   if (status === 'ready' || reportCandidate) {
     const report = normalizeReport(reportCandidate);
     if (!report) {

--- a/src/features/talent-partner/winoe-report/winoeReport.normalizeReport.ts
+++ b/src/features/talent-partner/winoe-report/winoeReport.normalizeReport.ts
@@ -1,5 +1,8 @@
 import type {
   WinoeReportDayScore,
+  WinoeReportDimension,
+  WinoeReportEvidence,
+  WinoeReportReviewerSummary,
   WinoeReportReport,
   WinoeReportVersion,
 } from './winoeReport.types';
@@ -7,11 +10,519 @@ import {
   asRecord,
   toNullableString,
   toPositiveIntList,
+  toStringList,
   toUnitInterval,
   toNumberOrNull,
+  toUnitIntervalOrNull,
 } from './winoeReport.normalize.base';
 import { normalizeDayScore } from './winoeReport.normalizeDayScore';
+import { normalizeEvidence } from './winoeReport.normalizeEvidence';
 import { normalizeWarnings } from './winoeReport.normalizeWarnings';
+import {
+  formatDayLabel,
+  getDimensionCatalog,
+  getDimensionDefinition,
+  humanizeKey,
+} from './winoeReport.catalog';
+
+type DimensionDefinition = ReturnType<typeof getDimensionCatalog>[number];
+
+const DIMENSION_ARRAY_KEYS = [
+  'dimensionScores',
+  'dimension_scores',
+  'dimensions',
+  'subScores',
+  'sub_scores',
+  'rubricDimensions',
+  'rubric_dimensions',
+];
+
+const REVIEWER_ARRAY_KEYS = [
+  'reviewerSummaries',
+  'reviewer_summaries',
+  'subAgentReports',
+  'sub_agent_reports',
+  'reviewerReports',
+  'reviewer_reports',
+];
+
+function getRecordArray(
+  record: Record<string, unknown>,
+  keys: string[],
+): Record<string, unknown>[] {
+  for (const key of keys) {
+    const value = record[key];
+    if (Array.isArray(value)) {
+      return value
+        .map((item) => asRecord(item))
+        .filter((item): item is Record<string, unknown> => Boolean(item));
+    }
+  }
+  return [];
+}
+
+function getEvidenceArray(
+  record: Record<string, unknown>,
+): WinoeReportEvidence[] {
+  const raw =
+    (Array.isArray(record.evidence) ? record.evidence : null) ??
+    (Array.isArray(record.evidenceItems) ? record.evidenceItems : null) ??
+    (Array.isArray(record.evidence_items) ? record.evidence_items : null) ??
+    (Array.isArray(record.artifacts) ? record.artifacts : null) ??
+    (Array.isArray(record.linkedArtifacts) ? record.linkedArtifacts : null) ??
+    (Array.isArray(record.linked_artifacts) ? record.linked_artifacts : null) ??
+    [];
+  return raw
+    .map(normalizeEvidence)
+    .filter((item): item is WinoeReportEvidence => Boolean(item));
+}
+
+function uniqueEvidenceCount(evidence: WinoeReportEvidence[]): number {
+  const seen = new Set<string>();
+  evidence.forEach((item) => {
+    const key =
+      item.ref ??
+      item.url ??
+      item.anchor ??
+      `${item.kind}-${item.dayIndex ?? 'x'}-${item.startMs ?? 'x'}`;
+    seen.add(key);
+  });
+  return seen.size;
+}
+
+function chooseString(...values: unknown[]): string | null {
+  for (const value of values) {
+    const text = toNullableString(value);
+    if (text) return text;
+  }
+  return null;
+}
+
+function normalizePositiveIntList(value: unknown): number[] {
+  if (Array.isArray(value)) return toPositiveIntList(value);
+  const numeric = toNumberOrNull(value);
+  return numeric === null || numeric <= 0 ? [] : [Math.round(numeric)];
+}
+
+function dimensionOrderIndex(key: string): number {
+  const index = getDimensionCatalog().findIndex((item) => item.key === key);
+  return index === -1 ? Number.POSITIVE_INFINITY : index;
+}
+
+function sortDimensionsByCatalogOrder(
+  a: WinoeReportDimension,
+  b: WinoeReportDimension,
+): number {
+  const orderA = dimensionOrderIndex(a.key);
+  const orderB = dimensionOrderIndex(b.key);
+  if (orderA !== orderB) return orderA - orderB;
+  return a.label.localeCompare(b.label);
+}
+
+function collectDimensionKeys(record: Record<string, unknown>): string[] {
+  return toStringList([
+    record.key,
+    record.id,
+    record.slug,
+    record.dimensionKey,
+    record.dimension_key,
+    record.dimension,
+    record.dimensionLabel,
+    record.dimension_label,
+    record.rubricKey,
+    record.rubric_key,
+    record.category,
+    record.name,
+    record.label,
+  ]);
+}
+
+function collectDimensionEvidence(
+  key: string,
+  label: string,
+  dayScores: WinoeReportDayScore[],
+): WinoeReportEvidence[] {
+  return dayScores.flatMap((day) =>
+    day.evidence.filter((item) => {
+      const dimensionKey =
+        item.dimensionKey ?? item.dimensionLabel ?? item.sourceLabel;
+      if (!dimensionKey) return false;
+      const definition = getDimensionDefinition(dimensionKey);
+      return Boolean(
+        definition?.key === key ||
+        definition?.label === label ||
+        dimensionKey === key ||
+        dimensionKey === label,
+      );
+    }),
+  );
+}
+
+function collectDimensionScoreSamples(
+  key: string,
+  label: string,
+  dayScores: WinoeReportDayScore[],
+): number[] {
+  return dayScores
+    .flatMap((day) =>
+      Object.entries(day.rubricBreakdown)
+        .filter(([entryKey]) => {
+          const dimension = getDimensionDefinition(entryKey);
+          return Boolean(
+            dimension?.key === key ||
+            dimension?.label === label ||
+            entryKey === key ||
+            humanizeKey(entryKey) === label,
+          );
+        })
+        .map(([, value]) => toUnitIntervalOrNull(value))
+        .filter((value): value is number => value !== null),
+    )
+    .filter((value): value is number => value !== null);
+}
+
+function mergeEvidenceItems(
+  primary: WinoeReportEvidence[],
+  secondary: WinoeReportEvidence[],
+): WinoeReportEvidence[] {
+  return Array.from(
+    new Map(
+      [...primary, ...secondary].map((item) => [
+        item.ref ??
+          item.url ??
+          item.anchor ??
+          `${item.kind}-${item.dayIndex ?? 'x'}-${item.startMs ?? 'x'}`,
+        item,
+      ]),
+    ).values(),
+  );
+}
+
+function buildDimensionFromParts({
+  key,
+  label,
+  description,
+  sourceKeys,
+  score,
+  summary,
+  evidence,
+}: {
+  key: string;
+  label: string;
+  description: string | null;
+  sourceKeys: string[];
+  score: number | null;
+  summary: string | null;
+  evidence: WinoeReportEvidence[];
+}): WinoeReportDimension {
+  const mergedEvidence = mergeEvidenceItems([], evidence);
+  return {
+    key,
+    label,
+    score,
+    summary,
+    evidence: mergedEvidence,
+    evidenceCount: mergedEvidence.length,
+    linkedArtifactCount: uniqueEvidenceCount(mergedEvidence),
+    sourceKeys: Array.from(new Set(sourceKeys)),
+    emptyStateMessage:
+      mergedEvidence.length === 0
+        ? 'No linked artifacts were returned for this dimension yet.'
+        : null,
+    description,
+  };
+}
+
+function buildExplicitDimension(
+  record: Record<string, unknown>,
+  dayScores: WinoeReportDayScore[],
+): WinoeReportDimension | null {
+  const rawLabel = chooseString(
+    record.label,
+    record.title,
+    record.name,
+    record.dimensionLabel,
+    record.dimension_label,
+    record.dimension,
+    record.key,
+  );
+  const definition = getDimensionDefinition(rawLabel);
+  const sourceKeys = Array.from(
+    new Set(
+      collectDimensionKeys(record).map((value) => {
+        const normalized = getDimensionDefinition(value);
+        return normalized?.key ?? value;
+      }),
+    ),
+  );
+  const key =
+    definition?.key ?? sourceKeys[0] ?? humanizeKey(rawLabel ?? 'dimension');
+  const label = definition?.label ?? rawLabel ?? humanizeKey(key);
+  const explicitScore = toUnitIntervalOrNull(
+    record.score ??
+      record.value ??
+      record.points ??
+      record.total ??
+      record.scoreValue ??
+      record.score_value,
+  );
+  const explanation = chooseString(
+    record.summary,
+    record.explanation,
+    record.description,
+    record.notes,
+    record.detail,
+  );
+  const evidence = getEvidenceArray(record);
+  const matchingDayEvidence = collectDimensionEvidence(key, label, dayScores);
+  const mergedEvidence = mergeEvidenceItems(evidence, matchingDayEvidence);
+  const scoreSamples = collectDimensionScoreSamples(key, label, dayScores);
+
+  return buildDimensionFromParts({
+    key,
+    label,
+    description: definition?.description ?? null,
+    sourceKeys,
+    score:
+      explicitScore ??
+      (scoreSamples.length > 0
+        ? scoreSamples.reduce((sum, value) => sum + value, 0) /
+          scoreSamples.length
+        : null),
+    summary:
+      explanation ??
+      (mergedEvidence.length > 0
+        ? `${mergedEvidence.length} linked artifact${mergedEvidence.length === 1 ? '' : 's'} captured for this dimension.`
+        : null),
+    evidence: mergedEvidence,
+  });
+}
+
+function buildCanonicalDimension(
+  definition: DimensionDefinition,
+  dayScores: WinoeReportDayScore[],
+  explicitDimension: WinoeReportDimension | null,
+): WinoeReportDimension {
+  if (explicitDimension) return explicitDimension;
+
+  const evidence = collectDimensionEvidence(
+    definition.key,
+    definition.label,
+    dayScores,
+  );
+  const scoreSamples = collectDimensionScoreSamples(
+    definition.key,
+    definition.label,
+    dayScores,
+  );
+  const derivedScore =
+    scoreSamples.length > 0
+      ? scoreSamples.reduce((sum, value) => sum + value, 0) /
+        scoreSamples.length
+      : null;
+
+  return buildDimensionFromParts({
+    key: definition.key,
+    label: definition.label,
+    description: definition.description,
+    sourceKeys: [definition.key, ...definition.aliases],
+    score: derivedScore,
+    summary:
+      derivedScore !== null
+        ? `${definition.description} Evidence was found in ${evidence.length} linked artifact${evidence.length === 1 ? '' : 's'}.`
+        : null,
+    evidence,
+  });
+}
+
+function buildDerivedExtraDimension(
+  key: string,
+  dayScores: WinoeReportDayScore[],
+  explicitKeySet: Set<string>,
+  canonicalKeySet: Set<string>,
+): WinoeReportDimension | null {
+  if (explicitKeySet.has(key) || canonicalKeySet.has(key)) return null;
+  const definition = getDimensionDefinition(key);
+  const label = definition?.label ?? humanizeKey(key);
+  const evidence = collectDimensionEvidence(key, label, dayScores);
+  const scoreSamples = collectDimensionScoreSamples(key, label, dayScores);
+  const score =
+    scoreSamples.length > 0
+      ? scoreSamples.reduce((sum, value) => sum + value, 0) /
+        scoreSamples.length
+      : null;
+  if (score === null && evidence.length === 0) return null;
+
+  return buildDimensionFromParts({
+    key: definition?.key ?? key,
+    label,
+    description: definition?.description ?? null,
+    sourceKeys: [key],
+    score,
+    summary:
+      score !== null
+        ? `Derived from day-level rubric and evidence signals. Evidence was found in ${evidence.length} linked artifact${evidence.length === 1 ? '' : 's'}.`
+        : null,
+    evidence,
+  });
+}
+
+function buildDimensions(
+  record: Record<string, unknown>,
+  dayScores: WinoeReportDayScore[],
+): WinoeReportDimension[] {
+  const dimensionRecords = getRecordArray(record, DIMENSION_ARRAY_KEYS);
+  const explicitDimensions = dimensionRecords
+    .map((item) => buildExplicitDimension(item, dayScores))
+    .filter((item): item is WinoeReportDimension => Boolean(item));
+  const explicitByKey = new Map(
+    explicitDimensions.map((item) => [item.key, item]),
+  );
+  const canonicalDefinitions = getDimensionCatalog();
+  const canonicalKeySet = new Set(canonicalDefinitions.map((item) => item.key));
+  const canonicalDimensions = canonicalDefinitions.map((definition) =>
+    buildCanonicalDimension(
+      definition,
+      dayScores,
+      explicitByKey.get(definition.key) ?? null,
+    ),
+  );
+
+  const explicitExtraDimensions = explicitDimensions
+    .filter((item) => !canonicalKeySet.has(item.key))
+    .sort(sortDimensionsByCatalogOrder);
+
+  const derivedExtraKeys = Array.from(
+    new Set(
+      dayScores.flatMap((day) => [
+        ...Object.keys(day.rubricBreakdown).map(
+          (value) => getDimensionDefinition(value)?.key ?? value,
+        ),
+        ...day.evidence
+          .map(
+            (item) =>
+              item.dimensionKey ?? item.dimensionLabel ?? item.sourceLabel,
+          )
+          .filter((value): value is string => Boolean(value))
+          .map((value) => getDimensionDefinition(value)?.key ?? value),
+      ]),
+    ),
+  );
+  const derivedExtraDimensions = derivedExtraKeys
+    .map((key) =>
+      buildDerivedExtraDimension(
+        key,
+        dayScores,
+        new Set(explicitDimensions.map((item) => item.key)),
+        canonicalKeySet,
+      ),
+    )
+    .filter((item): item is WinoeReportDimension => Boolean(item))
+    .sort(sortDimensionsByCatalogOrder);
+
+  return [
+    ...canonicalDimensions,
+    ...explicitExtraDimensions,
+    ...derivedExtraDimensions,
+  ];
+}
+
+function buildReviewerSummaries(
+  record: Record<string, unknown>,
+  dayScores: WinoeReportDayScore[],
+): WinoeReportReviewerSummary[] {
+  const reviewerRecords = getRecordArray(record, REVIEWER_ARRAY_KEYS);
+  const summaries: WinoeReportReviewerSummary[] = reviewerRecords
+    .map((item): WinoeReportReviewerSummary | null => {
+      const reviewerName = chooseString(
+        item.reviewerName,
+        item.reviewer_name,
+        item.name,
+        item.title,
+        item.label,
+      );
+      if (!reviewerName) return null;
+      const dayIndexes = Array.from(
+        new Set([
+          ...normalizePositiveIntList(item.dayIndexes),
+          ...normalizePositiveIntList(item.day_indexes),
+          ...normalizePositiveIntList(item.days),
+          ...normalizePositiveIntList(item.day),
+          ...normalizePositiveIntList(item.dayIndex),
+          ...normalizePositiveIntList(item.day_index),
+        ]),
+      );
+      const evidence = getEvidenceArray(item);
+      return {
+        reviewerName,
+        dayIndexes,
+        score: toUnitIntervalOrNull(
+          item.score ?? item.value ?? item.overallScore ?? item.overall_score,
+        ),
+        summary: chooseString(
+          item.summary,
+          item.explanation,
+          item.description,
+          item.notes,
+          item.result,
+        ),
+        strengths: toStringList(
+          item.strengths ?? item.keyStrengths ?? item.key_strengths,
+        ),
+        concerns: toStringList(item.concerns ?? item.risks ?? item.keyRisks),
+        evidence,
+        sourceLabel: chooseString(item.sourceLabel, item.source_label),
+      };
+    })
+    .filter((item): item is WinoeReportReviewerSummary => Boolean(item));
+
+  if (summaries.length > 0) {
+    return summaries;
+  }
+
+  const dayBasedSummaries = dayScores
+    .map((day): WinoeReportReviewerSummary | null => {
+      const summary = day.reviewerSummary ?? day.summary ?? null;
+      const reviewerName = `${day.dayLabel ?? formatDayLabel(day.dayIndex)} reviewer`;
+      if (!summary && day.evidence.length === 0) return null;
+      return {
+        reviewerName,
+        dayIndexes: [day.dayIndex],
+        score: day.score,
+        summary,
+        strengths: [],
+        concerns: [],
+        evidence: day.evidence,
+        sourceLabel: day.dayLabel ?? formatDayLabel(day.dayIndex),
+      };
+    })
+    .filter((item): item is WinoeReportReviewerSummary => Boolean(item));
+
+  const synthesis = chooseString(
+    record.narrativeAssessment,
+    record.narrative_assessment,
+    record.summary,
+    record.personaVoice,
+    record.persona_voice,
+  );
+
+  if (synthesis) {
+    dayBasedSummaries.unshift({
+      reviewerName: 'Winoe synthesis',
+      dayIndexes: dayScores.map((day) => day.dayIndex),
+      score: toUnitIntervalOrNull(
+        record.overallWinoeScore ?? record.overall_winoe_score,
+      ),
+      summary: synthesis,
+      strengths: [],
+      concerns: [],
+      evidence: [],
+      sourceLabel: 'Winoe synthesis',
+    });
+  }
+
+  return dayBasedSummaries;
+}
 
 export function normalizeVersion(value: unknown): WinoeReportVersion | null {
   const record = asRecord(value);
@@ -56,6 +567,24 @@ export function normalizeReport(value: unknown): WinoeReportReport | null {
     });
   });
   dayScores.sort((a, b) => a.dayIndex - b.dayIndex);
+  const dimensionScores = buildDimensions(record, dayScores);
+  const reviewerSummaries = buildReviewerSummaries(record, dayScores);
+  const narrativeAssessment = chooseString(
+    record.narrativeAssessment,
+    record.narrative_assessment,
+    record.summary,
+    record.personaVoice,
+    record.persona_voice,
+    record.assessment,
+    record.assessmentText,
+    record.assessment_text,
+  );
+  const personaVoice = chooseString(
+    record.personaVoice,
+    record.persona_voice,
+    record.winoeVoice,
+    record.winoe_voice,
+  );
 
   return {
     overallWinoeScore: toUnitInterval(
@@ -70,6 +599,15 @@ export function normalizeReport(value: unknown): WinoeReportReport | null {
           record.calibrationLanguage ??
           record.calibration_language,
       ) ?? null,
+    narrativeAssessment,
+    personaVoice,
+    summary: chooseString(
+      record.summary,
+      record.reportSummary,
+      record.report_summary,
+    ),
+    dimensionScores,
+    reviewerSummaries,
     dayScores,
     disabledDayIndexes,
     version: normalizeVersion(record.version),

--- a/src/features/talent-partner/winoe-report/winoeReport.types.ts
+++ b/src/features/talent-partner/winoe-report/winoeReport.types.ts
@@ -14,18 +14,33 @@ export type WinoeReportEvidence = {
   excerpt: string | null;
   startMs: number | null;
   endMs: number | null;
+  label?: string | null;
+  title?: string | null;
+  description?: string | null;
+  dayIndex?: number | null;
+  dayLabel?: string | null;
+  sourceDay?: number | null;
+  sourceType?: string | null;
+  sourceLabel?: string | null;
+  dimensionKey?: string | null;
+  dimensionLabel?: string | null;
+  anchor?: string | null;
 };
 
 export type WinoeReportDayEvaluationStatus = 'evaluated' | 'not_evaluated';
 
 export type WinoeReportDayScore = {
   dayIndex: number;
+  dayLabel?: string | null;
   score: number | null;
   rubricBreakdown: Record<string, unknown>;
   evidence: WinoeReportEvidence[];
   evaluationStatus: WinoeReportDayEvaluationStatus;
   reason: string | null;
   aiEvaluationEnabled: boolean;
+  summary?: string | null;
+  statusLabel?: string | null;
+  reviewerSummary?: string | null;
 };
 
 export type WinoeReportVersion = {
@@ -35,11 +50,40 @@ export type WinoeReportVersion = {
   modelVersion: string | null;
 };
 
+export type WinoeReportDimension = {
+  key: string;
+  label: string;
+  score: number | null;
+  summary: string | null;
+  evidence: WinoeReportEvidence[];
+  evidenceCount: number;
+  linkedArtifactCount: number;
+  sourceKeys: string[];
+  emptyStateMessage: string | null;
+  description?: string | null;
+};
+
+export type WinoeReportReviewerSummary = {
+  reviewerName: string;
+  dayIndexes: number[];
+  score: number | null;
+  summary: string | null;
+  strengths: string[];
+  concerns: string[];
+  evidence: WinoeReportEvidence[];
+  sourceLabel: string | null;
+};
+
 export type WinoeReportReport = {
   overallWinoeScore: number;
   recommendation: string;
   confidence: number | null;
   calibrationText: string | null;
+  narrativeAssessment: string | null;
+  personaVoice: string | null;
+  summary: string | null;
+  dimensionScores: WinoeReportDimension[];
+  reviewerSummaries: WinoeReportReviewerSummary[];
   dayScores: WinoeReportDayScore[];
   disabledDayIndexes: number[];
   version: WinoeReportVersion | null;

--- a/src/features/talent-partner/winoe-report/winoeReportFormatting.ts
+++ b/src/features/talent-partner/winoe-report/winoeReportFormatting.ts
@@ -8,26 +8,51 @@ export function formatScorePercent(value: number): string {
   return `${Math.round(clampUnit(value) * 100)}%`;
 }
 
-export function formatRecommendationLabel(value: string): string {
-  const normalized = value.trim().toLowerCase();
-  if (normalized === 'hire') return 'Hire';
-  if (normalized === 'lean_hire') return 'Lean Hire';
-  if (normalized === 'no_hire') return 'No Hire';
-  if (normalized === 'strong_hire') return 'Strong Hire';
+export function formatScoreOutOf100(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return '—';
+  const normalized = clampUnit(value);
+  return `${Math.round(normalized * 100)} / 100`;
+}
+
+export function formatCountLabel(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+export function formatStatusLabel(value: string | null | undefined): string {
+  if (!value) return 'Unknown';
   return value
-    .replace(/[_-]/g, ' ')
+    .trim()
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
     .replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
-export function recommendationToneClass(value: string): string {
-  const normalized = value.trim().toLowerCase();
-  if (normalized === 'hire' || normalized === 'strong_hire') {
-    return 'border-green-200 bg-green-50 text-green-700';
+export function formatRecommendationEvidenceLanguage(
+  value: string | null | undefined,
+): string {
+  const normalized = value?.trim().toLowerCase() ?? '';
+  if (
+    normalized === 'hire' ||
+    normalized === 'strong_hire' ||
+    normalized === 'recommended' ||
+    normalized === 'proceed'
+  ) {
+    return 'Evidence suggests strong alignment with this Trial.';
   }
-  if (normalized === 'no_hire') {
-    return 'border-red-200 bg-red-50 text-red-700';
+  if (normalized === 'lean_hire') {
+    return 'Evidence shows meaningful strengths.';
   }
-  return 'border-amber-200 bg-amber-50 text-amber-800';
+  if (normalized === 'mixed' || normalized === 'needs_review') {
+    return 'Evidence is mixed; review the linked artifacts.';
+  }
+  if (
+    normalized === 'reject' ||
+    normalized === 'no_hire' ||
+    normalized === 'do_not_proceed'
+  ) {
+    return 'Evidence shows material concerns to review.';
+  }
+  return 'Evidence is mixed; review the linked artifacts.';
 }
 
 export function formatTranscriptTime(ms: number | null): string | null {
@@ -57,6 +82,35 @@ export function formatCalibrationText(
   }
   return `Recommendation calibrated using rubric-aligned evidence across ${dayCount} scored day${dayCount === 1 ? '' : 's'}.`;
 }
+
+export function formatNarrativeSummary(
+  overallWinoeScore: number,
+  calibrationText: string | null,
+  recommendation: string | null,
+  dimensionCount: number,
+): string {
+  if (calibrationText && calibrationText.trim().length > 0) {
+    return calibrationText;
+  }
+
+  const recommendationLanguage =
+    formatRecommendationEvidenceLanguage(recommendation);
+  if (
+    recommendationLanguage ===
+      'Evidence suggests strong alignment with this Trial.' ||
+    overallWinoeScore >= 0.85
+  ) {
+    return `Evidence suggests strong alignment with this Trial's engineering demands. Winoe found ${dimensionCount} linked dimension${dimensionCount === 1 ? '' : 's'} with supporting artifacts, but the Talent Partner should still inspect the Evidence Trail before deciding.`;
+  }
+  if (
+    recommendationLanguage === 'Evidence shows meaningful strengths.' ||
+    overallWinoeScore >= 0.65
+  ) {
+    return `Evidence shows meaningful strengths, with a few areas worth follow-up. Winoe found ${dimensionCount} linked dimension${dimensionCount === 1 ? '' : 's'} and encourages the Talent Partner to inspect the underlying artifacts before deciding.`;
+  }
+  return `The Evidence Trail is mixed; review the concerns below before deciding. Winoe found ${dimensionCount} linked dimension${dimensionCount === 1 ? '' : 's'} and surfaces the supporting artifacts directly.`;
+}
+
 export {
   formatRubricKey,
   formatRubricValue,

--- a/tests/integration/talent-partner/TrialDetailPageClient.compareStates.test.tsx
+++ b/tests/integration/talent-partner/TrialDetailPageClient.compareStates.test.tsx
@@ -86,7 +86,11 @@ describe('TalentPartnerTrialDetailPage - compare states', () => {
 
     const row22 = screen.getByTestId('candidate-compare-row-22');
     expect(within(row22).getByText('84%')).toBeInTheDocument();
-    expect(within(row22).getByText('Hire')).toBeInTheDocument();
+    expect(
+      within(row22).getByText(
+        'Evidence suggests strong alignment with this Trial.',
+      ),
+    ).toBeInTheDocument();
   });
 
   it('shows talent_partner-scoped compare denial on compare 403 responses', async () => {

--- a/tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.testlib.tsx
+++ b/tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.testlib.tsx
@@ -33,6 +33,7 @@ let anchorClickSpy: jest.SpyInstance | null = null;
 const originalDebugErrors = process.env.NEXT_PUBLIC_WINOE_DEBUG_ERRORS;
 
 beforeEach(() => {
+  jest.useRealTimers();
   __resetCandidateCache();
   __resetHttpClientCache();
 });

--- a/tests/integration/talent-partner/trials/candidates/WinoeReportPage.errorStates.test.tsx
+++ b/tests/integration/talent-partner/trials/candidates/WinoeReportPage.errorStates.test.tsx
@@ -35,7 +35,11 @@ describe('WinoeReportPage error states', () => {
         : textResponse('Not found', 404),
     );
     renderWinoeReportPage();
-    expect(await screen.findByText(/Access denied/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        /Access denied\. You do not have permission to view this Winoe Report\./i,
+      ),
+    ).toBeInTheDocument();
   });
 
   it('maps generic request failures to error panel', async () => {

--- a/tests/integration/talent-partner/trials/candidates/WinoeReportPage.pollingGenerate.test.tsx
+++ b/tests/integration/talent-partner/trials/candidates/WinoeReportPage.pollingGenerate.test.tsx
@@ -34,7 +34,9 @@ describe('WinoeReportPage polling and generate flow', () => {
     await act(async () => {
       jest.advanceTimersByTime(10200);
     });
-    await waitFor(() => expect(screen.getByText('78%')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getAllByText('78 / 100')).toHaveLength(2),
+    );
   });
 
   it('triggers POST generate then renders ready view', async () => {
@@ -73,7 +75,9 @@ describe('WinoeReportPage polling and generate flow', () => {
     await act(async () => {
       jest.advanceTimersByTime(10200);
     });
-    await waitFor(() => expect(screen.getByText('78%')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getAllByText('78 / 100')).toHaveLength(2),
+    );
   });
 
   it('handles POST 409 generate by polling existing run until ready', async () => {
@@ -107,7 +111,9 @@ describe('WinoeReportPage polling and generate flow', () => {
     await act(async () => {
       jest.advanceTimersByTime(10200);
     });
-    await waitFor(() => expect(screen.getByText('78%')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getAllByText('78 / 100')).toHaveLength(2),
+    );
   });
 
   it('cleans up polling timer on unmount', async () => {

--- a/tests/integration/talent-partner/trials/candidates/WinoeReportPage.printProof.test.tsx
+++ b/tests/integration/talent-partner/trials/candidates/WinoeReportPage.printProof.test.tsx
@@ -66,11 +66,33 @@ describe('WinoeReportPage print-proof artifact', () => {
       </div>,
     );
 
-    expect(await screen.findByText('78%')).toBeInTheDocument();
+    expect(await screen.findAllByText('78 / 100')).toHaveLength(2);
+    expect(screen.getByText(/Winoe Report/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Winoe Score/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Dimensional sub-scores/i)).toBeInTheDocument();
+    expect(screen.getByText(/Evidence Trail drill-down/i)).toBeInTheDocument();
+    expect(screen.getByText(/Per-day scores/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Reviewer sub-agent summaries/i),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText(/Day 1/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Design Doc Reviewer/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Winoe synthesis/i).length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(/Winoe provides evidence, context, and calibration\./i),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-winoe-report-no-print="true"]'),
+    ).not.toBeNull();
     expect(screen.getByText(/URL:/)).toHaveTextContent(
       'https://github.com/org/repo/commit/abc123',
     );
     expect(screen.getByText(/URL:/)).not.toHaveTextContent('token=');
+    expect(
+      screen.getAllByText(
+        /No linked artifacts were returned for this dimension yet\./i,
+      ).length,
+    ).toBeGreaterThan(0);
 
     const cssPath = path.join(process.cwd(), 'src/app/globals.css');
     const fullCss = fs

--- a/tests/integration/talent-partner/trials/candidates/WinoeReportPage.rendering.test.tsx
+++ b/tests/integration/talent-partner/trials/candidates/WinoeReportPage.rendering.test.tsx
@@ -38,14 +38,37 @@ describe('WinoeReportPage rendering', () => {
         : textResponse('Not found', 404),
     );
     renderWinoeReportPage();
-    expect(await screen.findByText('78%')).toBeInTheDocument();
-    expect(screen.getByText('Day 1')).toBeInTheDocument();
+    expect(await screen.findAllByText('78 / 100')).toHaveLength(2);
+    expect(screen.getAllByText('Day 1').length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(/Winoe's narrative assessment/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Project scaffolding quality/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Architectural coherence/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Development process/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Reflection & self-awareness/i }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText(/Score pending/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/^Hire$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Reject$/i)).not.toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /Print \/ Save PDF/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('link', { name: /Open evidence link/i }),
-    ).toHaveAttribute('target', '_blank');
+      screen.getAllByRole('link', { name: /Open evidence link/i }),
+    ).toHaveLength(2);
+    expect(
+      screen.getAllByText(
+        /No linked artifacts were returned for this dimension yet\./i,
+      ).length,
+    ).toBeGreaterThan(0);
   });
 
   it('renders AI-disabled day cards as human-review-required placeholders', async () => {
@@ -82,10 +105,8 @@ describe('WinoeReportPage rendering', () => {
     renderWinoeReportPage();
     expect(await screen.findByText('Day 2')).toBeInTheDocument();
     expect(screen.getByText('Day 3')).toBeInTheDocument();
-    expect(
-      screen.getByText(/Disabled days excluded from scoring: 2, 3/i),
-    ).toBeInTheDocument();
-    expect(screen.getAllByText('AI Evaluation: Disabled')).toHaveLength(2);
+    expect(screen.getByText(/Disabled days: 2, 3/i)).toBeInTheDocument();
+    expect(screen.getAllByText('AI evaluation disabled')).toHaveLength(2);
     expect(
       screen.getAllByText(/AI evaluation disabled for this day./i),
     ).toHaveLength(2);

--- a/tests/integration/talent-partner/trials/candidates/WinoeReportPage.testlib.tsx
+++ b/tests/integration/talent-partner/trials/candidates/WinoeReportPage.testlib.tsx
@@ -8,6 +8,7 @@ import {
   jsonResponse,
   textResponse,
 } from '../../../../setup/responseHelpers';
+import { makeTrialDetailPayload } from '../../../../setup/fixtures/backendContracts';
 import { __resetHttpClientCache } from '@/platform/api-client/client';
 
 jest.mock('next/link', () => ({
@@ -31,19 +32,147 @@ export const READY_PAYLOAD = {
   generatedAt: '2026-03-11T18:00:00.000Z',
   report: {
     overallWinoeScore: 0.78,
-    recommendation: 'hire',
+    recommendation: 'strong_hire',
     confidence: 0.74,
+    calibrationText:
+      'Evidence is coherent across the Trial and the linked artifacts are readable.',
+    narrativeAssessment:
+      'Winoe sees a deliberate build sequence: scaffold first, then implementation, then tests and handoff. The evidence is strong enough to inspect directly, but the Talent Partner should still review the drill-down before deciding.',
+    personaVoice:
+      'I evaluate the Trial through commits, docs, timestamps, and reviewer summaries rather than personality or guesswork.',
+    summary:
+      'The report is backed by linked artifacts across the Trial timeline.',
+    dimensionScores: [
+      {
+        key: 'project_scaffolding_quality',
+        label: 'Project scaffolding quality',
+        score: 0.84,
+        summary:
+          'Repository structure was established early and kept coherent.',
+        evidence: [
+          {
+            kind: 'file_creation_timeline',
+            label: 'File timeline evidence',
+            ref: 'timeline-1',
+            excerpt: 'Workspace structure appears before feature work starts.',
+            dimensionKey: 'project_scaffolding_quality',
+            dayIndex: 2,
+          },
+        ],
+      },
+      {
+        key: 'communication_handoff_demo',
+        label: 'Communication / Handoff + Demo',
+        score: 0.76,
+        summary:
+          'The Handoff + Demo transcript explains tradeoffs and next steps clearly.',
+        evidence: [
+          {
+            kind: 'transcript',
+            label: 'Handoff + Demo transcript',
+            ref: 'transcript-4',
+            excerpt: 'Candidate describes architecture and follow-up items.',
+            startMs: 15000,
+            endMs: 19000,
+            dayIndex: 4,
+          },
+        ],
+      },
+    ],
+    reviewerSummaries: [
+      {
+        reviewerName: 'Design Doc Reviewer',
+        dayIndexes: [1],
+        score: 0.81,
+        summary:
+          'The design doc frames the API clearly and makes the open questions visible.',
+        strengths: ['Clear structure', 'Explicit tradeoffs'],
+        concerns: ['Scaling assumptions stay implicit'],
+        evidence: [
+          {
+            kind: 'design_doc_section',
+            label: 'Design doc evidence',
+            ref: 'doc-1',
+            excerpt: 'Architecture brief with API boundaries.',
+            dayIndex: 1,
+          },
+        ],
+        sourceLabel: 'Design Doc Reviewer',
+      },
+      {
+        reviewerName: 'Winoe synthesis',
+        dayIndexes: [1, 2, 3, 4, 5],
+        score: 0.78,
+        summary:
+          'Winoe sees a coherent build path with useful evidence links throughout the Trial.',
+        strengths: [],
+        concerns: [],
+        evidence: [],
+        sourceLabel: 'Winoe synthesis',
+      },
+    ],
     dayScores: [
       {
         dayIndex: 1,
         score: 0.7,
-        rubricBreakdown: { communication: 0.8 },
+        summary:
+          'Design work explains the boundaries and API contract clearly.',
+        reviewerSummary:
+          'The design doc reviewer wanted the scaling assumptions called out more explicitly.',
+        rubricBreakdown: {
+          project_scaffolding_quality: 0.72,
+          architectural_coherence: 0.68,
+        },
         evidence: [
           {
             kind: 'commit',
+            label: 'Commit evidence',
             ref: 'abc123',
             url: 'https://github.com/org/repo/commit/abc123',
             excerpt: 'Introduced clean module boundaries.',
+            dayIndex: 1,
+            dimensionKey: 'project_scaffolding_quality',
+          },
+        ],
+      },
+      {
+        dayIndex: 2,
+        score: 0.82,
+        summary:
+          'Implementation started from repository structure and moved through clear commit steps.',
+        rubricBreakdown: {
+          development_process: 0.84,
+          testing_discipline: 0.8,
+        },
+        evidence: [
+          {
+            kind: 'commit_range',
+            label: 'Commit range evidence',
+            ref: 'range-2',
+            excerpt: 'Core build work and test additions progressed in order.',
+            dayIndex: 2,
+            dimensionKey: 'development_process',
+          },
+        ],
+      },
+      {
+        dayIndex: 4,
+        score: 0.79,
+        summary:
+          'Handoff + Demo was concise and linked back to the implementation choices.',
+        rubricBreakdown: {
+          communication_handoff_demo: 0.79,
+        },
+        evidence: [
+          {
+            kind: 'transcript',
+            label: 'Handoff + Demo transcript',
+            ref: 'transcript-4',
+            excerpt: 'Candidate describes architecture and follow-up items.',
+            startMs: 15000,
+            endMs: 19000,
+            dayIndex: 4,
+            dimensionKey: 'communication_handoff_demo',
           },
         ],
       },
@@ -68,8 +197,23 @@ export function setFetchForWinoeReport(
   handler: (url: string, init?: RequestInit) => Promise<Response>,
 ) {
   const fetchMock = jest.fn(
-    async (input: RequestInfo | URL, init?: RequestInit) =>
-      handler(getRequestUrl(input), init),
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = getRequestUrl(input);
+      if (url === '/api/trials/1') {
+        return jsonResponse(makeTrialDetailPayload({ id: '1' }));
+      }
+      if (url === '/api/trials/1/candidates') {
+        return jsonResponse([
+          {
+            candidateSessionId: 2,
+            candidateName: 'Jordan Reyes',
+            status: 'completed',
+            hasReport: true,
+          },
+        ]);
+      }
+      return handler(url, init);
+    },
   );
   global.fetch = fetchMock as unknown as typeof fetch;
   return fetchMock;

--- a/tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.rows.test.tsx
+++ b/tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.rows.test.tsx
@@ -78,7 +78,25 @@ describe('CandidateCompareSection row rendering', () => {
 
     const row = screen.getByTestId('candidate-compare-row-cand-9');
     expect(within(row).getByText('84%')).toBeInTheDocument();
-    expect(within(row).getByText('Hire')).toBeInTheDocument();
+    expect(
+      within(row).getByText(
+        'Evidence suggests strong alignment with this Trial.',
+      ),
+    ).toBeInTheDocument();
+    expect(within(row).queryByText(/^Hire$/i)).not.toBeInTheDocument();
+    expect(within(row).queryByText(/^Reject$/i)).not.toBeInTheDocument();
+    expect(within(row).queryByText(/^Pass$/i)).not.toBeInTheDocument();
+    expect(within(row).queryByText(/^Fail$/i)).not.toBeInTheDocument();
+    expect(within(row).queryByText(/^Proceed$/i)).not.toBeInTheDocument();
+    expect(
+      within(row).queryByText(/^Do not proceed$/i),
+    ).not.toBeInTheDocument();
+    expect(
+      within(row).queryByText(/^Recommended hire$/i),
+    ).not.toBeInTheDocument();
+    expect(
+      within(row).queryByText(/^Not recommended$/i),
+    ).not.toBeInTheDocument();
     expect(
       within(row).getByText('Strength: Clear API communication'),
     ).toBeInTheDocument();

--- a/tests/unit/features/talent-partner/winoe-report/WinoeReportComponents.states.test.tsx
+++ b/tests/unit/features/talent-partner/winoe-report/WinoeReportComponents.states.test.tsx
@@ -20,7 +20,7 @@ describe('Winoe Report components states', () => {
       />,
     );
     expect(screen.getByText('Day 4')).toBeInTheDocument();
-    expect(screen.getByText('AI Evaluation: Disabled')).toBeInTheDocument();
+    expect(screen.getByText('AI evaluation disabled')).toBeInTheDocument();
     expect(
       screen.getByText(/AI evaluation disabled for this day./i),
     ).toBeInTheDocument();

--- a/tests/unit/features/talent-partner/winoe-report/WinoeReportComponents.test.tsx
+++ b/tests/unit/features/talent-partner/winoe-report/WinoeReportComponents.test.tsx
@@ -1,30 +1,72 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { DayScoreCard } from '@/features/talent-partner/winoe-report/DayScoreCard';
+import { WinoeDimensionBreakdown } from '@/features/talent-partner/winoe-report/WinoeDimensionBreakdown';
 import { WinoeScoreHeader } from '@/features/talent-partner/winoe-report/WinoeScoreHeader';
 
 describe('Winoe Report components', () => {
-  it('renders score header recommendation and calibration', () => {
+  it('renders score header narrative and calibration', () => {
     render(
       <WinoeScoreHeader
         overallWinoeScore={0.78}
-        recommendation="hire"
+        recommendation="strong_hire"
         confidence={0.74}
         calibrationText={null}
         generatedAt="2026-03-11T10:00:00.000Z"
         disabledDayIndexes={[4]}
+        dimensionCount={2}
         scoredDayCount={3}
+        narrativeAssessment="Evidence suggests strong alignment with this Trial's engineering demands."
       />,
     );
-    expect(screen.getByText('78%')).toBeInTheDocument();
-    expect(screen.getByText('Hire')).toBeInTheDocument();
+    expect(screen.getByText('78 / 100')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Winoe's narrative assessment/i),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(/Confidence 74% based on rubric-aligned evidence/i),
     ).toBeInTheDocument();
+    expect(screen.getByText(/2 dimensions linked/i)).toBeInTheDocument();
+    expect(screen.getByText(/Disabled days: 4/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/Disabled days excluded from scoring: 4/i),
+      screen.getByText(/Evidence suggests strong alignment with this Trial\./i),
     ).toBeInTheDocument();
+    expect(screen.queryByText(/Winoe persona/i)).not.toBeInTheDocument();
   });
+
+  it.each([
+    ['hire', 'Evidence suggests strong alignment with this Trial.'],
+    ['strong_hire', 'Evidence suggests strong alignment with this Trial.'],
+    ['reject', 'Evidence shows material concerns to review.'],
+    ['do_not_proceed', 'Evidence shows material concerns to review.'],
+  ] as const)(
+    'translates backend recommendation value %s into evidence language',
+    (recommendation, expectedCopy) => {
+      render(
+        <WinoeScoreHeader
+          overallWinoeScore={0.5}
+          recommendation={recommendation}
+          confidence={0.52}
+          calibrationText={null}
+          generatedAt={null}
+          disabledDayIndexes={[]}
+          dimensionCount={0}
+          scoredDayCount={0}
+          narrativeAssessment={null}
+        />,
+      );
+      expect(screen.getByText(expectedCopy)).toBeInTheDocument();
+      expect(screen.queryByText(/^Hire$/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/^Reject$/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/^Pass$/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/^Fail$/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/^Proceed$/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Do not proceed/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Recommended hire/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Not recommended/i)).not.toBeInTheDocument();
+    },
+  );
 
   it('renders day score card with rubric breakdown', () => {
     render(
@@ -44,9 +86,81 @@ describe('Winoe Report components', () => {
       />,
     );
     expect(screen.getByText('Day 2')).toBeInTheDocument();
-    expect(screen.getByText('61%')).toBeInTheDocument();
+    expect(screen.getByText('61 / 100')).toBeInTheDocument();
     expect(screen.getByText('Problem Solving')).toBeInTheDocument();
     expect(screen.getByText('0.7')).toBeInTheDocument();
     expect(screen.getByText('clear and direct')).toBeInTheDocument();
+  });
+
+  it('renders dimension drill-down and evidence trail', async () => {
+    const user = userEvent.setup();
+    render(
+      <WinoeDimensionBreakdown
+        dimensions={[
+          {
+            key: 'project_scaffolding_quality',
+            label: 'Project scaffolding quality',
+            score: 0.83,
+            summary: 'Repository structure was established early.',
+            evidenceCount: 1,
+            linkedArtifactCount: 1,
+            sourceKeys: ['project_scaffolding_quality'],
+            emptyStateMessage: null,
+            description: 'How clearly the repository was structured.',
+            evidence: [
+              {
+                kind: 'commit',
+                ref: 'abc123',
+                url: 'https://github.com/org/repo/commit/abc123',
+                excerpt: 'Initial scaffolding commit.',
+                startMs: null,
+                endMs: null,
+                dayIndex: 2,
+                dayLabel: 'Day 2',
+              },
+            ],
+          },
+          {
+            key: 'architectural_coherence',
+            label: 'Architectural coherence',
+            score: null,
+            summary: null,
+            evidenceCount: 0,
+            linkedArtifactCount: 0,
+            sourceKeys: ['architectural_coherence'],
+            emptyStateMessage:
+              'No linked artifacts were returned for this dimension yet.',
+            description: 'How well the implementation boundaries fit together.',
+            evidence: [],
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: /Project scaffolding quality/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Architectural coherence/i }),
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getByRole('button', { name: /Project scaffolding quality/i }),
+    );
+    expect(screen.getByText(/Evidence Trail drill-down/i)).toBeInTheDocument();
+    expect(screen.getByText(/Initial scaffolding commit/i)).toBeInTheDocument();
+
+    const secondButton = screen.getByRole('button', {
+      name: /Architectural coherence/i,
+    });
+    secondButton.focus();
+    await user.keyboard('{Enter}');
+    expect(
+      screen.getByRole('heading', { name: /Architectural coherence/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText(
+        /No linked artifacts were returned for this dimension yet\./i,
+      ).length,
+    ).toBeGreaterThan(0);
   });
 });

--- a/tests/unit/features/talent-partner/winoe-report/winoeReport.normalizeReport.test.ts
+++ b/tests/unit/features/talent-partner/winoe-report/winoeReport.normalizeReport.test.ts
@@ -1,0 +1,143 @@
+import { normalizeReport } from '@/features/talent-partner/winoe-report/winoeReport.normalizeReport';
+
+describe('normalizeReport', () => {
+  it('merges explicit backend dimensions, derived day-level dimensions, and canonical from-scratch dimensions', () => {
+    const report = normalizeReport({
+      overallWinoeScore: 0.82,
+      recommendation: 'strong_hire',
+      dimensionScores: [
+        {
+          key: 'communication_handoff_demo',
+          label: 'Communication / Handoff + Demo',
+          score: 0.88,
+          summary: 'Explicit backend dimension should win.',
+          evidence: [
+            {
+              kind: 'transcript',
+              ref: 'transcript-4',
+              dayIndex: 4,
+              startMs: 15000,
+              endMs: 19000,
+              excerpt: 'Handoff and demo transcript evidence.',
+              dimensionKey: 'communication_handoff_demo',
+            },
+          ],
+        },
+        {
+          key: 'custom_dimension',
+          label: 'Custom dimension',
+          score: 0.44,
+          summary: 'Unknown backend dimensions should trail the canonical set.',
+          evidence: [],
+        },
+      ],
+      dayScores: [
+        {
+          dayIndex: 1,
+          score: 0.7,
+          rubricBreakdown: {
+            project_scaffolding_quality: 0.72,
+            architectural_coherence: 0.68,
+          },
+          evidence: [
+            {
+              kind: 'commit',
+              ref: 'commit-1',
+              dayIndex: 1,
+              dimensionKey: 'project_scaffolding_quality',
+              excerpt: 'Repository scaffolding commit.',
+            },
+          ],
+        },
+        {
+          dayIndex: 2,
+          score: 0.8,
+          rubricBreakdown: {
+            development_process: 0.84,
+            testing_discipline: 0.8,
+          },
+          evidence: [
+            {
+              kind: 'commit_range',
+              ref: 'commit-range-2',
+              dayIndex: 2,
+              dimensionKey: 'development_process',
+              excerpt: 'Commit range evidence for process.',
+            },
+          ],
+        },
+        {
+          dayIndex: 4,
+          score: 0.79,
+          rubricBreakdown: {
+            communication_handoff_demo: 0.12,
+          },
+          evidence: [],
+        },
+      ],
+      reviewerSummaries: [],
+      disabledDayIndexes: [],
+    });
+
+    expect(report).not.toBeNull();
+    expect(report?.dimensionScores.map((item) => item.key)).toEqual([
+      'project_scaffolding_quality',
+      'architectural_coherence',
+      'development_process',
+      'code_quality',
+      'testing_discipline',
+      'communication_handoff_demo',
+      'reflection_self_awareness',
+      'custom_dimension',
+    ]);
+    expect(
+      report?.dimensionScores.find(
+        (item) => item.key === 'communication_handoff_demo',
+      )?.score,
+    ).toBe(0.88);
+    expect(
+      report?.dimensionScores.find(
+        (item) => item.key === 'project_scaffolding_quality',
+      )?.score,
+    ).toBe(0.72);
+    expect(
+      report?.dimensionScores.find(
+        (item) => item.key === 'reflection_self_awareness',
+      ),
+    ).toMatchObject({
+      score: null,
+      emptyStateMessage:
+        'No linked artifacts were returned for this dimension yet.',
+    });
+    expect(
+      report?.dimensionScores.find((item) => item.key === 'custom_dimension'),
+    ).toMatchObject({
+      label: 'Custom dimension',
+    });
+    expect(
+      report?.dimensionScores.find((item) => item.key === 'custom_dimension')
+        ?.score,
+    ).toBe(0.44);
+  });
+
+  it('keeps unknown dimensions after the canonical set when no catalog match exists', () => {
+    const report = normalizeReport({
+      overallWinoeScore: 0.7,
+      recommendation: 'lean_hire',
+      dimensionScores: [
+        {
+          key: 'zeta_custom',
+          label: 'Zeta custom',
+          score: 0.61,
+          evidence: [],
+        },
+      ],
+      dayScores: [],
+      reviewerSummaries: [],
+      disabledDayIndexes: [],
+    });
+
+    expect(report?.dimensionScores.at(-1)?.key).toBe('zeta_custom');
+    expect(report?.dimensionScores[0]?.key).toBe('project_scaffolding_quality');
+  });
+});


### PR DESCRIPTION
## Summary

This PR stabilizes the Talent Partner Winoe Report page into a demo-ready artifact for issue #188.

It delivers the full report experience expected for YC-demo readiness:

- prominent Winoe Score hero
- canonical dimensional sub-scores
- from-scratch dimensions visible
- Evidence Trail drill-down
- per-day scores
- reviewer sub-agent summaries
- persona-compliant narrative language
- print-to-PDF support
- evidence-first recommendation language
- backend evidence linkage preservation

The report now reads as a trustworthy evidence review surface rather than a thin placeholder view.

## Product / UX Changes

- Winoe Score now displays prominently as `X / 100`.
- Dimensional breakdown always includes the canonical from-scratch dimensions:
  - Project scaffolding quality
  - Architectural coherence
  - Development process
  - Code quality
  - Testing discipline
  - Communication / Handoff + Demo
  - Reflection & self-awareness
- Dimension cards are clickable and keyboard-accessible.
- The drill-down panel shows linked Evidence Trail artifacts for each selected dimension.
- Dimensions without returned artifacts show honest empty states instead of fabricated content.
- Per-day scores show Day 1 through Day 5 with correct labels.
- Day 4 user-facing copy says `Handoff + Demo`.
- Reviewer sub-agent summaries are visible in the report.
- The Winoe narrative is evidence-first and non-determinative.
- The print-to-PDF layout is demo-safe.

## Backend Changes

Real QA initially failed because backend evidence sanitization stripped linkage fields needed for frontend association.

Root cause:

- Evidence artifacts existed in the DB and in report composition.
- The backend report composer/schema stripped the fields needed by the frontend to map evidence into dimensions.
- This caused all dimensions to render `0 linked artifacts`.

Backend fix:

- Preserve evidence linkage fields in the Winoe Report API payload:
  - `dimensionKey`
  - `dimensionLabel`
  - `dayLabel`
  - `sourceLabel`
  - `label`
  - `title`
  - `description`
  - `anchor`
- Extend the backend Winoe Report evidence schema.
- Add backend tests proving evidence linkage survives the sanitizer/composer/API shape.

## Frontend Changes

- Report normalization now handles older and newer payload aliases.
- Explicit backend dimensions override derived dimensions when both are present.
- Derived day-level rubric and evidence fill gaps where the backend response is partial.
- Canonical fallback dimensions remain visible with truthful pending/empty states.
- Evidence rendering supports:
  - commits
  - commit ranges
  - docs
  - transcript timestamps
  - file timelines
  - code structure
  - tests
  - coverage
  - reflection excerpts
  - reviewer excerpts
- Deterministic recommendation helpers were removed and replaced with evidence-language formatting.
- Candidate compare row recommendation copy now uses evidence-language copy.

## Persona / Terminology Compliance

Confirmed user-facing copy avoids these retired or disallowed terms:

- `Tenon`
- `SimuHire`
- `recruiter`
- `simulation`
- `Fit Profile`
- `Fit Score`
- `template`
- `precommit`
- `Specializor`

Confirmed the UI does not use deterministic recommendation labels like:

- `Hire`
- `Reject`
- `Pass`
- `Fail`
- `Proceed`
- `Do not proceed`
- `Recommended hire`
- `Not recommended`

Confirmed the UI uses the intended Winoe vocabulary:

- `Winoe`
- `Winoe AI`
- `Trial`
- `Winoe Report`
- `Winoe Score`
- `Evidence Trail`
- `Talent Partner`
- `Handoff + Demo`

## QA Evidence

### Local E2E QA

- Frontend URL: `http://localhost:3000`
- Backend URL: `http://localhost:8000`
- Route tested: `http://localhost:3000/dashboard/trials/1/candidates/1/winoe-report`
- Account used: `robel.kebede@bison.howard.edu`
- Auth confirmed via `/api/debug/auth`
  - `roles: ["talent_partner"]`
  - `permissions: ["talent_partner:access"]`
- Onboarding completed for:
  - `companyId: 1`
  - `companyName: "Winoe Demo Company"`
- Live payload endpoint: `/api/candidate_sessions/1/winoe_report`
- Live payload status: `ready`
- Evidence linkage present in payload and rendered in UI.
- Winoe Score observed: `81 / 100`
- QA target note: the original Iteration 5 note referenced `trial 2`, but the current local seed snapshot contains the valid ready report at `trial 1 / candidate session 1`.

### Artifacts

```text
test-results/iteration-7-winoe-report.png
test-results/iteration-7-evidence-drilldown.png
test-results/iteration-7-winoe-report.pdf
test-results/iteration-7-browser-qa.json
```

## Validation Commands

### Frontend

```bash
npm run lint
npm run typecheck
npx jest --runInBand tests/unit/features/talent-partner/winoe-report tests/integration/talent-partner/trials/candidates/WinoeReportPage.rendering.test.tsx tests/integration/talent-partner/trials/candidates/WinoeReportPage.interactions.test.tsx tests/integration/talent-partner/trials/candidates/WinoeReportPage.printProof.test.tsx tests/integration/talent-partner/trials/candidates/WinoeReportPage.errorStates.test.tsx tests/integration/talent-partner/trials/candidates/WinoeReportPage.pollingGenerate.test.tsx
npx jest --runInBand tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.rows.test.tsx tests/integration/talent-partner/TrialDetailPageClient.compareStates.test.tsx
./precommit.sh
```

Results:

- `npm run lint` — pass
- `npm run typecheck` — pass
- Winoe Report focused tests — pass
- Compare regression tests — failed once, then passed on rerun in a fresh Jest process
- `./precommit.sh` — pass
- Full frontend gate — `502/502` test suites passed, `1565/1565` tests passed, build passed

### Backend

```bash
set -a && source .env && set +a && PYTHONPATH=. ./.venv/bin/pytest -q --no-cov tests/evaluations/services/test_evaluations_winoe_report_composer_sanitize_evidence_service.py tests/evaluations/services/test_evaluations_winoe_report_composer_service.py tests/shared/http/routes/test_shared_http_routes_winoe_report_and_jobs_routes.py

set -a && source .env && set +a && PYTHONPATH=. ./.venv/bin/pytest -q --no-cov tests/evaluations/services/test_evaluations_winoe_report_api_fetch_service.py
```

Results:

- backend Winoe Report composer/sanitizer/routes tests — pass
- backend API fetch service tests — pass
- `./runBackend.sh migrate` — pass
- `./runBackend.sh bootstrap-local` — pass
- `./runBackend.sh` — pass
- `curl -i http://localhost:8000/health` — pass
- `curl -i http://localhost:8000/ready` — pass

## Risks / Notes

- The compare regression test showed one transient flake, then passed on rerun and passed in full precommit.
- Local seed data currently validates against `trial 1 / candidate session 1`, not stale `trial 2`.
- Backend evidence linkage is preserved now, but future backend taxonomy changes may require frontend alias updates.
- No remaining blocker for #188.

## Ready Status

Fixes #188
