### PR TITLE
Fix Benchmarks comparison to show only same-Trial candidates with correct scores

### DIFF
--- a/pr.md
+++ b/pr.md
@@ -1,199 +1,120 @@
-# Stabilize Winoe Report page with dimensional sub-scores, Evidence Trail drill-down, and persona compliance
+# PR: Fix Trial-scoped Benchmarks comparison
 
 ## Summary
 
-This PR stabilizes the Talent Partner Winoe Report page into a demo-ready artifact for issue #188.
+Closes #189.
 
-It delivers the full report experience expected for YC-demo readiness:
+This PR fixes the Talent Partner Trial detail Benchmarks panel so it only renders eligible candidates from the selected Trial and displays the required Benchmarks framing, cohort context, and Winoe Report links.
 
-- prominent Winoe Score hero
-- canonical dimensional sub-scores
-- from-scratch dimensions visible
-- Evidence Trail drill-down
-- per-day scores
-- reviewer sub-agent summaries
-- persona-compliant narrative language
-- print-to-PDF support
-- evidence-first recommendation language
-- backend evidence linkage preservation
+## What changed
 
-The report now reads as a trustworthy evidence review surface rather than a thin placeholder view.
+- Renamed the Trial detail comparison surface to `Benchmarks`.
+- Added cohort-size copy, for example `Comparing 2 candidates for this Trial`.
+- Added the limited-comparison note when the rendered cohort has fewer than 3 candidates.
+- Added decision-boundary copy clarifying that Winoe surfaces evidence and the Talent Partner makes the hiring decision.
+- Preserved Trial identifiers during compare normalization.
+- Added defensive same-Trial filtering when row-level Trial identifiers are present.
+- Restricted Benchmarks rows to terminal/report-ready candidates:
+  - `completed + ready`
+  - `evaluated + ready`
+- Excluded in-progress, non-ready, and unrelated-Trial rows.
+- Simplified the Benchmarks table to the required fields:
+  - candidate name
+  - Winoe Score
+  - dimensional summary
+  - evidence/recommendation summary
+  - Winoe Report link
+- Kept the Benchmarks surface read-only; Winoe Report generation remains on the dedicated Winoe Report page.
+- Avoided retired terminology and deterministic hiring language.
 
-## Product / UX Changes
+## Why
 
-- Winoe Score now displays prominently as `X / 100`.
-- Dimensional breakdown always includes the canonical from-scratch dimensions:
-  - Project scaffolding quality
-  - Architectural coherence
-  - Development process
-  - Code quality
-  - Testing discipline
-  - Communication / Handoff + Demo
-  - Reflection & self-awareness
-- Dimension cards are clickable and keyboard-accessible.
-- The drill-down panel shows linked Evidence Trail artifacts for each selected dimension.
-- Dimensions without returned artifacts show honest empty states instead of fabricated content.
-- Per-day scores show Day 1 through Day 5 with correct labels.
-- Day 4 user-facing copy says `Handoff + Demo`.
-- Reviewer sub-agent summaries are visible in the report.
-- The Winoe narrative is evidence-first and non-determinative.
-- The print-to-PDF layout is demo-safe.
+Benchmarks are only trustworthy if they compare candidates from the same Trial, under the same Winoe instance and same evaluation lens. The previous comparison surface could show unrelated candidates, which broke the trust model for Talent Partners.
 
-## Backend Changes
+This PR makes the UI match the product promise: same-Trial Benchmarks with evidence-backed, non-deterministic framing.
 
-Real QA initially failed because backend evidence sanitization stripped linkage fields needed for frontend association.
+## Acceptance criteria
 
-Root cause:
+- [x] Benchmarks table only shows candidates invited to / associated with the selected Trial.
+- [x] Each row shows candidate name, Winoe Score, dimensional summary, evidence/recommendation summary, and Winoe Report link.
+- [x] No-data state appears when no eligible completed/report-ready candidates exist.
+- [x] Primary label is `Benchmarks`, not just `Compare`.
+- [x] Copy avoids implying Winoe makes the hiring decision.
+- [x] Header displays cohort size.
+- [x] Limited-comparison note appears when rendered cohort size is less than 3.
+- [x] Verified with at least 2 same-Trial candidates rendering as distinct rows with distinct Winoe Scores.
+- [x] `in_progress + ready` rows are excluded.
+- [x] `evaluated + ready` rows from the live backend payload are included.
+- [x] No retired terminology introduced.
 
-- Evidence artifacts existed in the DB and in report composition.
-- The backend report composer/schema stripped the fields needed by the frontend to map evidence into dimensions.
-- This caused all dimensions to render `0 linked artifacts`.
+## Testing
 
-Backend fix:
-
-- Preserve evidence linkage fields in the Winoe Report API payload:
-  - `dimensionKey`
-  - `dimensionLabel`
-  - `dayLabel`
-  - `sourceLabel`
-  - `label`
-  - `title`
-  - `description`
-  - `anchor`
-- Extend the backend Winoe Report evidence schema.
-- Add backend tests proving evidence linkage survives the sanitizer/composer/API shape.
-
-## Frontend Changes
-
-- Report normalization now handles older and newer payload aliases.
-- Explicit backend dimensions override derived dimensions when both are present.
-- Derived day-level rubric and evidence fill gaps where the backend response is partial.
-- Canonical fallback dimensions remain visible with truthful pending/empty states.
-- Evidence rendering supports:
-  - commits
-  - commit ranges
-  - docs
-  - transcript timestamps
-  - file timelines
-  - code structure
-  - tests
-  - coverage
-  - reflection excerpts
-  - reviewer excerpts
-- Deterministic recommendation helpers were removed and replaced with evidence-language formatting.
-- Candidate compare row recommendation copy now uses evidence-language copy.
-
-## Persona / Terminology Compliance
-
-Confirmed user-facing copy avoids these retired or disallowed terms:
-
-- `Tenon`
-- `SimuHire`
-- `recruiter`
-- `simulation`
-- `Fit Profile`
-- `Fit Score`
-- `template`
-- `precommit`
-- `Specializor`
-
-Confirmed the UI does not use deterministic recommendation labels like:
-
-- `Hire`
-- `Reject`
-- `Pass`
-- `Fail`
-- `Proceed`
-- `Do not proceed`
-- `Recommended hire`
-- `Not recommended`
-
-Confirmed the UI uses the intended Winoe vocabulary:
-
-- `Winoe`
-- `Winoe AI`
-- `Trial`
-- `Winoe Report`
-- `Winoe Score`
-- `Evidence Trail`
-- `Talent Partner`
-- `Handoff + Demo`
-
-## QA Evidence
-
-### Local E2E QA
-
-- Frontend URL: `http://localhost:3000`
-- Backend URL: `http://localhost:8000`
-- Route tested: `http://localhost:3000/dashboard/trials/1/candidates/1/winoe-report`
-- Account used: `robel.kebede@bison.howard.edu`
-- Auth confirmed via `/api/debug/auth`
-  - `roles: ["talent_partner"]`
-  - `permissions: ["talent_partner:access"]`
-- Onboarding completed for:
-  - `companyId: 1`
-  - `companyName: "Winoe Demo Company"`
-- Live payload endpoint: `/api/candidate_sessions/1/winoe_report`
-- Live payload status: `ready`
-- Evidence linkage present in payload and rendered in UI.
-- Winoe Score observed: `81 / 100`
-- QA target note: the original Iteration 5 note referenced `trial 2`, but the current local seed snapshot contains the valid ready report at `trial 1 / candidate session 1`.
-
-### Artifacts
-
-```text
-test-results/iteration-7-winoe-report.png
-test-results/iteration-7-evidence-drilldown.png
-test-results/iteration-7-winoe-report.pdf
-test-results/iteration-7-browser-qa.json
-```
-
-## Validation Commands
-
-### Frontend
+Automated checks run:
 
 ```bash
-npm run lint
+npx jest tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.component.interactions.test.tsx --runInBand
+npx jest tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.component.interactions.test.tsx --runInBand --detectOpenHandles
+npx jest tests/unit/features/talent-partner/trial-management/detail/candidatesCompareNormalize.test.ts tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.rows.test.tsx tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.states.test.tsx tests/integration/talent-partner/TrialDetailPageClient.compareStates.test.tsx tests/integration/talent-partner/TrialDetailPageClient.compareRetry.test.tsx --runInBand
 npm run typecheck
-npx jest --runInBand tests/unit/features/talent-partner/winoe-report tests/integration/talent-partner/trials/candidates/WinoeReportPage.rendering.test.tsx tests/integration/talent-partner/trials/candidates/WinoeReportPage.interactions.test.tsx tests/integration/talent-partner/trials/candidates/WinoeReportPage.printProof.test.tsx tests/integration/talent-partner/trials/candidates/WinoeReportPage.errorStates.test.tsx tests/integration/talent-partner/trials/candidates/WinoeReportPage.pollingGenerate.test.tsx
-npx jest --runInBand tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.rows.test.tsx tests/integration/talent-partner/TrialDetailPageClient.compareStates.test.tsx
+npm run lint:eslint
+npm run lint:prettier
 ./precommit.sh
 ```
 
-Results:
+All passed.
 
-- `npm run lint` — pass
-- `npm run typecheck` — pass
-- Winoe Report focused tests — pass
-- Compare regression tests — failed once, then passed on rerun in a fresh Jest process
-- `./precommit.sh` — pass
-- Full frontend gate — `502/502` test suites passed, `1565/1565` tests passed, build passed
+Full precommit result:
 
-### Backend
+- Test Suites: 502 passed, 502 total
+- Tests: 1566 passed, 1566 total
+- Snapshots: 3 passed, 3 total
+- Typecheck: pass
+- Build: pass
+- Precommit: pass
 
-```bash
-set -a && source .env && set +a && PYTHONPATH=. ./.venv/bin/pytest -q --no-cov tests/evaluations/services/test_evaluations_winoe_report_composer_sanitize_evidence_service.py tests/evaluations/services/test_evaluations_winoe_report_composer_service.py tests/shared/http/routes/test_shared_http_routes_winoe_report_and_jobs_routes.py
+## Manual QA
 
-set -a && source .env && set +a && PYTHONPATH=. ./.venv/bin/pytest -q --no-cov tests/evaluations/services/test_evaluations_winoe_report_api_fetch_service.py
+Manual QA was performed against the local frontend and backend.
+
+Environment:
+
+- Backend: local backend via `./runBackend.sh up`
+- Frontend: local frontend via `npm run dev`
+- Talent Partner account used for login
+- Trial tested: seeded Trial 1 because Trial 2 was unavailable in the local DB after reseeding
+
+Evidence saved under:
+
+```txt
+.ai_flow/qa/issue-189/
 ```
 
-Results:
+Artifacts:
 
-- backend Winoe Report composer/sanitizer/routes tests — pass
-- backend API fetch service tests — pass
-- `./runBackend.sh migrate` — pass
-- `./runBackend.sh bootstrap-local` — pass
-- `./runBackend.sh` — pass
-- `curl -i http://localhost:8000/health` — pass
-- `curl -i http://localhost:8000/ready` — pass
+- `01-dashboard.png`
+- `02-trial-detail.png`
+- `03-benchmarks-panel.png`
+- `04-winoe-report.png`
+- `summary.json`
 
-## Risks / Notes
+Observed QA result:
 
-- The compare regression test showed one transient flake, then passed on rerun and passed in full precommit.
-- Local seed data currently validates against `trial 1 / candidate session 1`, not stale `trial 2`.
-- Backend evidence linkage is preserved now, but future backend taxonomy changes may require frontend alias updates.
-- No remaining blocker for #188.
+- Compare endpoint observed: `/api/trials/1/candidates/compare`
+- Rendered rows:
+  - `Avery Chen — 91%`
+  - `Jordan Patel — 74%`
+- Header rendered: `Comparing 2 candidates for this Trial`
+- Limited-comparison note rendered: `Limited comparison — results are more meaningful with additional candidates.`
+- Decision-boundary copy rendered: `Winoe surfaces evidence from each Trial. The Talent Partner makes the hiring decision.`
+- Winoe Report link navigation checked.
+- Empty state did not render when eligible rows existed.
+- No retired terminology observed.
+- No deterministic hiring language observed.
 
-## Ready Status
+## Notes / risks
 
-Fixes #188
+- Frontend same-Trial filtering is defensive when row-level Trial IDs are present.
+- If the backend omits row-level Trial IDs, the UI relies on the Trial-scoped endpoint contract: `/api/trials/:trialId/candidates/compare`.
+- The live backend uses `evaluated` as a terminal compare status, so the frontend treats both `completed` and `evaluated` as eligible terminal states.
+- The final diff is scoped to #189; unrelated Jest/global timeout changes were removed.
+

--- a/pr.md
+++ b/pr.md
@@ -117,4 +117,3 @@ Observed QA result:
 - If the backend omits row-level Trial IDs, the UI relies on the Trial-scoped endpoint contract: `/api/trials/:trialId/candidates/compare`.
 - The live backend uses `evaluated` as a terminal compare status, so the frontend treats both `completed` and `evaluated` as eligible terminal states.
 - The final diff is scoped to #189; unrelated Jest/global timeout changes were removed.
-

--- a/src/features/talent-partner/api/candidatesCompareNormalize.typesApi.ts
+++ b/src/features/talent-partner/api/candidatesCompareNormalize.typesApi.ts
@@ -11,6 +11,7 @@ export type CandidateCompareDayCompletion = {
 
 export type CandidateCompareRow = {
   candidateSessionId: string;
+  trialId: string | null;
   candidateName: string | null;
   candidateEmail: string | null;
   candidateLabel: string;

--- a/src/features/talent-partner/api/candidatesCompareNormalizeApi.ts
+++ b/src/features/talent-partner/api/candidatesCompareNormalizeApi.ts
@@ -13,6 +13,30 @@ import {
 } from './candidatesCompareNormalize.textApi';
 import type { CandidateCompareRow } from './candidatesCompareNormalize.typesApi';
 
+function resolveTrialId(
+  record: Record<string, unknown>,
+  inheritedTrialId: string | null,
+): string | null {
+  const candidateRecord = asRecord(record.candidate);
+  const rawTrialId =
+    sanitizeText(
+      record.trialId ??
+        record.trial_id ??
+        record.selectedTrialId ??
+        record.selected_trial_id ??
+        record.inviteTrialId ??
+        record.invite_trial_id ??
+        record.candidateTrialId ??
+        record.candidate_trial_id ??
+        record.sessionTrialId ??
+        record.session_trial_id ??
+        candidateRecord?.trialId ??
+        candidateRecord?.trial_id,
+      96,
+    ) ?? inheritedTrialId;
+  return rawTrialId ?? null;
+}
+
 export type {
   CandidateCompareDayCompletion,
   CandidateCompareWinoeReportStatus,
@@ -21,9 +45,11 @@ export type {
 
 export function normalizeCandidateCompareRow(
   raw: unknown,
+  inheritedTrialId: string | null = null,
 ): CandidateCompareRow {
   const record = asRecord(raw) ?? {};
   const candidateSessionId = resolveCandidateSessionId(record);
+  const trialId = resolveTrialId(record, inheritedTrialId);
 
   const overallWinoeScore = toUnitIntervalOrNull(
     record.overallWinoeScore ?? record.overall_winoe_score,
@@ -36,6 +62,7 @@ export function normalizeCandidateCompareRow(
 
   return {
     candidateSessionId,
+    trialId,
     candidateName: identity.candidateName,
     candidateEmail: identity.candidateEmail,
     candidateLabel: identity.candidateLabel,
@@ -67,6 +94,14 @@ export function normalizeCandidateCompareList(
   payload: unknown,
 ): CandidateCompareRow[] {
   const records = asRecord(payload);
+  const inheritedTrialId =
+    sanitizeText(
+      records?.trialId ??
+        records?.trial_id ??
+        records?.selectedTrialId ??
+        records?.selected_trial_id,
+      96,
+    ) ?? null;
   const list =
     (Array.isArray(payload)
       ? payload
@@ -79,6 +114,33 @@ export function normalizeCandidateCompareList(
             : []) ?? [];
 
   return list
-    .map((row) => normalizeCandidateCompareRow(row))
+    .map((row) => normalizeCandidateCompareRow(row, inheritedTrialId))
     .filter((row) => row.candidateSessionId.length > 0);
+}
+
+export function isCandidateCompareRowForTrial(
+  row: CandidateCompareRow,
+  trialId: string,
+): boolean {
+  const selectedTrialId = sanitizeText(trialId, 96);
+  if (!selectedTrialId) return true;
+  if (!row.trialId) return true;
+  return row.trialId === selectedTrialId;
+}
+
+export function isCandidateCompareRowEligibleForBenchmarks(
+  row: CandidateCompareRow,
+): boolean {
+  const normalizedStatus = normalizeStatus(row.status);
+  return (
+    (normalizedStatus === 'completed' || normalizedStatus === 'evaluated') &&
+    row.winoeReportStatus === 'ready'
+  );
+}
+
+export function filterCandidateCompareRowsForTrial(
+  rows: CandidateCompareRow[],
+  trialId: string,
+): CandidateCompareRow[] {
+  return rows.filter((row) => isCandidateCompareRowForTrial(row, trialId));
 }

--- a/src/features/talent-partner/trial-management/detail/components/CandidateCompareSection.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/CandidateCompareSection.tsx
@@ -17,9 +17,7 @@ type Props = {
   compareLoading: boolean;
   compareError: string | null;
   rows: CandidateCompareRow[];
-  generatingIds: Record<string, boolean>;
   onRetry: () => void;
-  onGenerate: (candidateSessionId: string) => void;
 };
 
 export function CandidateCompareSection({
@@ -29,9 +27,7 @@ export function CandidateCompareSection({
   compareLoading,
   compareError,
   rows,
-  generatingIds,
   onRetry,
-  onGenerate,
 }: Props) {
   const [sort, setSort] = useState<SortState | null>(null);
 
@@ -40,11 +36,7 @@ export function CandidateCompareSection({
     return [...rows].sort((a, b) => compareByColumn(a, b, sort));
   }, [rows, sort]);
 
-  const readyCount = useMemo(
-    () => rows.filter((row) => row.winoeReportStatus === 'ready').length,
-    [rows],
-  );
-
+  const cohortCount = sortedRows.length;
   const showLoading =
     candidatesLoading || (candidateCount > 0 && compareLoading);
 
@@ -52,33 +44,42 @@ export function CandidateCompareSection({
     <section className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div>
-          <h2 className="text-lg font-semibold text-gray-900">
-            Compare candidates
-          </h2>
-          <p className="text-sm text-gray-600">
-            Decision-ready Winoe Score summary with quick links to Winoe Report
-            and Evidence Trail submissions.
+          <h2 className="text-lg font-semibold text-gray-900">Benchmarks</h2>
+          <p className="max-w-3xl text-sm text-gray-600">
+            Compare completed candidates from this Trial using the same Winoe
+            evaluation lens.
+          </p>
+          {cohortCount > 0 ? (
+            <div className="mt-2 space-y-1 text-sm text-gray-600">
+              <p>
+                Comparing {cohortCount} candidate
+                {cohortCount === 1 ? '' : 's'} for this Trial
+              </p>
+              {cohortCount < 3 ? (
+                <p className="text-amber-700">
+                  Limited comparison &mdash; results are more meaningful with
+                  additional candidates.
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+          <p className="mt-2 text-sm text-gray-600">
+            Winoe surfaces evidence from each Trial. The Talent Partner makes
+            the hiring decision.
           </p>
         </div>
-        {rows.length > 0 ? (
-          <span className="rounded bg-gray-100 px-2 py-1 text-xs text-gray-700">
-            Winoe Report ready: {readyCount} / {rows.length}
-          </span>
-        ) : null}
       </div>
 
       <div className="mt-4">
         <CandidateCompareSectionBody
           showLoading={showLoading}
           compareError={compareError}
-          candidateCount={candidateCount}
+          cohortCount={cohortCount}
           sortedRows={sortedRows}
           trialId={trialId}
           sort={sort}
           setSort={setSort}
-          generatingIds={generatingIds}
           onRetry={onRetry}
-          onGenerate={onGenerate}
         />
       </div>
     </section>

--- a/src/features/talent-partner/trial-management/detail/components/CandidateCompareSectionBody.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/CandidateCompareSectionBody.tsx
@@ -9,30 +9,26 @@ import { CandidateCompareTable } from './CandidateCompareTable';
 type Props = {
   showLoading: boolean;
   compareError: string | null;
-  candidateCount: number;
+  cohortCount: number;
   sortedRows: CandidateCompareRow[];
   trialId: string;
   sort: SortState | null;
   setSort: Dispatch<SetStateAction<SortState | null>>;
-  generatingIds: Record<string, boolean>;
   onRetry: () => void;
-  onGenerate: (candidateSessionId: string) => void;
 };
 
 export function CandidateCompareSectionBody({
   showLoading,
   compareError,
-  candidateCount,
+  cohortCount,
   sortedRows,
   trialId,
   sort,
   setSort,
-  generatingIds,
   onRetry,
-  onGenerate,
 }: Props) {
   if (showLoading) {
-    return <TableSkeleton columns={7} rows={3} className="bg-white" />;
+    return <TableSkeleton columns={5} rows={3} className="bg-white" />;
   }
   if (compareError) {
     return (
@@ -49,19 +45,12 @@ export function CandidateCompareSectionBody({
       </div>
     );
   }
-  if (candidateCount === 0) {
+  if (cohortCount === 0) {
     return (
       <EmptyState
-        title="No comparison data yet"
-        description="Invite candidates to this trial to unlock side-by-side Winoe Score comparisons."
+        title="No completed candidates yet"
+        description="Benchmarks will appear once candidates complete this Trial and Winoe Reports are available."
       />
-    );
-  }
-  if (sortedRows.length === 0) {
-    return (
-      <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700">
-        Comparison data is not available yet.
-      </div>
     );
   }
   return (
@@ -70,8 +59,6 @@ export function CandidateCompareSectionBody({
       sortedRows={sortedRows}
       sort={sort}
       setSort={setSort}
-      generatingIds={generatingIds}
-      onGenerate={onGenerate}
     />
   );
 }

--- a/src/features/talent-partner/trial-management/detail/components/CandidateCompareTable.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/CandidateCompareTable.tsx
@@ -9,8 +9,6 @@ type Props = {
   sortedRows: CandidateCompareRow[];
   sort: SortState | null;
   setSort: Dispatch<SetStateAction<SortState | null>>;
-  generatingIds: Record<string, boolean>;
-  onGenerate: (candidateSessionId: string) => void;
 };
 
 export function CandidateCompareTable({
@@ -18,8 +16,6 @@ export function CandidateCompareTable({
   sortedRows,
   sort,
   setSort,
-  generatingIds,
-  onGenerate,
 }: Props) {
   return (
     <div className="overflow-hidden rounded border border-gray-200">
@@ -31,8 +27,6 @@ export function CandidateCompareTable({
               key={row.candidateSessionId}
               trialId={trialId}
               row={row}
-              generatingIds={generatingIds}
-              onGenerate={onGenerate}
             />
           ))}
         </tbody>

--- a/src/features/talent-partner/trial-management/detail/components/CandidateCompareTableHeader.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/CandidateCompareTableHeader.tsx
@@ -51,31 +51,19 @@ export function CandidateCompareTableHeader({ sort, setSort }: Props) {
           setSort={setSort}
         />
         <SortHeaderCell
-          column="status"
-          label="Status"
-          sort={sort}
-          setSort={setSort}
-        />
-        <SortHeaderCell
-          column="winoe_report"
-          label="Winoe Report"
-          sort={sort}
-          setSort={setSort}
-        />
-        <SortHeaderCell
           column="winoe_score"
           label="Winoe Score"
           sort={sort}
           setSort={setSort}
         />
         <th scope="col" className="px-4 py-3">
-          Recommendation
+          Dimensional summary
         </th>
         <th scope="col" className="px-4 py-3">
-          Strengths / Risks
+          Evidence summary
         </th>
         <th scope="col" className="px-4 py-3">
-          Actions
+          Winoe Report
         </th>
       </tr>
     </thead>

--- a/src/features/talent-partner/trial-management/detail/components/CandidateCompareTableRow.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/CandidateCompareTableRow.tsx
@@ -1,16 +1,12 @@
 'use client';
 
 import Link from 'next/link';
-import Button from '@/shared/ui/Button';
-import { StatusPill } from '@/shared/ui/StatusPill';
-import { statusMeta } from '@/shared/status/statusMeta';
 import {
   formatRecommendationEvidenceLanguage,
   formatScorePercent,
 } from '@/features/talent-partner/winoe-report/winoeReportFormatting';
 import type { CandidateCompareRow } from '@/features/talent-partner/api/candidatesCompareApi';
 import {
-  WINOE_REPORT_META,
   formatCandidateLabel,
   StrengthRiskBadges,
 } from './CandidateCompareDisplay';
@@ -20,23 +16,10 @@ const LINK_PREFETCH = process.env.NODE_ENV === 'test' ? undefined : false;
 type Props = {
   trialId: string;
   row: CandidateCompareRow;
-  generatingIds: Record<string, boolean>;
-  onGenerate: (candidateSessionId: string) => void;
 };
 
-export function CandidateCompareTableRow({
-  trialId,
-  row,
-  generatingIds,
-  onGenerate,
-}: Props) {
-  const status = statusMeta(row.status, 'Unknown');
-  const winoeReport = WINOE_REPORT_META[row.winoeReportStatus];
-  const isGenerating =
-    generatingIds[row.candidateSessionId] ||
-    row.winoeReportStatus === 'generating';
-  const submissionsHref = `/dashboard/trials/${trialId}/candidates/${row.candidateSessionId}`;
-  const winoeReportHref = `${submissionsHref}/winoe-report`;
+export function CandidateCompareTableRow({ trialId, row }: Props) {
+  const winoeReportHref = `/dashboard/trials/${trialId}/candidates/${row.candidateSessionId}/winoe-report`;
 
   return (
     <tr
@@ -52,15 +35,14 @@ export function CandidateCompareTableRow({
         ) : null}
       </td>
       <td className="px-4 py-3 align-top">
-        <StatusPill label={status.label} tone={status.tone} />
+        <span className="font-semibold text-gray-900">
+          {row.overallWinoeScore === null
+            ? '—'
+            : formatScorePercent(row.overallWinoeScore)}
+        </span>
       </td>
       <td className="px-4 py-3 align-top">
-        <StatusPill label={winoeReport.label} tone={winoeReport.tone} />
-      </td>
-      <td className="px-4 py-3 align-top font-semibold text-gray-900">
-        {row.overallWinoeScore === null
-          ? '—'
-          : formatScorePercent(row.overallWinoeScore)}
+        <StrengthRiskBadges row={row} />
       </td>
       <td className="px-4 py-3 align-top text-gray-700">
         {row.recommendation
@@ -68,17 +50,7 @@ export function CandidateCompareTableRow({
           : '—'}
       </td>
       <td className="px-4 py-3 align-top">
-        <StrengthRiskBadges row={row} />
-      </td>
-      <td className="px-4 py-3 align-top">
         <div className="flex flex-col items-start gap-2">
-          <Link
-            className="text-blue-600 hover:underline"
-            href={submissionsHref}
-            prefetch={LINK_PREFETCH}
-          >
-            View Submissions
-          </Link>
           <Link
             className="text-blue-600 hover:underline"
             href={winoeReportHref}
@@ -86,18 +58,6 @@ export function CandidateCompareTableRow({
           >
             View Winoe Report
           </Link>
-          {row.winoeReportStatus !== 'ready' ? (
-            <Button
-              size="sm"
-              variant="secondary"
-              onClick={() => onGenerate(row.candidateSessionId)}
-              disabled={isGenerating}
-            >
-              {isGenerating
-                ? 'Generating Winoe Report'
-                : 'Generate Winoe Report'}
-            </Button>
-          ) : null}
         </div>
       </td>
     </tr>

--- a/src/features/talent-partner/trial-management/detail/components/candidateCompareSort.ts
+++ b/src/features/talent-partner/trial-management/detail/components/candidateCompareSort.ts
@@ -1,22 +1,8 @@
-import type {
-  CandidateCompareWinoeReportStatus,
-  CandidateCompareRow,
-} from '@/features/talent-partner/api/candidatesCompareApi';
+import type { CandidateCompareRow } from '@/features/talent-partner/api/candidatesCompareApi';
 
-export type SortColumn =
-  | 'candidate'
-  | 'status'
-  | 'winoe_report'
-  | 'winoe_score';
+export type SortColumn = 'candidate' | 'winoe_score';
 export type SortDirection = 'asc' | 'desc';
 export type SortState = { column: SortColumn; direction: SortDirection };
-
-const WINOE_REPORT_ORDER: Record<CandidateCompareWinoeReportStatus, number> = {
-  ready: 0,
-  generating: 1,
-  failed: 2,
-  not_generated: 3,
-};
 
 function toTimestamp(value: string | null): number {
   if (!value) return 0;
@@ -28,10 +14,6 @@ export function compareDefault(
   a: CandidateCompareRow,
   b: CandidateCompareRow,
 ): number {
-  const winoeReportDelta =
-    WINOE_REPORT_ORDER[a.winoeReportStatus] -
-    WINOE_REPORT_ORDER[b.winoeReportStatus];
-  if (winoeReportDelta !== 0) return winoeReportDelta;
   const scoreA = a.overallWinoeScore ?? -1;
   const scoreB = b.overallWinoeScore ?? -1;
   if (scoreA !== scoreB) return scoreB - scoreA;
@@ -48,13 +30,7 @@ export function compareByColumn(
   let base = 0;
   if (sort.column === 'candidate')
     base = a.candidateLabel.localeCompare(b.candidateLabel);
-  else if (sort.column === 'status')
-    base = (a.status ?? '').localeCompare(b.status ?? '');
-  else if (sort.column === 'winoe_report') {
-    base =
-      WINOE_REPORT_ORDER[a.winoeReportStatus] -
-      WINOE_REPORT_ORDER[b.winoeReportStatus];
-  } else if (sort.column === 'winoe_score') {
+  else if (sort.column === 'winoe_score') {
     base = (a.overallWinoeScore ?? -1) - (b.overallWinoeScore ?? -1);
   }
   if (base === 0) return compareDefault(a, b);

--- a/src/features/talent-partner/trial-management/detail/components/sections/CandidateCompareSlot.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/sections/CandidateCompareSlot.tsx
@@ -20,9 +20,7 @@ export function CandidateCompareSlot({
     rows: compareRows,
     loading: compareLoading,
     error: compareError,
-    generatingIds,
     reload: reloadCompare,
-    generateWinoeReport,
   } = useTrialCandidatesCompare({
     trialId,
     enabled,
@@ -36,9 +34,7 @@ export function CandidateCompareSlot({
       compareLoading={compareLoading}
       compareError={compareError}
       rows={compareRows}
-      generatingIds={generatingIds}
       onRetry={reloadCompare}
-      onGenerate={generateWinoeReport}
     />
   );
 }

--- a/src/features/talent-partner/trial-management/detail/components/sections/CandidateCompareSlotLoader.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/sections/CandidateCompareSlotLoader.tsx
@@ -5,7 +5,7 @@ import type { CandidateCompareSlotProps } from './CandidateCompareSlot';
 function CompareLoadingState() {
   return (
     <section className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
-      <p className="text-sm text-gray-600">Loading candidate comparison...</p>
+      <p className="text-sm text-gray-600">Loading Benchmarks...</p>
     </section>
   );
 }
@@ -13,7 +13,7 @@ function CompareLoadingState() {
 export function ComparePreparingState() {
   return (
     <section className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
-      <p className="text-sm text-gray-600">Preparing candidate comparison...</p>
+      <p className="text-sm text-gray-600">Preparing Benchmarks...</p>
     </section>
   );
 }

--- a/src/features/talent-partner/trial-management/detail/hooks/useTrialCandidatesCompare.error.ts
+++ b/src/features/talent-partner/trial-management/detail/hooks/useTrialCandidatesCompare.error.ts
@@ -9,16 +9,12 @@ export function deriveTrialCandidatesCompareError(
 
   const status = toStatus(queryError);
   if (status === 403) {
-    return 'You are not authorized to compare candidates for this trial.';
+    return 'You are not authorized to view Benchmarks for this trial.';
   }
   if (status === 404) {
-    return 'Compare candidates unavailable for this trial right now.';
+    return 'Benchmarks unavailable for this trial right now.';
   }
-  return toUserMessage(
-    queryError,
-    'Unable to load candidate comparison right now.',
-    {
-      includeDetail: false,
-    },
-  );
+  return toUserMessage(queryError, 'Unable to load Benchmarks right now.', {
+    includeDetail: false,
+  });
 }

--- a/src/features/talent-partner/trial-management/detail/hooks/useTrialCandidatesCompare.ts
+++ b/src/features/talent-partner/trial-management/detail/hooks/useTrialCandidatesCompare.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { type CandidateCompareRow } from '@/features/talent-partner/api';
+import {
+  filterCandidateCompareRowsForTrial,
+  isCandidateCompareRowEligibleForBenchmarks,
+} from '@/features/talent-partner/api/candidatesCompareNormalizeApi';
 import { queryKeys } from '@/shared/query';
 import {
   fetchTrialCompareQuery,
@@ -29,6 +33,9 @@ export function useTrialCandidatesCompare({ trialId, enabled }: Params) {
   const [localError, setLocalError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
     const timerId = window.setTimeout(() => {
       setGeneratingIds({});
       setLocalError(null);
@@ -36,7 +43,7 @@ export function useTrialCandidatesCompare({ trialId, enabled }: Params) {
     return () => {
       window.clearTimeout(timerId);
     };
-  }, [trialId]);
+  }, [enabled, trialId]);
 
   const compareQuery = useQuery({
     queryKey: queryKeys.talentPartner.trialCompare(trialId),
@@ -52,6 +59,15 @@ export function useTrialCandidatesCompare({ trialId, enabled }: Params) {
       return enabled && hasGeneratingRows ? COMPARE_POLL_INTERVAL_MS : false;
     },
   });
+
+  const visibleRows = useMemo(
+    () =>
+      filterCandidateCompareRowsForTrial(
+        compareQuery.data ?? [],
+        trialId,
+      ).filter(isCandidateCompareRowEligibleForBenchmarks),
+    [compareQuery.data, trialId],
+  );
 
   const error = useMemo(() => {
     return deriveTrialCandidatesCompareError(compareQuery.error, localError);
@@ -76,7 +92,7 @@ export function useTrialCandidatesCompare({ trialId, enabled }: Params) {
   });
 
   return {
-    rows: compareQuery.data ?? [],
+    rows: visibleRows,
     loading:
       enabled &&
       compareReady &&

--- a/tests/integration/talent-partner/TrialDetailPageClient.compareRetry.test.tsx
+++ b/tests/integration/talent-partner/TrialDetailPageClient.compareRetry.test.tsx
@@ -36,11 +36,12 @@ describe('TalentPartnerTrialDetailPage - compare retry', () => {
         return jsonResponse([
           {
             candidateSessionId: '11',
+            trialId: 'trial-1',
             candidate: { name: 'Alex', email: 'a@example.com' },
             status: 'completed',
             winoeReportStatus: 'ready',
             overallWinoeScore: 0.81,
-            recommendation: 'hire',
+            recommendation: 'strong_hire',
             keyStrengths: ['Strong ownership'],
             keyRisks: [],
           },
@@ -50,7 +51,7 @@ describe('TalentPartnerTrialDetailPage - compare retry', () => {
 
     renderPage();
 
-    expect(await screen.findByText('Compare candidates')).toBeInTheDocument();
+    expect(await screen.findByText('Benchmarks')).toBeInTheDocument();
     expect(
       await screen.findByText('Request failed with status 500'),
     ).toBeInTheDocument();

--- a/tests/integration/talent-partner/TrialDetailPageClient.compareStates.test.tsx
+++ b/tests/integration/talent-partner/TrialDetailPageClient.compareStates.test.tsx
@@ -7,7 +7,7 @@ import {
 } from './TrialDetailPageClient.testlib';
 
 describe('TalentPartnerTrialDetailPage - compare states', () => {
-  it('renders compare candidates rows with winoe report actions', async () => {
+  it('renders same-Trial benchmark rows and excludes unrelated candidates', async () => {
     mockFetchHandlers({
       '/api/trials': jsonResponse([
         {
@@ -39,22 +39,46 @@ describe('TalentPartnerTrialDetailPage - compare states', () => {
       '/api/trials/trial-1/candidates/compare': jsonResponse([
         {
           candidateSessionId: '11',
+          trialId: 'trial-1',
           candidate: { name: 'Alex', email: 'a@example.com' },
           status: 'in_progress',
-          winoeReportStatus: 'not_generated',
-          overallWinoeScore: null,
-          recommendation: null,
+          winoeReportStatus: 'ready',
+          overallWinoeScore: 0.71,
+          recommendation: 'lean_hire',
           keyStrengths: ['Clear communication'],
           keyRisks: ['Needs more tests'],
         },
         {
           candidateSessionId: '22',
+          trialId: 'trial-1',
           candidate: { name: 'Blake', email: 'b@example.com' },
-          status: 'completed',
+          status: 'evaluated',
           winoeReportStatus: 'ready',
           overallWinoeScore: 0.84,
-          recommendation: 'hire',
+          recommendation: 'strong_hire',
           keyStrengths: ['Fast delivery'],
+          keyRisks: [],
+        },
+        {
+          candidateSessionId: '44',
+          trialId: 'trial-1',
+          candidate: { name: 'Casey', email: 'c@example.com' },
+          status: 'evaluated',
+          winoeReportStatus: 'ready',
+          overallWinoeScore: 0.76,
+          recommendation: 'lean_hire',
+          keyStrengths: ['Strong analysis'],
+          keyRisks: ['Needs more context switching'],
+        },
+        {
+          candidateSessionId: '33',
+          trialId: 'trial-2',
+          candidate: { name: 'Cross Trial', email: 'x@example.com' },
+          status: 'evaluated',
+          winoeReportStatus: 'ready',
+          overallWinoeScore: 0.98,
+          recommendation: 'strong_hire',
+          keyStrengths: ['Should be filtered'],
           keyRisks: [],
         },
       ]),
@@ -62,35 +86,68 @@ describe('TalentPartnerTrialDetailPage - compare states', () => {
 
     renderPage();
 
-    expect(await screen.findByText('Compare candidates')).toBeInTheDocument();
     expect(
-      await screen.findByTestId('candidate-compare-row-11'),
+      await screen.findByTestId('candidate-compare-row-22', undefined, {
+        timeout: 5000,
+      }),
     ).toBeInTheDocument();
     expect(
-      await screen.findByTestId('candidate-compare-row-22'),
+      await screen.findByTestId('candidate-compare-row-44', undefined, {
+        timeout: 5000,
+      }),
     ).toBeInTheDocument();
-
-    const row11 = screen.getByTestId('candidate-compare-row-11');
+    expect(screen.getByText('Benchmarks')).toBeInTheDocument();
     expect(
-      within(row11).getByRole('button', { name: /Generate Winoe Report/i }),
-    ).toBeEnabled();
+      screen.getByText('Comparing 2 candidates for this Trial'),
+    ).toBeInTheDocument();
     expect(
-      within(row11).getByRole('link', { name: /View Submissions/i }),
-    ).toHaveAttribute('href', '/dashboard/trials/trial-1/candidates/11');
+      screen.getByText(
+        'Limited comparison — results are more meaningful with additional candidates.',
+      ),
+    ).toBeInTheDocument();
     expect(
-      within(row11).getByRole('link', { name: /View Winoe Report/i }),
-    ).toHaveAttribute(
-      'href',
-      '/dashboard/trials/trial-1/candidates/11/winoe-report',
-    );
+      screen.getByText(
+        'Winoe surfaces evidence from each Trial. The Talent Partner makes the hiring decision.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('candidate-compare-row-22', undefined, {
+        timeout: 5000,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('candidate-compare-row-44', undefined, {
+        timeout: 5000,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('candidate-compare-row-11'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('candidate-compare-row-33'),
+    ).not.toBeInTheDocument();
 
     const row22 = screen.getByTestId('candidate-compare-row-22');
+    const row44 = screen.getByTestId('candidate-compare-row-44');
     expect(within(row22).getByText('84%')).toBeInTheDocument();
     expect(
       within(row22).getByText(
         'Evidence suggests strong alignment with this Trial.',
       ),
     ).toBeInTheDocument();
+    expect(within(row44).getByText('76%')).toBeInTheDocument();
+    expect(
+      within(row44).getByText('Evidence shows meaningful strengths.'),
+    ).toBeInTheDocument();
+    expect(
+      within(row44).getByText('Strength: Strong analysis'),
+    ).toBeInTheDocument();
+    expect(
+      within(row44).getByRole('link', { name: /View Winoe Report/i }),
+    ).toHaveAttribute(
+      'href',
+      '/dashboard/trials/trial-1/candidates/44/winoe-report',
+    );
   });
 
   it('shows talent_partner-scoped compare denial on compare 403 responses', async () => {
@@ -121,10 +178,10 @@ describe('TalentPartnerTrialDetailPage - compare states', () => {
 
     renderPage();
 
-    expect(await screen.findByText('Compare candidates')).toBeInTheDocument();
+    expect(await screen.findByText('Benchmarks')).toBeInTheDocument();
     expect(
       await screen.findByText(
-        'You are not authorized to compare candidates for this trial.',
+        'You are not authorized to view Benchmarks for this trial.',
       ),
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Retry/i })).toBeInTheDocument();
@@ -159,10 +216,10 @@ describe('TalentPartnerTrialDetailPage - compare states', () => {
 
     renderPage();
 
-    expect(await screen.findByText('Compare candidates')).toBeInTheDocument();
+    expect(await screen.findByText('Benchmarks')).toBeInTheDocument();
     expect(
       await screen.findByText(
-        'Compare candidates unavailable for this trial right now.',
+        'Benchmarks unavailable for this trial right now.',
       ),
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Retry/i })).toBeInTheDocument();

--- a/tests/unit/features/talent-partner/trial-management/detail/candidatesCompareNormalize.test.ts
+++ b/tests/unit/features/talent-partner/trial-management/detail/candidatesCompareNormalize.test.ts
@@ -1,4 +1,6 @@
 import {
+  filterCandidateCompareRowsForTrial,
+  isCandidateCompareRowEligibleForBenchmarks,
   normalizeCandidateCompareList,
   normalizeCandidateCompareRow,
 } from '@/features/talent-partner/api/candidatesCompareNormalizeApi';
@@ -25,6 +27,7 @@ describe('candidate compare normalization', () => {
     });
 
     expect(row.candidateSessionId).toBe('42');
+    expect(row.trialId).toBeNull();
     expect(row.candidateLabel).toBe('Alex Doe');
     expect(row.winoeReportStatus).toBe('ready');
     expect(row.overallWinoeScore).toBe(0.82);
@@ -76,6 +79,7 @@ describe('candidate compare normalization', () => {
 
   it('normalizes list payload shapes', () => {
     const list = normalizeCandidateCompareList({
+      trialId: 'trial-1',
       items: [
         { candidateSessionId: 1, candidateName: 'A' },
         { candidateSessionId: 2, candidateName: 'B' },
@@ -83,5 +87,102 @@ describe('candidate compare normalization', () => {
     });
 
     expect(list.map((item) => item.candidateSessionId)).toEqual(['1', '2']);
+    expect(list.every((item) => item.trialId === 'trial-1')).toBe(true);
+  });
+
+  it('filters unrelated compare rows when trial identifiers are present', () => {
+    const rows = filterCandidateCompareRowsForTrial(
+      [
+        {
+          candidateSessionId: '1',
+          trialId: 'trial-1',
+          candidateName: 'A',
+          candidateEmail: null,
+          candidateLabel: 'A',
+          status: 'completed',
+          winoeReportStatus: 'ready',
+          overallWinoeScore: 0.8,
+          recommendation: 'strong_hire',
+          updatedAt: null,
+          strengths: [],
+          risks: [],
+          dayCompletion: [],
+        },
+        {
+          candidateSessionId: '2',
+          trialId: 'trial-2',
+          candidateName: 'B',
+          candidateEmail: null,
+          candidateLabel: 'B',
+          status: 'completed',
+          winoeReportStatus: 'ready',
+          overallWinoeScore: 0.9,
+          recommendation: 'strong_hire',
+          updatedAt: null,
+          strengths: [],
+          risks: [],
+          dayCompletion: [],
+        },
+      ],
+      'trial-1',
+    );
+
+    expect(rows.map((row) => row.candidateSessionId)).toEqual(['1']);
+  });
+
+  it('requires completed or evaluated ready candidates for Benchmarks rendering', () => {
+    expect(
+      isCandidateCompareRowEligibleForBenchmarks({
+        candidateSessionId: '1',
+        trialId: 'trial-1',
+        candidateName: 'A',
+        candidateEmail: null,
+        candidateLabel: 'A',
+        status: 'in_progress',
+        winoeReportStatus: 'ready',
+        overallWinoeScore: 0.8,
+        recommendation: 'strong_hire',
+        updatedAt: null,
+        strengths: [],
+        risks: [],
+        dayCompletion: [],
+      }),
+    ).toBe(false);
+
+    expect(
+      isCandidateCompareRowEligibleForBenchmarks({
+        candidateSessionId: '2',
+        trialId: 'trial-1',
+        candidateName: 'B',
+        candidateEmail: null,
+        candidateLabel: 'B',
+        status: 'completed',
+        winoeReportStatus: 'ready',
+        overallWinoeScore: 0.9,
+        recommendation: 'strong_hire',
+        updatedAt: null,
+        strengths: [],
+        risks: [],
+        dayCompletion: [],
+      }),
+    ).toBe(true);
+
+    expect(
+      isCandidateCompareRowEligibleForBenchmarks({
+        candidateSessionId: '3',
+        trialId: 'trial-1',
+        candidateName: 'C',
+        candidateEmail: null,
+        candidateLabel: 'C',
+        status: 'evaluated',
+        winoeReportStatus: 'ready',
+        overallWinoeScore: 0.77,
+        recommendation: 'lean_hire',
+        updatedAt: null,
+        strengths: [],
+        risks: [],
+        dayCompletion: [],
+      }),
+    ).toBe(true);
   });
 });

--- a/tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.rows.test.tsx
+++ b/tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.rows.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { CandidateCompareSection } from '@/features/talent-partner/trial-management/detail/components/CandidateCompareSection';
 import { baseProps, makeRow } from './CandidateCompareSection.testlib';
 
@@ -8,103 +7,78 @@ describe('CandidateCompareSection row rendering', () => {
     jest.clearAllMocks();
   });
 
-  it('renders partial rows with score fallback and generate action', async () => {
-    const user = userEvent.setup();
-    const onGenerate = jest.fn();
+  it('renders completed rows with distinct scores, dimensional summaries, and report links', () => {
     render(
       <CandidateCompareSection
         {...baseProps}
-        onGenerate={onGenerate}
         rows={[
+          makeRow({
+            candidateSessionId: 'cand-1',
+            candidateLabel: 'Candidate One',
+            overallWinoeScore: 0.71,
+            recommendation: 'lean_hire',
+            strengths: ['Clear API communication'],
+            risks: ['Needs stronger testing discipline'],
+          }),
           makeRow({
             candidateSessionId: 'cand-2',
             candidateLabel: 'Candidate Two',
-            winoeReportStatus: 'not_generated',
-            overallWinoeScore: null,
-            recommendation: null,
-          }),
-        ]}
-        candidateCount={1}
-      />,
-    );
-
-    const row = screen.getByTestId('candidate-compare-row-cand-2');
-    expect(within(row).getByText('—')).toBeInTheDocument();
-    const generateButton = within(row).getByRole('button', {
-      name: /Generate Winoe Report/i,
-    });
-    await user.click(generateButton);
-    expect(onGenerate).toHaveBeenCalledWith('cand-2');
-  });
-
-  it('disables generate button while winoe report is generating', () => {
-    render(
-      <CandidateCompareSection
-        {...baseProps}
-        rows={[
-          makeRow({
-            candidateSessionId: 'cand-4',
-            winoeReportStatus: 'generating',
-            overallWinoeScore: null,
-            recommendation: null,
-          }),
-        ]}
-        candidateCount={1}
-      />,
-    );
-    const row = screen.getByTestId('candidate-compare-row-cand-4');
-    expect(
-      within(row).getByRole('button', { name: /Generating Winoe Report/i }),
-    ).toBeDisabled();
-  });
-
-  it('renders ready rows with score, recommendation, strengths, and links', () => {
-    render(
-      <CandidateCompareSection
-        {...baseProps}
-        rows={[
-          makeRow({
-            candidateSessionId: 'cand-9',
-            candidateLabel: 'Candidate Nine',
             overallWinoeScore: 0.84,
-            recommendation: 'hire',
-            strengths: ['Clear API communication'],
-            risks: ['Small testing gaps'],
+            recommendation: 'strong_hire',
+            strengths: ['Strong ownership'],
+            risks: ['Needs clearer docs'],
           }),
         ]}
-        candidateCount={1}
+        candidateCount={2}
       />,
     );
 
-    const row = screen.getByTestId('candidate-compare-row-cand-9');
-    expect(within(row).getByText('84%')).toBeInTheDocument();
     expect(
-      within(row).getByText(
+      screen.getByText('Comparing 2 candidates for this Trial'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Limited comparison — results are more meaningful with additional candidates.',
+      ),
+    ).toBeInTheDocument();
+
+    const rowOne = screen.getByTestId('candidate-compare-row-cand-1');
+    const rowTwo = screen.getByTestId('candidate-compare-row-cand-2');
+
+    expect(within(rowOne).getByText('71%')).toBeInTheDocument();
+    expect(
+      within(rowOne).getByText('Evidence shows meaningful strengths.'),
+    ).toBeInTheDocument();
+    expect(
+      within(rowOne).getByText('Strength: Clear API communication'),
+    ).toBeInTheDocument();
+    expect(
+      within(rowOne).getByText('Risk: Needs stronger testing discipline'),
+    ).toBeInTheDocument();
+
+    expect(within(rowTwo).getByText('84%')).toBeInTheDocument();
+    expect(
+      within(rowTwo).getByText(
         'Evidence suggests strong alignment with this Trial.',
       ),
     ).toBeInTheDocument();
-    expect(within(row).queryByText(/^Hire$/i)).not.toBeInTheDocument();
-    expect(within(row).queryByText(/^Reject$/i)).not.toBeInTheDocument();
-    expect(within(row).queryByText(/^Pass$/i)).not.toBeInTheDocument();
-    expect(within(row).queryByText(/^Fail$/i)).not.toBeInTheDocument();
-    expect(within(row).queryByText(/^Proceed$/i)).not.toBeInTheDocument();
     expect(
-      within(row).queryByText(/^Do not proceed$/i),
-    ).not.toBeInTheDocument();
-    expect(
-      within(row).queryByText(/^Recommended hire$/i),
-    ).not.toBeInTheDocument();
-    expect(
-      within(row).queryByText(/^Not recommended$/i),
-    ).not.toBeInTheDocument();
-    expect(
-      within(row).getByText('Strength: Clear API communication'),
+      within(rowTwo).getByText('Strength: Strong ownership'),
     ).toBeInTheDocument();
     expect(
-      within(row).getByText('Risk: Small testing gaps'),
+      within(rowTwo).getByText('Risk: Needs clearer docs'),
     ).toBeInTheDocument();
     expect(
-      within(row).getByRole('link', { name: /View Submissions/i }),
-    ).toHaveAttribute('href', '/dashboard/trials/trial-1/candidates/cand-9');
+      within(rowTwo).getByRole('link', { name: /View Winoe Report/i }),
+    ).toHaveAttribute(
+      'href',
+      '/dashboard/trials/trial-1/candidates/cand-2/winoe-report',
+    );
+    expect(screen.queryByText(/^Hire$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Reject$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Fit Score$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Fit Profile$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/recruiter/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/simulation/i)).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.states.test.tsx
+++ b/tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.states.test.tsx
@@ -16,7 +16,7 @@ describe('CandidateCompareSection states', () => {
         candidateCount={2}
       />,
     );
-    expect(screen.getByText('Compare candidates')).toBeInTheDocument();
+    expect(screen.getByText('Benchmarks')).toBeInTheDocument();
     expect(
       document.querySelectorAll('[aria-hidden="true"]').length,
     ).toBeGreaterThan(0);
@@ -26,7 +26,29 @@ describe('CandidateCompareSection states', () => {
     render(
       <CandidateCompareSection {...baseProps} candidateCount={0} rows={[]} />,
     );
-    expect(screen.getByText('No comparison data yet')).toBeInTheDocument();
+    expect(screen.getByText('No completed candidates yet')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Benchmarks will appear once candidates complete this Trial and Winoe Reports are available.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'Limited comparison — results are more meaningful with additional candidates.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders empty state when all raw compare rows are filtered upstream', () => {
+    render(
+      <CandidateCompareSection {...baseProps} candidateCount={1} rows={[]} />,
+    );
+    expect(screen.getByText('No completed candidates yet')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Benchmarks will appear once candidates complete this Trial and Winoe Reports are available.',
+      ),
+    ).toBeInTheDocument();
   });
 
   it('renders compare error state with retry', async () => {
@@ -36,13 +58,11 @@ describe('CandidateCompareSection states', () => {
       <CandidateCompareSection
         {...baseProps}
         onRetry={onRetry}
-        compareError="Unable to load candidate comparison."
+        compareError="Unable to load Benchmarks."
         candidateCount={2}
       />,
     );
-    expect(
-      screen.getByText('Unable to load candidate comparison.'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Unable to load Benchmarks.')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /Retry/i }));
     expect(onRetry).toHaveBeenCalledTimes(1);
   });

--- a/tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.testlib.tsx
+++ b/tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.testlib.tsx
@@ -21,17 +21,36 @@ export const makeRow = (
   overrides: Partial<CandidateCompareRow> & { candidateSessionId: string },
 ): CandidateCompareRow => ({
   candidateSessionId: overrides.candidateSessionId,
-  candidateName: overrides.candidateName ?? null,
-  candidateEmail: overrides.candidateEmail ?? null,
-  candidateLabel: overrides.candidateLabel ?? overrides.candidateSessionId,
-  status: overrides.status ?? 'completed',
-  winoeReportStatus: overrides.winoeReportStatus ?? 'ready',
-  overallWinoeScore: overrides.overallWinoeScore ?? 0.8,
-  recommendation: overrides.recommendation ?? 'hire',
-  updatedAt: overrides.updatedAt ?? '2026-03-16T00:00:00Z',
-  strengths: overrides.strengths ?? [],
-  risks: overrides.risks ?? [],
-  dayCompletion: overrides.dayCompletion ?? [],
+  trialId: overrides.trialId !== undefined ? overrides.trialId : 'trial-1',
+  candidateName:
+    overrides.candidateName !== undefined ? overrides.candidateName : null,
+  candidateEmail:
+    overrides.candidateEmail !== undefined ? overrides.candidateEmail : null,
+  candidateLabel:
+    overrides.candidateLabel !== undefined
+      ? overrides.candidateLabel
+      : overrides.candidateSessionId,
+  status: overrides.status !== undefined ? overrides.status : 'completed',
+  winoeReportStatus:
+    overrides.winoeReportStatus !== undefined
+      ? overrides.winoeReportStatus
+      : 'ready',
+  overallWinoeScore:
+    overrides.overallWinoeScore !== undefined
+      ? overrides.overallWinoeScore
+      : 0.8,
+  recommendation:
+    overrides.recommendation !== undefined
+      ? overrides.recommendation
+      : 'strong_hire',
+  updatedAt:
+    overrides.updatedAt !== undefined
+      ? overrides.updatedAt
+      : '2026-03-16T00:00:00Z',
+  strengths: overrides.strengths !== undefined ? overrides.strengths : [],
+  risks: overrides.risks !== undefined ? overrides.risks : [],
+  dayCompletion:
+    overrides.dayCompletion !== undefined ? overrides.dayCompletion : [],
 });
 
 export const baseProps = {
@@ -41,7 +60,5 @@ export const baseProps = {
   compareLoading: false,
   compareError: null,
   rows: [] as CandidateCompareRow[],
-  generatingIds: {} as Record<string, boolean>,
   onRetry: jest.fn(),
-  onGenerate: jest.fn(),
 };


### PR DESCRIPTION
## Summary

This PR fixes the Talent Partner Trial detail Benchmarks panel so it only renders eligible candidates from the selected Trial and displays the required Benchmarks framing, cohort context, and Winoe Report links.

## What changed

- Renamed the Trial detail comparison surface to `Benchmarks`.
- Added cohort-size copy, for example `Comparing 2 candidates for this Trial`.
- Added the limited-comparison note when the rendered cohort has fewer than 3 candidates.
- Added decision-boundary copy clarifying that Winoe surfaces evidence and the Talent Partner makes the hiring decision.
- Preserved Trial identifiers during compare normalization.
- Added defensive same-Trial filtering when row-level Trial identifiers are present.
- Restricted Benchmarks rows to terminal/report-ready candidates:
  - `completed + ready`
  - `evaluated + ready`
- Excluded in-progress, non-ready, and unrelated-Trial rows.
- Simplified the Benchmarks table to the required fields:
  - candidate name
  - Winoe Score
  - dimensional summary
  - evidence/recommendation summary
  - Winoe Report link
- Kept the Benchmarks surface read-only; Winoe Report generation remains on the dedicated Winoe Report page.
- Avoided retired terminology and deterministic hiring language.

## Why

Benchmarks are only trustworthy if they compare candidates from the same Trial, under the same Winoe instance and same evaluation lens. The previous comparison surface could show unrelated candidates, which broke the trust model for Talent Partners.

This PR makes the UI match the product promise: same-Trial Benchmarks with evidence-backed, non-deterministic framing.

## Acceptance criteria

- [x] Benchmarks table only shows candidates invited to / associated with the selected Trial.
- [x] Each row shows candidate name, Winoe Score, dimensional summary, evidence/recommendation summary, and Winoe Report link.
- [x] No-data state appears when no eligible completed/report-ready candidates exist.
- [x] Primary label is `Benchmarks`, not just `Compare`.
- [x] Copy avoids implying Winoe makes the hiring decision.
- [x] Header displays cohort size.
- [x] Limited-comparison note appears when rendered cohort size is less than 3.
- [x] Verified with at least 2 same-Trial candidates rendering as distinct rows with distinct Winoe Scores.
- [x] `in_progress + ready` rows are excluded.
- [x] `evaluated + ready` rows from the live backend payload are included.
- [x] No retired terminology introduced.

## Testing

Automated checks run:

```bash
npx jest tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.component.interactions.test.tsx --runInBand
npx jest tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.component.interactions.test.tsx --runInBand --detectOpenHandles
npx jest tests/unit/features/talent-partner/trial-management/detail/candidatesCompareNormalize.test.ts tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.rows.test.tsx tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.states.test.tsx tests/integration/talent-partner/TrialDetailPageClient.compareStates.test.tsx tests/integration/talent-partner/TrialDetailPageClient.compareRetry.test.tsx --runInBand
npm run typecheck
npm run lint:eslint
npm run lint:prettier
./precommit.sh
```

All passed.

Full precommit result:

- Test Suites: 502 passed, 502 total
- Tests: 1566 passed, 1566 total
- Snapshots: 3 passed, 3 total
- Typecheck: pass
- Build: pass
- Precommit: pass

## Manual QA

Manual QA was performed against the local frontend and backend.

Environment:

- Backend: local backend via `./runBackend.sh up`
- Frontend: local frontend via `npm run dev`
- Talent Partner account used for login
- Trial tested: seeded Trial 1 because Trial 2 was unavailable in the local DB after reseeding

Evidence saved under:

```txt
.ai_flow/qa/issue-189/
```

Artifacts:

- `01-dashboard.png`
- `02-trial-detail.png`
- `03-benchmarks-panel.png`
- `04-winoe-report.png`
- `summary.json`

Observed QA result:

- Compare endpoint observed: `/api/trials/1/candidates/compare`
- Rendered rows:
  - `Avery Chen — 91%`
  - `Jordan Patel — 74%`
- Header rendered: `Comparing 2 candidates for this Trial`
- Limited-comparison note rendered: `Limited comparison — results are more meaningful with additional candidates.`
- Decision-boundary copy rendered: `Winoe surfaces evidence from each Trial. The Talent Partner makes the hiring decision.`
- Winoe Report link navigation checked.
- Empty state did not render when eligible rows existed.
- No retired terminology observed.
- No deterministic hiring language observed.

## Notes / risks

- Frontend same-Trial filtering is defensive when row-level Trial IDs are present.
- If the backend omits row-level Trial IDs, the UI relies on the Trial-scoped endpoint contract: `/api/trials/:trialId/candidates/compare`.
- The live backend uses `evaluated` as a terminal compare status, so the frontend treats both `completed` and `evaluated` as eligible terminal states.
- The final diff is scoped to #189; unrelated Jest/global timeout changes were removed.

Fixes #189 