### PR TITLE
Complete Day 5 reflection essay UI with extended window and completion transition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ ai_flow_boot_script.sh
 
 # Contract-live generated artifacts
 /qa_verifications/Contract-Live-QA/contract_live_qa_latest
+/qa_verifications/Contract-Live-QA/iteration*-live-evidence/
 
 # Code Quality generated artifacts
 /code-quality

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -123,6 +123,8 @@ runtimeRequire('./tests/setup/jest/consoleSilence');
 runtimeRequire('./tests/setup/jest/reactMarkdownMock');
 runtimeRequire('./tests/setup/jest/candidateApiCompatMocks');
 
+jest.setTimeout(15000);
+
 afterEach(() => {
   cleanup();
 });

--- a/qa_verifications/Contract-Live-QA/live_flow_driver.mjs
+++ b/qa_verifications/Contract-Live-QA/live_flow_driver.mjs
@@ -5,7 +5,16 @@ import { chromium } from 'playwright';
 const command = process.argv[2]?.trim() || '';
 const baseURL =
   process.env.CONTRACT_LIVE_BASE_URL?.trim() || 'http://localhost:3000';
+const backendBaseURL =
+  process.env.CONTRACT_LIVE_BACKEND_URL?.trim() || 'http://127.0.0.1:8000';
 const artifactsDir = process.env.CONTRACT_LIVE_ARTIFACTS_DIR?.trim();
+const LOCAL_DEV_USER_EMAILS = {
+  talent_partner: 'talent_partner1@local.test',
+  candidate: 'candidate1@local.test',
+};
+let activeDevUserEmail = null;
+let activeDevUserRole = null;
+let activeCandidateSessionId = null;
 
 if (!artifactsDir) {
   throw new Error('CONTRACT_LIVE_ARTIFACTS_DIR is required.');
@@ -76,6 +85,23 @@ function trimToNull(value) {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
   return trimmed || null;
+}
+
+function resolveActiveDevUserEmail(role, overrideEmail = null) {
+  const explicitEmail = trimToNull(overrideEmail);
+  if (explicitEmail) return explicitEmail;
+  if (role === 'talent_partner') {
+    return (
+      trimToNull(process.env.CONTRACT_LIVE_TALENT_PARTNER_EMAIL) ||
+      trimToNull(process.env.QA_E2E_TALENT_PARTNER_EMAIL) ||
+      LOCAL_DEV_USER_EMAILS.talent_partner
+    );
+  }
+  return (
+    trimToNull(process.env.CONTRACT_LIVE_CANDIDATE_EMAIL) ||
+    trimToNull(process.env.QA_E2E_CANDIDATE_EMAIL) ||
+    LOCAL_DEV_USER_EMAILS.candidate
+  );
 }
 
 function parseDateInput(dateInput) {
@@ -241,64 +267,122 @@ async function sleep(ms) {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function withPage(role, work) {
+async function withPage(
+  role,
+  work,
+  candidateSessionId = null,
+  devUserEmailOverride = null,
+) {
   const browser = await chromium.launch({ headless: true });
+  const activeEmail = resolveActiveDevUserEmail(role, devUserEmailOverride);
+  const extraHTTPHeaders = {};
+  if (activeEmail) {
+    extraHTTPHeaders['x-dev-user-email'] = activeEmail;
+    extraHTTPHeaders['authorization'] = `Bearer ${role}:${activeEmail}`;
+  }
+  if (candidateSessionId != null) {
+    extraHTTPHeaders['x-candidate-session-id'] = String(candidateSessionId);
+  }
   const context = await browser.newContext({
     baseURL,
     storageState: requireStorageState(role),
+    extraHTTPHeaders,
   });
   const page = await context.newPage();
+  activeDevUserEmail = activeEmail;
+  activeDevUserRole = role;
+  activeCandidateSessionId = candidateSessionId;
+  await page.route('**/api/backend/**', async (route) => {
+    const headers = {
+      ...route.request().headers(),
+    };
+    if (activeDevUserEmail) {
+      headers['x-dev-user-email'] = activeDevUserEmail;
+      headers['authorization'] = `Bearer ${role}:${activeDevUserEmail}`;
+    }
+    if (activeCandidateSessionId != null) {
+      headers['x-candidate-session-id'] = String(activeCandidateSessionId);
+    }
+    await route.continue({ headers });
+  });
   try {
-    await page.goto(
-      role === 'talent_partner' ? '/dashboard' : '/candidate/dashboard',
-      {
+    if (role === 'talent_partner') {
+      await page.goto('/dashboard', {
         waitUntil: 'domcontentloaded',
-      },
-    );
-    await page.waitForLoadState('domcontentloaded');
+      });
+      await page.waitForLoadState('domcontentloaded');
+    }
     return await work(page);
   } finally {
+    activeDevUserEmail = null;
+    activeDevUserRole = null;
+    activeCandidateSessionId = null;
     await browser.close();
   }
 }
 
 async function browserFetchJson(page, url, options = {}) {
-  return await page.evaluate(
-    async ({ url: innerUrl, options: innerOptions }) => {
-      const headers = {
-        ...(innerOptions.headers || {}),
-      };
-      if (
-        innerOptions.body != null &&
-        !Object.keys(headers).some(
-          (key) => key.toLowerCase() === 'content-type',
-        )
-      ) {
-        headers['content-type'] = 'application/json';
-      }
-      const res = await fetch(innerUrl, {
-        ...innerOptions,
-        headers,
-        body: innerOptions.body ?? undefined,
-      });
-      const text = await res.text();
-      let json = null;
-      try {
-        json = text ? JSON.parse(text) : null;
-      } catch {
-        json = { raw: text };
-      }
-      return {
-        ok: res.ok,
-        status: res.status,
-        statusText: res.statusText,
-        url: res.url,
-        text,
-        json,
-      };
-    },
-    { url, options },
-  );
+  const cookieJar = await page.context().cookies(baseURL);
+  const cookieHeader = cookieJar
+    .map((cookie) => `${cookie.name}=${cookie.value}`)
+    .join('; ');
+  const headers = {
+    ...(activeDevUserEmail ? { 'x-dev-user-email': activeDevUserEmail } : {}),
+    ...(activeDevUserEmail && activeDevUserRole
+      ? {
+          authorization: `Bearer ${activeDevUserRole}:${activeDevUserEmail}`,
+        }
+      : {}),
+    ...(activeCandidateSessionId != null
+      ? {
+          'x-candidate-session-id': String(activeCandidateSessionId),
+        }
+      : {}),
+    ...(url.startsWith('/api/backend/') ? { origin: baseURL } : {}),
+    ...(cookieHeader ? { cookie: cookieHeader } : {}),
+    ...(options.headers || {}),
+  };
+  const requestOptions = {
+    ...options,
+    headers,
+  };
+  if (options.body != null) {
+    if (
+      !Object.keys(headers).some((key) => key.toLowerCase() === 'content-type')
+    ) {
+      headers['content-type'] = 'application/json';
+    }
+    const rawBody = String(options.body);
+    try {
+      requestOptions.data = JSON.parse(rawBody);
+    } catch {
+      requestOptions.data = rawBody;
+    }
+    delete requestOptions.body;
+  }
+
+  const absoluteUrl = new URL(
+    url.startsWith('/api/backend/')
+      ? url.replace(/^\/api\/backend/, '/api')
+      : url,
+    url.startsWith('/api/backend/') ? backendBaseURL : baseURL,
+  ).toString();
+  const res = await page.request.fetch(absoluteUrl, requestOptions);
+  const text = await res.text();
+  let json = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = { raw: text };
+  }
+  return {
+    ok: res.ok(),
+    status: res.status(),
+    statusText: res.statusText(),
+    url: res.url(),
+    text,
+    json,
+  };
 }
 
 async function pollUntil(
@@ -465,15 +549,24 @@ async function clickFirstVisible(locator) {
   return true;
 }
 
-async function gotoCandidateSession(page, inviteToken) {
+async function gotoCandidateSession(
+  page,
+  inviteToken,
+  options = { waitForReady: true },
+) {
   await page.goto(`/candidate/session/${inviteToken}`, {
-    waitUntil: 'domcontentloaded',
+    waitUntil: 'commit',
+    timeout: 60000,
   });
-  await page.waitForLoadState('networkidle');
+  await page
+    .waitForLoadState('domcontentloaded', { timeout: 60000 })
+    .catch(() => {});
   if (page.url().includes('/auth/login')) {
     throw new Error(`Candidate session redirected to login: ${page.url()}`);
   }
-  await waitForCandidateSessionReady(page, 60000);
+  if (options.waitForReady !== false) {
+    await waitForCandidateSessionReady(page, 60000);
+  }
 }
 
 async function ensureDayVisible(page, day) {
@@ -628,12 +721,12 @@ async function controlCandidateSessionDayWindow(
     );
   }
 
-  const response = await browserFetchJson(
-    page,
-    `/api/backend/admin/candidate_sessions/${candidateSessionId}/day_windows/control`,
+  const response = await fetch(
+    `${backendBaseURL}/api/admin/candidate_sessions/${candidateSessionId}/day_windows/control`,
     {
       method: 'POST',
       headers: {
+        'Content-Type': 'application/json',
         'X-Admin-Key': adminKey,
       },
       body: JSON.stringify({
@@ -643,13 +736,28 @@ async function controlCandidateSessionDayWindow(
       }),
     },
   );
-  writeJson(`candidate-day${targetDayIndex}-day-window-control.json`, response);
+  const text = await response.text();
+  let json = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = { raw: text };
+  }
+  const result = {
+    ok: response.ok,
+    status: response.status,
+    statusText: response.statusText,
+    url: response.url,
+    text,
+    json,
+  };
+  writeJson(`candidate-day${targetDayIndex}-day-window-control.json`, result);
   if (!response.ok) {
     throw new Error(
-      `Candidate day-window control failed for day ${targetDayIndex}: ${response.status} ${response.text}`,
+      `Candidate day-window control failed for day ${targetDayIndex}: ${response.status} ${text}`,
     );
   }
-  return response;
+  return result;
 }
 
 async function submitCandidateTaskViaApi(
@@ -781,9 +889,8 @@ async function runTalentPartnerFreshFlow() {
     const createPayload = {
       title,
       role: 'Backend Engineer',
-      techStack: 'Python, FastAPI, pytest',
-      seniority: 'mid',
-      templateKey: 'python-fastapi',
+      seniority: 'Mid',
+      preferredLanguageFramework: 'Python, FastAPI, pytest',
       focus: 'Fresh end-to-end proof after live bundle/runtime repairs',
       companyContext: {
         domain: 'B2B developer tooling',
@@ -848,7 +955,7 @@ async function runTalentPartnerFreshFlow() {
 
     const approve = await browserFetchJson(
       page,
-      `/api/backend/trials/${trialId}/scenario/${scenarioVersionId}/approve`,
+      `/api/trials/${trialId}/scenario/${scenarioVersionId}/approve`,
       { method: 'POST' },
     );
     writeJson(`trial-${trialId}-approve.json`, approve);
@@ -860,7 +967,7 @@ async function runTalentPartnerFreshFlow() {
 
     const activate = await browserFetchJson(
       page,
-      `/api/backend/trials/${trialId}/activate`,
+      `/api/trials/${trialId}/activate`,
       {
         method: 'POST',
         body: JSON.stringify({ confirm: true }),
@@ -958,118 +1065,145 @@ async function runCandidateScheduleFlow() {
     );
   }
 
-  return await withPage('candidate', async (page) => {
-    await gotoCandidateSession(page, inviteToken);
-    const bootstrapBefore = await fetchCandidateBootstrap(
-      page,
-      inviteToken,
-      'candidate-bootstrap-before-schedule.json',
-    );
-    if (!bootstrapBefore.ok) {
-      throw new Error(
-        `Candidate bootstrap failed before scheduling: ${bootstrapBefore.status} ${bootstrapBefore.text}`,
+  return await withPage(
+    'candidate',
+    async (page) => {
+      await gotoCandidateSession(page, inviteToken, { waitForReady: false });
+      const bootstrapBefore = await fetchCandidateBootstrap(
+        page,
+        inviteToken,
+        'candidate-bootstrap-before-schedule.json',
       );
-    }
-    await capturePage(page, 'candidate-schedule-landing.json', {
-      inviteToken,
-      scheduleDate,
-      candidateTimezone,
-    });
-
-    const startButton = page.getByRole('button', { name: /start trial/i });
-    const scheduleStartDate = page.getByLabel(/start date/i);
-    if ((await startButton.count()) > 0) {
-      await startButton.first().waitFor({ state: 'visible', timeout: 60000 });
-      const startButtonClicked = await clickFirstVisible(startButton);
-      if (startButtonClicked) {
-        await page.waitForLoadState('networkidle');
+      if (!bootstrapBefore.ok) {
+        throw new Error(
+          `Candidate bootstrap failed before scheduling: ${bootstrapBefore.status} ${bootstrapBefore.text}`,
+        );
       }
-    }
-    await scheduleStartDate.waitFor({ state: 'visible', timeout: 60000 });
-
-    await scheduleStartDate.fill(scheduleDate);
-    const timezoneInput = page.getByLabel(/timezone/i);
-    if ((await timezoneInput.count()) > 0) {
-      await timezoneInput.fill(candidateTimezone);
-      await timezoneInput.press('Tab').catch(() => {});
-    }
-    await capturePage(page, 'candidate-schedule-draft.json', {
-      inviteToken,
-      scheduleDate,
-      candidateTimezone,
-    });
-
-    const continueButton = page.getByRole('button', { name: /^continue$/i });
-    await continueButton.click();
-    await page.waitForTimeout(500);
-    const githubValidationVisible = await page
-      .getByText(/enter your github username/i)
-      .first()
-      .isVisible()
-      .catch(() => false);
-    if (!githubValidationVisible) {
-      throw new Error(
-        'Candidate schedule should block empty GitHub username before continuing.',
-      );
-    }
-
-    await page.getByLabel(/github username/i).fill(githubUsername);
-
-    await page.getByRole('button', { name: /^continue$/i }).click();
-    const scheduledStartAtUtc = localDateAtHourToUtcIso({
-      dateInput: scheduleDate,
-      timezone: candidateTimezone,
-    });
-    const scheduleResponse = await scheduleCandidateSessionViaApi(
-      page,
-      inviteToken,
-      {
-        scheduledStartAt: scheduledStartAtUtc,
+      await capturePage(page, 'candidate-schedule-landing.json', {
+        inviteToken,
+        scheduleDate,
         candidateTimezone,
-        githubUsername,
-      },
-    );
-    const scheduleJson = scheduleResponse.json;
+      });
 
-    await page.waitForLoadState('networkidle');
-    await page.reload({ waitUntil: 'networkidle' });
-    const bootstrapAfter = await fetchCandidateBootstrap(
-      page,
-      inviteToken,
-      'candidate-bootstrap-after-schedule.json',
-    );
-    await capturePage(page, 'candidate-schedule-post-confirm.json', {
-      inviteToken,
-      scheduleDate,
-      candidateTimezone,
-    });
+      const startButton = page.getByRole('button', { name: /start trial/i });
+      const scheduleStartDate = page.getByLabel(/start date/i);
+      if ((await startButton.count()) > 0) {
+        await startButton.first().waitFor({ state: 'visible', timeout: 60000 });
+        const startButtonClicked = await clickFirstVisible(startButton);
+        if (startButtonClicked) {
+          await page.waitForLoadState('networkidle');
+        }
+      }
+      await scheduleStartDate.waitFor({ state: 'visible', timeout: 60000 });
 
-    const summary = {
-      inviteToken,
-      candidateSessionId:
-        bootstrapAfter.json?.candidateSessionId ?? context.candidateSessionId,
-      scheduledStartAt:
-        scheduleJson?.scheduledStartAt ??
-        bootstrapAfter.json?.scheduledStartAt ??
-        null,
-      candidateTimezone:
-        scheduleJson?.candidateTimezone ??
-        bootstrapAfter.json?.candidateTimezone ??
-        null,
-      githubUsername:
-        scheduleJson?.githubUsername ??
-        bootstrapAfter.json?.githubUsername ??
-        null,
-      scheduleLockedAt:
-        scheduleJson?.scheduleLockedAt ??
-        bootstrapAfter.json?.scheduleLockedAt ??
-        null,
-      currentDayWindow: bootstrapAfter.json?.currentDayWindow ?? null,
-      pageUrl: page.url(),
-    };
-    writeJson('candidate-schedule-summary.json', summary);
-    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
-  });
+      await scheduleStartDate.fill(scheduleDate);
+      const timezoneInput = page.getByLabel(/timezone/i);
+      if ((await timezoneInput.count()) > 0) {
+        await timezoneInput.fill(candidateTimezone);
+        await timezoneInput.press('Tab').catch(() => {});
+      }
+      await capturePage(page, 'candidate-schedule-draft.json', {
+        inviteToken,
+        scheduleDate,
+        candidateTimezone,
+      });
+
+      const continueButton = page.getByRole('button', { name: /^continue$/i });
+      await continueButton.click();
+      await page.waitForTimeout(500);
+      const githubValidationVisible = await page
+        .getByText(/enter your github username/i)
+        .first()
+        .isVisible()
+        .catch(() => false);
+      if (!githubValidationVisible) {
+        throw new Error(
+          'Candidate schedule should block empty GitHub username before continuing.',
+        );
+      }
+
+      await page.getByLabel(/github username/i).fill(githubUsername);
+
+      await page.getByRole('button', { name: /^continue$/i }).click();
+      const confirmButton = page.getByRole('button', {
+        name: /confirm schedule/i,
+      });
+      await confirmButton.waitFor({ state: 'visible', timeout: 60000 });
+      const scheduleResponsePromise = page.waitForResponse(
+        (response) =>
+          response
+            .url()
+            .includes(
+              `/api/backend/candidate/session/${encodeURIComponent(inviteToken)}/schedule`,
+            ) && response.request().method() === 'POST',
+        { timeout: 120000 },
+      );
+      await confirmButton.click();
+      const scheduleResponse = await scheduleResponsePromise;
+      const scheduleResponseText = await scheduleResponse.text();
+      let scheduleJson = null;
+      try {
+        scheduleJson = scheduleResponseText
+          ? JSON.parse(scheduleResponseText)
+          : null;
+      } catch {
+        scheduleJson = { raw: scheduleResponseText };
+      }
+      writeJson('candidate-schedule-response.json', {
+        ok: scheduleResponse.ok(),
+        status: scheduleResponse.status(),
+        statusText: scheduleResponse.statusText(),
+        url: scheduleResponse.url(),
+        text: scheduleResponseText,
+        json: scheduleJson,
+      });
+      if (!scheduleResponse.ok()) {
+        throw new Error(
+          `Candidate schedule failed: ${scheduleResponse.status()} ${scheduleResponseText}`,
+        );
+      }
+
+      await page.waitForLoadState('networkidle');
+      await page.reload({ waitUntil: 'networkidle' });
+      const bootstrapAfter = await fetchCandidateBootstrap(
+        page,
+        inviteToken,
+        'candidate-bootstrap-after-schedule.json',
+      );
+      await capturePage(page, 'candidate-schedule-post-confirm.json', {
+        inviteToken,
+        scheduleDate,
+        candidateTimezone,
+      });
+
+      const summary = {
+        inviteToken,
+        candidateSessionId:
+          bootstrapAfter.json?.candidateSessionId ?? context.candidateSessionId,
+        scheduledStartAt:
+          scheduleJson?.scheduledStartAt ??
+          bootstrapAfter.json?.scheduledStartAt ??
+          null,
+        candidateTimezone:
+          scheduleJson?.candidateTimezone ??
+          bootstrapAfter.json?.candidateTimezone ??
+          null,
+        githubUsername:
+          scheduleJson?.githubUsername ??
+          bootstrapAfter.json?.githubUsername ??
+          null,
+        scheduleLockedAt:
+          scheduleJson?.scheduleLockedAt ??
+          bootstrapAfter.json?.scheduleLockedAt ??
+          null,
+        currentDayWindow: bootstrapAfter.json?.currentDayWindow ?? null,
+        pageUrl: page.url(),
+      };
+      writeJson('candidate-schedule-summary.json', summary);
+      process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+    },
+    context.candidateSessionId,
+  );
 }
 
 async function runCandidateDayFlow() {
@@ -1089,154 +1223,18 @@ async function runCandidateDayFlow() {
     throw new Error('candidate-day requires CONTRACT_LIVE_DAY=1..5.');
   }
 
-  return await withPage('candidate', async (page) => {
-    await gotoCandidateSession(page, inviteToken);
-    const startTrialButton = page.getByRole('button', { name: /start trial/i });
-    const startTrialVisible = await startTrialButton
-      .first()
-      .isVisible()
-      .catch(() => false);
-    if (!startTrialVisible) {
-      await controlCandidateSessionDayWindow(
-        page,
-        candidateSessionId,
-        requestedDay,
-        candidateTimezone,
-      );
-      await page.reload({ waitUntil: 'networkidle' });
-      await waitForCandidateSessionReady(page, 60000);
-    }
-    await clickFirstVisible(startTrialButton);
-    await page.waitForLoadState('networkidle');
-    await ensureDayVisible(page, requestedDay);
-
-    const currentTaskBefore = await fetchCandidateCurrentTask(
-      page,
-      candidateSessionId,
-      `candidate-day${requestedDay}-current-task-before.json`,
-    );
-    if (!currentTaskBefore.ok) {
-      throw new Error(
-        `Unable to load current task for day ${requestedDay}: ${currentTaskBefore.status} ${currentTaskBefore.text}`,
-      );
-    }
-    const currentTask = extractCurrentTask(currentTaskBefore);
-    const taskId = Number(currentTask?.id);
-    const actualDayIndex = Number(currentTask?.dayIndex);
-    const closedByBackend =
-      currentTaskBefore.json?.currentWindow?.isOpen === false ||
-      currentTaskBefore.json?.currentWindow?.state === 'closed';
-    if (!Number.isFinite(taskId)) {
-      throw new Error(
-        `Current task for day ${requestedDay} did not include a task id: ${JSON.stringify(
-          currentTaskBefore.json,
-          null,
-          2,
-        )}`,
-      );
-    }
-    if (requestedDay === 1 && actualDayIndex > requestedDay) {
-      writeJson(`candidate-day${requestedDay}-already-advanced.json`, {
-        requestedDay,
-        actualDayIndex,
-        currentTask: currentTaskBefore.json?.currentTask ?? null,
-        completedTaskIds: currentTaskBefore.json?.completedTaskIds ?? null,
-        note: 'Day 1 was already advanced in the live session state, so the driver records the current task and continues with later phases.',
+  return await withPage(
+    'candidate',
+    async (page) => {
+      await gotoCandidateSession(page, inviteToken);
+      const startTrialButton = page.getByRole('button', {
+        name: /start trial/i,
       });
-      const summary = {
-        inviteToken,
-        candidateSessionId,
-        taskId,
-        requestedDay,
-        pageUrl: page.url(),
-        closedByBackend,
-        currentTaskAfter: currentTaskBefore.json,
-        skippedAlreadyAdvanced: true,
-      };
-      writeJson(`candidate-day${requestedDay}-summary.json`, summary);
-      process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
-      return;
-    }
-    if (actualDayIndex !== requestedDay) {
-      throw new Error(
-        `Expected day ${requestedDay} but current task is day ${actualDayIndex}: ${JSON.stringify(
-          currentTaskBefore.json,
-          null,
-          2,
-        )}`,
-      );
-    }
-
-    await capturePage(page, `candidate-day${requestedDay}-before.json`, {
-      inviteToken,
-      candidateSessionId,
-      taskId,
-    });
-
-    if (requestedDay === 1) {
-      const textArea = page.locator('textarea').first();
-      const textAreaVisible = await textArea
-        .isVisible({ timeout: 5000 })
+      const startTrialVisible = await startTrialButton
+        .first()
+        .isVisible()
         .catch(() => false);
-      if (textAreaVisible) {
-        await textArea.fill(defaultDay1Response());
-        await clickFirstVisible(
-          page.getByRole('button', { name: /save draft/i }),
-        );
-        const submitResponsePromise = page.waitForResponse(
-          (response) =>
-            response.url().includes(`/tasks/${taskId}/submit`) &&
-            response.request().method() === 'POST',
-          { timeout: 120000 },
-        );
-        await page.getByRole('button', { name: /submit & continue/i }).click();
-        const submitResponse = await submitResponsePromise;
-        writeJson(`candidate-day${requestedDay}-submit.json`, {
-          ok: submitResponse.ok(),
-          status: submitResponse.status(),
-          url: submitResponse.url(),
-          text: await submitResponse.text(),
-          mode: 'ui',
-        });
-        if (!submitResponse.ok()) {
-          throw new Error(
-            `Day ${requestedDay} submit failed with status ${submitResponse.status()}.`,
-          );
-        }
-      } else {
-        const submitResponse = await submitCandidateTaskViaApi(
-          page,
-          taskId,
-          candidateSessionId,
-          { contentText: defaultDay1Response() },
-          `candidate-day${requestedDay}-submit-api.json`,
-        );
-        writeJson(`candidate-day${requestedDay}-submit.json`, {
-          ok: submitResponse.ok,
-          status: submitResponse.status,
-          url: submitResponse.url,
-          text: submitResponse.text,
-          mode: 'api',
-        });
-      }
-      await page.waitForTimeout(1000);
-      const currentTaskAfter = await fetchCandidateCurrentTask(
-        page,
-        candidateSessionId,
-        `candidate-day${requestedDay}-current-task-after.json`,
-      );
-      const nextDayIndex = Number(currentTaskAfter.json?.currentTask?.dayIndex);
-      if (!Number.isFinite(nextDayIndex) || nextDayIndex !== requestedDay + 1) {
-        throw new Error(
-          `Day ${requestedDay} submit did not advance to the next task. Current task: ${JSON.stringify(
-            currentTaskAfter.json,
-            null,
-            2,
-          )}`,
-        );
-      }
-    } else if (requestedDay === 2 || requestedDay === 3) {
-      if (closedByBackend) {
+      if (!startTrialVisible) {
         await controlCandidateSessionDayWindow(
           page,
           candidateSessionId,
@@ -1244,18 +1242,93 @@ async function runCandidateDayFlow() {
           candidateTimezone,
         );
         await page.reload({ waitUntil: 'networkidle' });
-        const currentTaskAfterControl = await fetchCandidateCurrentTask(
-          page,
+        await waitForCandidateSessionReady(page, 60000);
+      }
+      await clickFirstVisible(startTrialButton);
+      await page.waitForLoadState('networkidle');
+      await ensureDayVisible(page, requestedDay);
+
+      const currentTaskBefore = await fetchCandidateCurrentTask(
+        page,
+        candidateSessionId,
+        `candidate-day${requestedDay}-current-task-before.json`,
+      );
+      if (!currentTaskBefore.ok) {
+        throw new Error(
+          `Unable to load current task for day ${requestedDay}: ${currentTaskBefore.status} ${currentTaskBefore.text}`,
+        );
+      }
+      const currentTask = extractCurrentTask(currentTaskBefore);
+      const taskId = Number(currentTask?.id);
+      const actualDayIndex = Number(currentTask?.dayIndex);
+      const closedByBackend =
+        currentTaskBefore.json?.currentWindow?.isOpen === false ||
+        currentTaskBefore.json?.currentWindow?.state === 'closed';
+      if (!Number.isFinite(taskId)) {
+        throw new Error(
+          `Current task for day ${requestedDay} did not include a task id: ${JSON.stringify(
+            currentTaskBefore.json,
+            null,
+            2,
+          )}`,
+        );
+      }
+      if (requestedDay === 1 && actualDayIndex > requestedDay) {
+        writeJson(`candidate-day${requestedDay}-already-advanced.json`, {
+          requestedDay,
+          actualDayIndex,
+          currentTask: currentTaskBefore.json?.currentTask ?? null,
+          completedTaskIds: currentTaskBefore.json?.completedTaskIds ?? null,
+          note: 'Day 1 was already advanced in the live session state, so the driver records the current task and continues with later phases.',
+        });
+        const summary = {
+          inviteToken,
           candidateSessionId,
-          `candidate-day${requestedDay}-current-task-after-control.json`,
-        );
-        const reopenedDayIndex = Number(
-          currentTaskAfterControl.json?.currentTask?.dayIndex,
-        );
-        if (reopenedDayIndex !== requestedDay) {
+          taskId,
+          requestedDay,
+          pageUrl: page.url(),
+          closedByBackend,
+          currentTaskAfter: currentTaskBefore.json,
+          skippedAlreadyAdvanced: true,
+        };
+        writeJson(`candidate-day${requestedDay}-summary.json`, summary);
+        process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+        return;
+      }
+      if (actualDayIndex !== requestedDay) {
+        if (
+          requestedDay >= 4 &&
+          Number.isFinite(actualDayIndex) &&
+          actualDayIndex < requestedDay
+        ) {
+          await controlCandidateSessionDayWindow(
+            page,
+            candidateSessionId,
+            requestedDay,
+            candidateTimezone,
+          );
+          await page.reload({ waitUntil: 'networkidle' });
+          const currentTaskAfterControl = await fetchCandidateCurrentTask(
+            page,
+            candidateSessionId,
+            `candidate-day${requestedDay}-current-task-after-control.json`,
+          );
+          const reopenedDayIndex = Number(
+            currentTaskAfterControl.json?.currentTask?.dayIndex,
+          );
+          if (reopenedDayIndex !== requestedDay) {
+            throw new Error(
+              `Day ${requestedDay} window control did not expose the requested day. Current task: ${JSON.stringify(
+                currentTaskAfterControl.json,
+                null,
+                2,
+              )}`,
+            );
+          }
+        } else {
           throw new Error(
-            `Day ${requestedDay} window control did not expose the requested day. Current task: ${JSON.stringify(
-              currentTaskAfterControl.json,
+            `Expected day ${requestedDay} but current task is day ${actualDayIndex}: ${JSON.stringify(
+              currentTaskBefore.json,
               null,
               2,
             )}`,
@@ -1263,128 +1336,167 @@ async function runCandidateDayFlow() {
         }
       }
 
-      const codespaceLink = page.getByRole('link', {
-        name: /^open codespace$/i,
-      });
-      await codespaceLink.first().waitFor({ state: 'visible', timeout: 60000 });
-      const readinessLabel = await waitForCodespaceReadyMarkers(page, 60000);
-      const workspaceHref = await codespaceLink.first().getAttribute('href');
-      writeJson(`candidate-day${requestedDay}-workspace.json`, {
-        href: workspaceHref,
-        label: 'Open Codespace',
-        readinessLabel,
-      });
-
-      const runTestsButton = page
-        .getByRole('button', { name: /^run tests$/i })
-        .first();
-      await runTestsButton.waitFor({ state: 'visible', timeout: 60000 });
-
-      const runResponsePromise = page.waitForResponse(
-        (response) =>
-          response.url().includes(`/tasks/${taskId}/run`) &&
-          response.request().method() === 'POST',
-        { timeout: 120000 },
-      );
-      await runTestsButton.click();
-      const runResponse = await runResponsePromise;
-      const runResponseText = await runResponse.text();
-      writeJson(`candidate-day${requestedDay}-run-start.json`, {
-        ok: runResponse.ok(),
-        status: runResponse.status(),
-        url: runResponse.url(),
-        text: runResponseText,
-      });
-      if (!runResponse.ok()) {
-        throw new Error(
-          `Day ${requestedDay} run-tests start failed: ${runResponse.status()} ${runResponseText}`,
-        );
-      }
-
-      await waitForText(page, /running tests/i, 30000);
-      const runResult = await waitForRunTestsTerminalState(page, requestedDay);
-      writeJson(`candidate-day${requestedDay}-run-result.json`, runResult);
-
-      const submitResponsePromise = page.waitForResponse(
-        (response) =>
-          response.url().includes(`/tasks/${taskId}/submit`) &&
-          response.request().method() === 'POST',
-        { timeout: 120000 },
-      );
-      await page.getByRole('button', { name: /submit & continue/i }).click();
-      const submitResponse = await submitResponsePromise;
-      writeJson(`candidate-day${requestedDay}-submit.json`, {
-        ok: submitResponse.ok(),
-        status: submitResponse.status(),
-        url: submitResponse.url(),
-        text: await submitResponse.text(),
-      });
-      if (!submitResponse.ok()) {
-        throw new Error(
-          `Day ${requestedDay} submit failed with status ${submitResponse.status()}.`,
-        );
-      }
-    } else if (requestedDay === 4) {
-      const transcriptReadyText = page.getByText(/full transcript/i).first();
-      const transcriptAlreadyReady = await transcriptReadyText
-        .isVisible({ timeout: 1000 })
-        .catch(() => false);
-      if (!transcriptAlreadyReady) {
-        const day4DemoFile = resolveDay4DemoFile();
-        const consentCheckbox = page
-          .getByLabel(
-            /I consent to submission and processing of my demo video and transcript for evaluation/i,
-          )
-          .first();
-        await consentCheckbox.check();
-        await page.locator('input[type="file"]').setInputFiles(day4DemoFile);
-        writeJson('candidate-day4-upload-fixture.json', {
-          path: day4DemoFile,
-          bytes: fs.statSync(day4DemoFile).size,
-        });
-        await page
-          .getByRole('button', { name: /finalize demo/i })
-          .waitFor({ state: 'visible', timeout: 30000 });
-        await page.getByRole('button', { name: /finalize demo/i }).click();
-        await waitForTranscriptReady(page);
-      }
-      await capturePage(page, 'candidate-day4-transcript-ready.json', {
+      await capturePage(page, `candidate-day${requestedDay}-before.json`, {
         inviteToken,
         candidateSessionId,
         taskId,
       });
-    } else if (requestedDay === 5) {
-      const reflection = defaultDay5Reflection();
-      const reflectionMarkdown = buildDay5ReflectionMarkdown(reflection);
-      await clickFirstVisible(page.getByRole('button', { name: /^write$/i }));
-      const editorVisible = await page
-        .locator('#reflection-challenges')
-        .isVisible({ timeout: 5000 })
-        .catch(() => false);
-      if (editorVisible) {
-        await page
-          .locator('#reflection-challenges')
-          .fill(reflection.challenges);
-        await page.locator('#reflection-decisions').fill(reflection.decisions);
-        await page.locator('#reflection-tradeoffs').fill(reflection.tradeoffs);
-        await page
-          .locator('#reflection-communication')
-          .fill(reflection.communication);
-        await page.locator('#reflection-next').fill(reflection.next);
-        await clickFirstVisible(
-          page.getByRole('button', { name: /^preview$/i }),
+
+      if (requestedDay === 1) {
+        const textArea = page.locator('textarea').first();
+        const textAreaVisible = await textArea
+          .isVisible({ timeout: 5000 })
+          .catch(() => false);
+        if (textAreaVisible) {
+          await textArea.fill(defaultDay1Response());
+          await clickFirstVisible(
+            page.getByRole('button', { name: /save draft/i }),
+          );
+          const submitResponsePromise = page.waitForResponse(
+            (response) =>
+              response.url().includes(`/tasks/${taskId}/submit`) &&
+              response.request().method() === 'POST',
+            { timeout: 120000 },
+          );
+          await page
+            .getByRole('button', { name: /submit & continue/i })
+            .click();
+          const submitResponse = await submitResponsePromise;
+          writeJson(`candidate-day${requestedDay}-submit.json`, {
+            ok: submitResponse.ok(),
+            status: submitResponse.status(),
+            url: submitResponse.url(),
+            text: await submitResponse.text(),
+            mode: 'ui',
+          });
+          if (!submitResponse.ok()) {
+            throw new Error(
+              `Day ${requestedDay} submit failed with status ${submitResponse.status()}.`,
+            );
+          }
+        } else {
+          const submitResponse = await submitCandidateTaskViaApi(
+            page,
+            taskId,
+            candidateSessionId,
+            { contentText: defaultDay1Response() },
+            `candidate-day${requestedDay}-submit-api.json`,
+          );
+          writeJson(`candidate-day${requestedDay}-submit.json`, {
+            ok: submitResponse.ok,
+            status: submitResponse.status,
+            url: submitResponse.url,
+            text: submitResponse.text,
+            mode: 'api',
+          });
+        }
+        await page.waitForTimeout(1000);
+        const currentTaskAfter = await fetchCandidateCurrentTask(
+          page,
+          candidateSessionId,
+          `candidate-day${requestedDay}-current-task-after.json`,
         );
-        await clickFirstVisible(page.getByRole('button', { name: /^write$/i }));
-        await clickFirstVisible(
-          page.getByRole('button', { name: /save draft/i }),
+        const nextDayIndex = Number(
+          currentTaskAfter.json?.currentTask?.dayIndex,
         );
+        if (
+          !Number.isFinite(nextDayIndex) ||
+          nextDayIndex !== requestedDay + 1
+        ) {
+          throw new Error(
+            `Day ${requestedDay} submit did not advance to the next task. Current task: ${JSON.stringify(
+              currentTaskAfter.json,
+              null,
+              2,
+            )}`,
+          );
+        }
+      } else if (requestedDay === 2 || requestedDay === 3) {
+        if (closedByBackend) {
+          await controlCandidateSessionDayWindow(
+            page,
+            candidateSessionId,
+            requestedDay,
+            candidateTimezone,
+          );
+          await page.reload({ waitUntil: 'networkidle' });
+          const currentTaskAfterControl = await fetchCandidateCurrentTask(
+            page,
+            candidateSessionId,
+            `candidate-day${requestedDay}-current-task-after-control.json`,
+          );
+          const reopenedDayIndex = Number(
+            currentTaskAfterControl.json?.currentTask?.dayIndex,
+          );
+          if (reopenedDayIndex !== requestedDay) {
+            throw new Error(
+              `Day ${requestedDay} window control did not expose the requested day. Current task: ${JSON.stringify(
+                currentTaskAfterControl.json,
+                null,
+                2,
+              )}`,
+            );
+          }
+        }
+
+        const codespaceLink = page.getByRole('link', {
+          name: /^open codespace$/i,
+        });
+        await codespaceLink
+          .first()
+          .waitFor({ state: 'visible', timeout: 60000 });
+        const readinessLabel = await waitForCodespaceReadyMarkers(page, 60000);
+        const workspaceHref = await codespaceLink.first().getAttribute('href');
+        writeJson(`candidate-day${requestedDay}-workspace.json`, {
+          href: workspaceHref,
+          label: 'Open Codespace',
+          readinessLabel,
+        });
+
+        const runTestsButton = page
+          .getByRole('button', { name: /^run tests$/i })
+          .first();
+        await runTestsButton.waitFor({ state: 'visible', timeout: 60000 });
+
+        const runResponsePromise = page.waitForResponse(
+          (response) =>
+            response.url().includes(`/tasks/${taskId}/run`) &&
+            response.request().method() === 'POST',
+          { timeout: 120000 },
+        );
+        await runTestsButton.click();
+        const runResponse = await runResponsePromise;
+        const runResponseText = await runResponse.text();
+        writeJson(`candidate-day${requestedDay}-run-start.json`, {
+          ok: runResponse.ok(),
+          status: runResponse.status(),
+          url: runResponse.url(),
+          text: runResponseText,
+        });
+        if (!runResponse.ok()) {
+          throw new Error(
+            `Day ${requestedDay} run-tests start failed: ${runResponse.status()} ${runResponseText}`,
+          );
+        }
+
+        await waitForText(page, /running tests/i, 30000);
+        const runResult = await waitForRunTestsTerminalState(
+          page,
+          requestedDay,
+        );
+        writeJson(`candidate-day${requestedDay}-run-result.json`, runResult);
+
+        const submitButtonName =
+          requestedDay === 3
+            ? /submit implementation wrap-up/i
+            : /submit & continue/i;
         const submitResponsePromise = page.waitForResponse(
           (response) =>
             response.url().includes(`/tasks/${taskId}/submit`) &&
             response.request().method() === 'POST',
           { timeout: 120000 },
         );
-        await page.getByRole('button', { name: /submit & continue/i }).click();
+        await page.getByRole('button', { name: submitButtonName }).click();
         const submitResponse = await submitResponsePromise;
         writeJson(`candidate-day${requestedDay}-submit.json`, {
           ok: submitResponse.ok(),
@@ -1397,74 +1509,205 @@ async function runCandidateDayFlow() {
             `Day ${requestedDay} submit failed with status ${submitResponse.status()}.`,
           );
         }
-      } else {
-        const draftResponse = await browserFetchJson(
-          page,
-          `/api/backend/tasks/${taskId}/draft`,
-          {
-            method: 'PUT',
-            headers: { 'x-candidate-session-id': String(candidateSessionId) },
-            body: JSON.stringify({
-              contentText: reflectionMarkdown,
-              contentJson: { reflection },
-            }),
-          },
-        );
-        writeJson(
-          `candidate-day${requestedDay}-draft-upsert.json`,
-          draftResponse,
-        );
-        if (!draftResponse.ok) {
-          throw new Error(
-            `Day ${requestedDay} draft upsert failed: ${draftResponse.status} ${draftResponse.text}`,
+      } else if (requestedDay === 4) {
+        const transcriptReadyText = page.getByText(/full transcript/i).first();
+        const transcriptAlreadyReady = await transcriptReadyText
+          .isVisible({ timeout: 1000 })
+          .catch(() => false);
+        if (!transcriptAlreadyReady) {
+          const day4DemoFile = resolveDay4DemoFile();
+          const consentCheckbox = page
+            .getByLabel(
+              /I consent to submission and processing of my demo video and transcript for evaluation/i,
+            )
+            .first();
+          await consentCheckbox.check();
+          await page
+            .locator('input[type="file"][accept*="video"]')
+            .first()
+            .setInputFiles({
+              name: path.basename(day4DemoFile),
+              mimeType: 'video/mp4',
+              path: day4DemoFile,
+            });
+          writeJson('candidate-day4-upload-fixture.json', {
+            path: day4DemoFile,
+            bytes: fs.statSync(day4DemoFile).size,
+            mimeType: 'video/mp4',
+          });
+          const uploadInitRequestPromise = page.waitForRequest(
+            (request) =>
+              request.url().includes(`/tasks/${taskId}/handoff/upload/init`) &&
+              request.method() === 'POST',
+            { timeout: 120000 },
           );
-        }
-        const submitResponse = await browserFetchJson(
-          page,
-          `/api/backend/tasks/${taskId}/submit`,
-          {
-            method: 'POST',
-            headers: { 'x-candidate-session-id': String(candidateSessionId) },
-            body: JSON.stringify({
-              reflection,
-              contentText: reflectionMarkdown,
-            }),
-          },
-        );
-        writeJson(`candidate-day${requestedDay}-submit.json`, submitResponse);
-        if (!submitResponse.ok) {
-          throw new Error(
-            `Day ${requestedDay} submit failed: ${submitResponse.status} ${submitResponse.text}`,
+          const uploadInitResponsePromise = page.waitForResponse(
+            (response) =>
+              response.url().includes(`/tasks/${taskId}/handoff/upload/init`) &&
+              response.request().method() === 'POST',
+            { timeout: 120000 },
           );
+          await page
+            .getByRole('button', { name: /finalize demo/i })
+            .waitFor({ state: 'visible', timeout: 30000 });
+          await page.getByRole('button', { name: /finalize demo/i }).click();
+          const uploadInitRequest = await uploadInitRequestPromise;
+          const uploadInitResponse = await uploadInitResponsePromise;
+          let uploadInitRequestBody = null;
+          try {
+            uploadInitRequestBody = uploadInitRequest.postDataJSON();
+          } catch {
+            uploadInitRequestBody = uploadInitRequest.postData();
+          }
+          writeJson(`candidate-day${requestedDay}-upload-init.json`, {
+            request: {
+              url: uploadInitRequest.url(),
+              method: uploadInitRequest.method(),
+              headers: uploadInitRequest.headers(),
+              body: uploadInitRequestBody,
+            },
+            response: {
+              ok: uploadInitResponse.ok(),
+              status: uploadInitResponse.status(),
+              url: uploadInitResponse.url(),
+              text: await uploadInitResponse.text(),
+            },
+          });
+          if (!uploadInitResponse.ok()) {
+            throw new Error(
+              `Day ${requestedDay} upload init failed with status ${uploadInitResponse.status()}.`,
+            );
+          }
+          await waitForTranscriptReady(page);
         }
+        await capturePage(page, 'candidate-day4-transcript-ready.json', {
+          inviteToken,
+          candidateSessionId,
+          taskId,
+        });
+      } else if (requestedDay === 5) {
+        const reflection = defaultDay5Reflection();
+        const reflectionMarkdown = buildDay5ReflectionMarkdown(reflection);
+        await clickFirstVisible(page.getByRole('button', { name: /^write$/i }));
+        const editorVisible = await page
+          .locator('#reflection-challenges')
+          .isVisible({ timeout: 5000 })
+          .catch(() => false);
+        if (editorVisible) {
+          await page
+            .locator('#reflection-challenges')
+            .fill(reflection.challenges);
+          await page
+            .locator('#reflection-decisions')
+            .fill(reflection.decisions);
+          await page
+            .locator('#reflection-tradeoffs')
+            .fill(reflection.tradeoffs);
+          await page
+            .locator('#reflection-communication')
+            .fill(reflection.communication);
+          await page.locator('#reflection-next').fill(reflection.next);
+          await clickFirstVisible(
+            page.getByRole('button', { name: /^preview$/i }),
+          );
+          await clickFirstVisible(
+            page.getByRole('button', { name: /^write$/i }),
+          );
+          await clickFirstVisible(
+            page.getByRole('button', { name: /save draft/i }),
+          );
+          const submitResponsePromise = page.waitForResponse(
+            (response) =>
+              response.url().includes(`/tasks/${taskId}/submit`) &&
+              response.request().method() === 'POST',
+            { timeout: 120000 },
+          );
+          await page
+            .getByRole('button', { name: /submit & continue/i })
+            .click();
+          const submitResponse = await submitResponsePromise;
+          writeJson(`candidate-day${requestedDay}-submit.json`, {
+            ok: submitResponse.ok(),
+            status: submitResponse.status(),
+            url: submitResponse.url(),
+            text: await submitResponse.text(),
+          });
+          if (!submitResponse.ok()) {
+            throw new Error(
+              `Day ${requestedDay} submit failed with status ${submitResponse.status()}.`,
+            );
+          }
+        } else {
+          const draftResponse = await browserFetchJson(
+            page,
+            `/api/backend/tasks/${taskId}/draft`,
+            {
+              method: 'PUT',
+              headers: { 'x-candidate-session-id': String(candidateSessionId) },
+              body: JSON.stringify({
+                contentText: reflectionMarkdown,
+                contentJson: { reflection },
+              }),
+            },
+          );
+          writeJson(
+            `candidate-day${requestedDay}-draft-upsert.json`,
+            draftResponse,
+          );
+          if (!draftResponse.ok) {
+            throw new Error(
+              `Day ${requestedDay} draft upsert failed: ${draftResponse.status} ${draftResponse.text}`,
+            );
+          }
+          const submitResponse = await browserFetchJson(
+            page,
+            `/api/backend/tasks/${taskId}/submit`,
+            {
+              method: 'POST',
+              headers: { 'x-candidate-session-id': String(candidateSessionId) },
+              body: JSON.stringify({
+                reflection,
+                contentText: reflectionMarkdown,
+              }),
+            },
+          );
+          writeJson(`candidate-day${requestedDay}-submit.json`, submitResponse);
+          if (!submitResponse.ok) {
+            throw new Error(
+              `Day ${requestedDay} submit failed: ${submitResponse.status} ${submitResponse.text}`,
+            );
+          }
+        }
+        await page.reload({ waitUntil: 'networkidle' });
+        await waitForText(page, /trial complete/i, 60000);
       }
-      await page.reload({ waitUntil: 'networkidle' });
-      await waitForText(page, /trial complete/i, 60000);
-    }
 
-    await page.waitForLoadState('networkidle');
-    await capturePage(page, `candidate-day${requestedDay}-after.json`, {
-      inviteToken,
-      candidateSessionId,
-      taskId,
-    });
-    const currentTaskAfter = await fetchCandidateCurrentTask(
-      page,
-      candidateSessionId,
-      `candidate-day${requestedDay}-current-task-after.json`,
-    );
-    const summary = {
-      inviteToken,
-      candidateSessionId,
-      taskId,
-      requestedDay,
-      pageUrl: page.url(),
-      closedByBackend,
-      currentTaskAfter: currentTaskAfter.json,
-    };
-    writeJson(`candidate-day${requestedDay}-summary.json`, summary);
-    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
-  });
+      await page.waitForLoadState('networkidle');
+      await capturePage(page, `candidate-day${requestedDay}-after.json`, {
+        inviteToken,
+        candidateSessionId,
+        taskId,
+      });
+      const currentTaskAfter = await fetchCandidateCurrentTask(
+        page,
+        candidateSessionId,
+        `candidate-day${requestedDay}-current-task-after.json`,
+      );
+      const summary = {
+        inviteToken,
+        candidateSessionId,
+        taskId,
+        requestedDay,
+        pageUrl: page.url(),
+        closedByBackend,
+        currentTaskAfter: currentTaskAfter.json,
+      };
+      writeJson(`candidate-day${requestedDay}-summary.json`, summary);
+      process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+    },
+    candidateSessionId,
+    context.summary?.candidateEmail ?? null,
+  );
 }
 
 function extractCompareRows(responseJson) {
@@ -1703,6 +1946,12 @@ async function runTalentPartnerTerminateFlow() {
 switch (command) {
   case 'talent_partner-fresh':
     await runTalentPartnerFreshFlow();
+    break;
+  case 'candidate-day5':
+    if (!trimToNull(process.env.CONTRACT_LIVE_DAY)) {
+      process.env.CONTRACT_LIVE_DAY = '5';
+    }
+    await runCandidateDayFlow();
     break;
   case 'candidate-schedule':
     await runCandidateScheduleFlow();

--- a/qa_verifications/Contract-Live-QA/run_contract_live.sh
+++ b/qa_verifications/Contract-Live-QA/run_contract_live.sh
@@ -296,7 +296,11 @@ echo "Evidence directory: $EVIDENCE_DIR" | tee -a "$RUNNER_LOG"
 echo "Storage states: $STORAGE_DIR" | tee -a "$RUNNER_LOG"
 echo "Base URL: $CONTRACT_LIVE_BASE_URL" | tee -a "$RUNNER_LOG"
 echo "WINOE_EMAIL_PROVIDER: $WINOE_EMAIL_PROVIDER" | tee -a "$RUNNER_LOG"
-echo "Auth bootstrap: real Auth0 browser login" | tee -a "$RUNNER_LOG"
+if [[ -n "${QA_E2E_TALENT_PARTNER_EMAIL:-}" && -n "${QA_E2E_TALENT_PARTNER_PASSWORD:-}" && -n "${QA_E2E_CANDIDATE_EMAIL:-}" && -n "${QA_E2E_CANDIDATE_PASSWORD:-}" ]]; then
+  echo "Auth bootstrap: real Auth0 browser login" | tee -a "$RUNNER_LOG"
+else
+  echo "Auth bootstrap: local dev storage-state fallback" | tee -a "$RUNNER_LOG"
+fi
 echo "Driver sequence: ${DRIVER_SEQUENCE_RAW:-<none>}" | tee -a "$RUNNER_LOG"
 echo | tee -a "$RUNNER_LOG"
 

--- a/qa_verifications/Contract-Live-QA/run_contract_live_stack.sh
+++ b/qa_verifications/Contract-Live-QA/run_contract_live_stack.sh
@@ -27,6 +27,27 @@ FRONTEND_PORT="${CONTRACT_LIVE_FRONTEND_PORT:-3000}"
 
 load_contract_live_local_env "$FRONTEND_DIR/.env.local" "$BACKEND_DIR/.env"
 
+USE_LOCAL_DEV_AUTH=0
+if [[ -z "${QA_E2E_TALENT_PARTNER_EMAIL:-}" || -z "${QA_E2E_TALENT_PARTNER_PASSWORD:-}" || -z "${QA_E2E_CANDIDATE_EMAIL:-}" || -z "${QA_E2E_CANDIDATE_PASSWORD:-}" ]]; then
+  USE_LOCAL_DEV_AUTH=1
+fi
+if [[ "$USE_LOCAL_DEV_AUTH" -eq 1 ]]; then
+  export CONTRACT_LIVE_DEV_AUTH_BYPASS=1
+fi
+
+apply_local_dev_auth_env() {
+  if [[ "$USE_LOCAL_DEV_AUTH" -eq 1 ]]; then
+    export DEV_AUTH_BYPASS=1
+    export WINOE_DEV_AUTH_BYPASS=1
+    export CONTRACT_LIVE_DEV_AUTH_BYPASS=1
+    return 0
+  fi
+
+  export DEV_AUTH_BYPASS="${DEV_AUTH_BYPASS:-0}"
+  export WINOE_DEV_AUTH_BYPASS="${WINOE_DEV_AUTH_BYPASS:-0}"
+  export CONTRACT_LIVE_DEV_AUTH_BYPASS="${CONTRACT_LIVE_DEV_AUTH_BYPASS:-0}"
+}
+
 if command -v gh >/dev/null 2>&1; then
   GH_AUTH_TOKEN="$(gh auth token 2>/dev/null || true)"
   if [[ -n "${GH_AUTH_TOKEN:-}" ]] && [[ "${CONTRACT_LIVE_PREFER_GH_TOKEN:-1}" != "0" ]]; then
@@ -92,6 +113,11 @@ echo "Contract-live fake UTC: $FAKE_TIME_UTC"
 echo "Contract-live scenario generation runtime mode: $SCENARIO_GENERATION_RUNTIME_MODE"
 echo "Contract-live scenario generation provider: $SCENARIO_GENERATION_PROVIDER"
 echo "Contract-live scenario generation model: $SCENARIO_GENERATION_MODEL"
+if [[ "$USE_LOCAL_DEV_AUTH" -eq 1 ]]; then
+  echo "Contract-live auth bootstrap mode: local dev auth bypass"
+else
+  echo "Contract-live auth bootstrap mode: real Auth0"
+fi
 if [[ -n "${STACK_LABEL// }" ]]; then
   echo "Contract-live stack label: $STACK_LABEL"
 fi
@@ -202,8 +228,7 @@ bootstrap_local_database() {
     export WINOE_SCENARIO_GENERATION_PROVIDER="$SCENARIO_GENERATION_PROVIDER"
     export WINOE_SCENARIO_GENERATION_MODEL="$SCENARIO_GENERATION_MODEL"
     export WINOE_AUTH0_LEEWAY_SECONDS="$AUTH0_LEEWAY_SECONDS"
-    export DEV_AUTH_BYPASS=0
-    export WINOE_DEV_AUTH_BYPASS=0
+    apply_local_dev_auth_env
     export CONTRACT_LIVE_FAKE_TIME_UTC="$FAKE_TIME_UTC"
     export WINOE_TEST_NOW_UTC="$FAKE_TIME_UTC"
     export WINOE_BACKEND_BASE_URL="http://$BACKEND_HOST:$BACKEND_PORT"
@@ -241,8 +266,7 @@ wait_for_url() {
   export WINOE_SCENARIO_GENERATION_PROVIDER="$SCENARIO_GENERATION_PROVIDER"
   export WINOE_SCENARIO_GENERATION_MODEL="$SCENARIO_GENERATION_MODEL"
   export WINOE_AUTH0_LEEWAY_SECONDS="$AUTH0_LEEWAY_SECONDS"
-  export DEV_AUTH_BYPASS="${DEV_AUTH_BYPASS:-0}"
-  export WINOE_DEV_AUTH_BYPASS="${WINOE_DEV_AUTH_BYPASS:-0}"
+  apply_local_dev_auth_env
   export CONTRACT_LIVE_FAKE_TIME_UTC="$FAKE_TIME_UTC"
   export WINOE_TEST_NOW_UTC="$FAKE_TIME_UTC"
   export WINOE_BACKEND_BASE_URL="http://$BACKEND_HOST:$BACKEND_PORT"
@@ -259,8 +283,7 @@ BACKEND_PID=$!
   export WINOE_SCENARIO_GENERATION_PROVIDER="$SCENARIO_GENERATION_PROVIDER"
   export WINOE_SCENARIO_GENERATION_MODEL="$SCENARIO_GENERATION_MODEL"
   export WINOE_AUTH0_LEEWAY_SECONDS="$AUTH0_LEEWAY_SECONDS"
-  export DEV_AUTH_BYPASS="${DEV_AUTH_BYPASS:-0}"
-  export WINOE_DEV_AUTH_BYPASS="${WINOE_DEV_AUTH_BYPASS:-0}"
+  apply_local_dev_auth_env
   export CONTRACT_LIVE_FAKE_TIME_UTC="$FAKE_TIME_UTC"
   export WINOE_TEST_NOW_UTC="$FAKE_TIME_UTC"
   export WINOE_BACKEND_BASE_URL="http://$BACKEND_HOST:$BACKEND_PORT"
@@ -270,12 +293,13 @@ WORKER_PID=$!
 
   (
     cd "$FRONTEND_DIR"
-    export WINOE_EMAIL_PROVIDER="$EMAIL_PROVIDER"
-    export WINOE_DEMO_MODE=1
-    export WINOE_SCENARIO_DEMO_MODE=1
-    export CONTRACT_LIVE_FAKE_TIME_UTC="$FAKE_TIME_UTC"
-    export WINOE_TEST_NOW_UTC="$FAKE_TIME_UTC"
-    export NEXT_PUBLIC_WINOE_TEST_NOW_UTC="$FAKE_TIME_UTC"
+  export WINOE_EMAIL_PROVIDER="$EMAIL_PROVIDER"
+  export WINOE_DEMO_MODE=1
+  export WINOE_SCENARIO_DEMO_MODE=1
+  export CONTRACT_LIVE_FAKE_TIME_UTC="$FAKE_TIME_UTC"
+  export WINOE_TEST_NOW_UTC="$FAKE_TIME_UTC"
+  export NEXT_PUBLIC_WINOE_TEST_NOW_UTC="$FAKE_TIME_UTC"
+  apply_local_dev_auth_env
   export WINOE_BACKEND_BASE_URL="http://$BACKEND_HOST:$BACKEND_PORT"
   exec npm run dev -- --hostname "$FRONTEND_HOST" --port "$FRONTEND_PORT"
 ) >"$FRONTEND_LOG" 2>&1 &

--- a/src/features/candidate/session/views/CompleteView.tsx
+++ b/src/features/candidate/session/views/CompleteView.tsx
@@ -1,5 +1,9 @@
 import Button from '@/shared/ui/Button';
-import { StateMessage } from '../components/StateMessage';
+import {
+  TECH_TRIAL_DAY_SUMMARY,
+  TRIAL_COMPLETION_COPY,
+  TRIAL_COMPLETION_DETAIL,
+} from './completeView.copy';
 
 type CompleteViewProps = {
   onReview: () => void;
@@ -8,17 +12,41 @@ type CompleteViewProps = {
 
 export function CompleteView({ onReview, onDashboard }: CompleteViewProps) {
   return (
-    <StateMessage
-      title="Trial complete 🎉"
-      description="You’ve submitted all 5 days. Review your completed work any time from the candidate dashboard."
-      action={
-        <div className="flex flex-wrap gap-2">
-          <Button onClick={onReview}>Review submissions</Button>
-          <Button variant="secondary" onClick={onDashboard}>
-            Back to Candidate Dashboard
-          </Button>
-        </div>
-      }
-    />
+    <div className="mx-auto max-w-3xl space-y-5 p-6">
+      <div className="rounded-2xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-white p-6 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-700">
+          Trial complete
+        </p>
+        <h1 className="mt-2 text-2xl font-semibold text-gray-950">
+          {TRIAL_COMPLETION_COPY}
+        </h1>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-gray-700">
+          {TRIAL_COMPLETION_DETAIL}
+        </p>
+      </div>
+
+      <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-gray-950">
+          Completed 5-day Trial
+        </h2>
+        <ol className="mt-4 grid gap-3 sm:grid-cols-2">
+          {TECH_TRIAL_DAY_SUMMARY.map((summary) => (
+            <li
+              key={summary}
+              className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-800"
+            >
+              {summary}
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <div className="flex flex-wrap gap-2">
+        <Button onClick={onReview}>Review submissions</Button>
+        <Button variant="secondary" onClick={onDashboard}>
+          Back to Candidate Dashboard
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/src/features/candidate/session/views/ResourceSections.tsx
+++ b/src/features/candidate/session/views/ResourceSections.tsx
@@ -26,10 +26,10 @@ export function ResourceSections({
       {showDocs ? (
         <ResourcePanel
           title="Day 5 reflection essay"
-          description="Write your final markdown reflection essay in the editor below."
+          description="Use the final markdown editor below to reflect on your full Trial experience."
           linkUrl={resourceLink}
           linkLabel="Open reference"
-          emptyMessage="Use the markdown editor below to write your reflection essay."
+          emptyMessage="Day 5 is open from 9:00 AM–9:00 PM your local time. Use the markdown editor below to write your reflection essay."
         />
       ) : null}
     </>

--- a/src/features/candidate/session/views/StartView.tsx
+++ b/src/features/candidate/session/views/StartView.tsx
@@ -30,7 +30,8 @@ export function StartView({ title, role, onStart, onDashboard }: Props) {
           <li>
             <b>Day 5:</b> reflection essay.
           </li>
-          <li>Schedule: 9:00 AM–5:00 PM local time, for 5 consecutive days.</li>
+          <li>Days 1-4: 9:00 AM–5:00 PM local time.</li>
+          <li>Day 5: 9:00 AM–9:00 PM local time for reflection.</li>
         </ul>
       </div>
 

--- a/src/features/candidate/session/views/completeView.copy.ts
+++ b/src/features/candidate/session/views/completeView.copy.ts
@@ -1,0 +1,13 @@
+export const TRIAL_COMPLETION_COPY =
+  'Congratulations - your 5-day Trial is complete.';
+
+export const TRIAL_COMPLETION_DETAIL =
+  'Your active work is finished. Your Evidence Trail is now ready for review. Winoe will evaluate the artifacts from your Trial and produce a Winoe Report for the Talent Partner.';
+
+export const TECH_TRIAL_DAY_SUMMARY = [
+  'Day 1: Planning & Design Doc',
+  'Day 2: Implementation Kickoff',
+  'Day 3: Implementation Wrap-Up',
+  'Day 4: Handoff + Demo',
+  'Day 5: Reflection Essay',
+] as const;

--- a/src/features/candidate/tasks/CandidateTaskView.tsx
+++ b/src/features/candidate/tasks/CandidateTaskView.tsx
@@ -1,11 +1,15 @@
 'use client';
 
 import { CandidateTaskViewInner } from './CandidateTaskViewInner';
-import { HandoffUploadPanelComponent } from './CandidateTaskViewPanels';
+import {
+  Day5ReflectionPanelComponent,
+  HandoffUploadPanelComponent,
+} from './CandidateTaskViewPanels';
 import {
   DEFAULT_ACTION_GATE,
   type CandidateTaskViewProps,
 } from './CandidateTaskView.types';
+import { isDay5ReflectionTask } from './utils/day5ReflectionUtils';
 
 export default function CandidateTaskView(props: CandidateTaskViewProps) {
   const actionGate = props.actionGate ?? DEFAULT_ACTION_GATE;
@@ -18,6 +22,21 @@ export default function CandidateTaskView(props: CandidateTaskViewProps) {
         task={props.task}
         actionGate={actionGate}
         onTaskWindowClosed={props.onTaskWindowClosed}
+      />
+    );
+  }
+
+  if (isDay5ReflectionTask(props.task)) {
+    return (
+      <Day5ReflectionPanelComponent
+        key={props.task.id}
+        candidateSessionId={props.candidateSessionId}
+        task={props.task}
+        submitting={props.submitting}
+        submitError={props.submitError}
+        actionGate={actionGate}
+        onTaskWindowClosed={props.onTaskWindowClosed}
+        onSubmit={props.onSubmit}
       />
     );
   }

--- a/src/features/candidate/tasks/components/Day5ReflectionPanel.tsx
+++ b/src/features/candidate/tasks/components/Day5ReflectionPanel.tsx
@@ -4,13 +4,15 @@ import { TaskContainer } from './TaskContainer';
 import { TaskDescription } from './TaskDescription';
 import { TaskHeader } from './TaskHeader';
 import { TaskPanelErrorBanner } from './TaskPanelErrorBanner';
-import { TaskStatus } from './TaskStatus';
 import { Day5ReflectionActions } from './day5Reflection/Day5ReflectionActions';
+import { Day5ReflectionClosedView } from './day5Reflection/Day5ReflectionClosedView';
+import { Day5ReflectionCompletionView } from './day5Reflection/Day5ReflectionCompletionView';
+import { Day5ReflectionGuidance } from './day5Reflection/Day5ReflectionGuidance';
 import { Day5ReflectionEditableView } from './day5Reflection/Day5ReflectionEditableView';
 import { Day5ReflectionMarkdownPreview } from './day5Reflection/Day5ReflectionMarkdownPreview';
-import { Day5ReflectionReadOnlyView } from './day5Reflection/Day5ReflectionReadOnlyView';
 import type { Day5ReflectionPanelProps } from './day5Reflection/day5ReflectionPanel.types';
 import { useDay5ReflectionFormState } from './day5Reflection/useDay5ReflectionFormState';
+import { withDay5ReflectionCopy } from '../utils/day5Reflection.taskCopyUtils';
 
 export function Day5ReflectionPanel({
   candidateSessionId,
@@ -30,61 +32,57 @@ export function Day5ReflectionPanel({
     onTaskWindowClosed,
     onSubmit,
   });
+  const displayTask = withDay5ReflectionCopy(task);
+  const completed =
+    reflection.submittedTerminal ||
+    Boolean(task.recordedSubmission?.submittedAt);
+  const notYetOpen =
+    reflection.readOnly && Boolean(actionGate.comeBackAt) && !completed;
+  const closedAfterDeadline = reflection.readOnly && !notYetOpen && !completed;
 
   return (
     <TaskContainer>
-      <TaskHeader task={task} />
-      <TaskDescription description={task.description} />
+      <TaskHeader task={displayTask} />
 
-      {reflection.readOnly ? (
-        <Day5ReflectionReadOnlyView
-          readOnlyReason={reflection.readOnlyReason}
-          readOnlySections={reflection.readOnlySections}
-          readOnlyFallbackMarkdown={reflection.readOnlyFallbackMarkdown}
-          PreviewComponent={Day5ReflectionMarkdownPreview}
+      {completed ? (
+        <Day5ReflectionCompletionView />
+      ) : notYetOpen ? (
+        <Day5ReflectionClosedView
+          variant="not_open"
+          reason={reflection.readOnlyReason}
+        />
+      ) : closedAfterDeadline ? (
+        <Day5ReflectionClosedView
+          variant="closed"
+          reason={reflection.readOnlyReason}
         />
       ) : (
-        <Day5ReflectionEditableView
-          mode={reflection.mode}
-          previewPending={reflection.previewPending}
-          markdownPreview={reflection.markdownPreview}
-          submitAttempted={reflection.submitAttempted}
-          touched={reflection.touched}
-          backendFieldErrors={reflection.backendFieldErrors}
-          clientFieldMessages={reflection.clientFieldMessages}
-          sections={reflection.sections}
-          displayStatus={reflection.displayStatus}
-          submitting={submitting}
-          draftAutosave={reflection.draftAutosave}
-          PreviewComponent={Day5ReflectionMarkdownPreview}
-          onModeChange={reflection.handleModeChange}
-          onSectionChange={reflection.handleSectionChange}
-          onSectionBlur={reflection.handleSectionBlur}
-        />
+        <>
+          <TaskDescription description={displayTask.description} />
+          <Day5ReflectionGuidance />
+          <Day5ReflectionEditableView
+            mode={reflection.mode}
+            previewPending={reflection.previewPending}
+            markdown={reflection.markdown}
+            markdownPreview={reflection.markdownPreview}
+            displayStatus={reflection.displayStatus}
+            submitting={submitting}
+            draftAutosave={reflection.draftAutosave}
+            PreviewComponent={Day5ReflectionMarkdownPreview}
+            onModeChange={reflection.handleModeChange}
+            onMarkdownChange={reflection.handleMarkdownChange}
+          />
+          <TaskPanelErrorBanner message={reflection.errorToShow} />
+          <Day5ReflectionActions
+            displayStatus={reflection.displayStatus}
+            submitting={submitting}
+            submitDisabled={reflection.submitDisabled}
+            hasClientValidationErrors={reflection.hasClientValidationErrors}
+            onSaveDraft={reflection.onSaveDraft}
+            onSubmitReflection={reflection.onSubmitReflection}
+          />
+        </>
       )}
-
-      {reflection.submittedTerminal ? (
-        <div className="mt-4 rounded-md border border-green-300 bg-green-50 p-3 text-sm text-green-900">
-          Submitted. Your Day 5 reflection is finalized.
-        </div>
-      ) : null}
-
-      <TaskStatus
-        displayStatus={reflection.displayStatus}
-        progress={reflection.lastProgress}
-      />
-      <TaskPanelErrorBanner message={reflection.errorToShow} />
-
-      {!reflection.readOnly ? (
-        <Day5ReflectionActions
-          displayStatus={reflection.displayStatus}
-          submitting={submitting}
-          submitDisabled={reflection.submitDisabled}
-          hasClientValidationErrors={reflection.hasClientValidationErrors}
-          onSaveDraft={reflection.onSaveDraft}
-          onSubmitReflection={reflection.onSubmitReflection}
-        />
-      ) : null}
     </TaskContainer>
   );
 }

--- a/src/features/candidate/tasks/components/TaskHeader.tsx
+++ b/src/features/candidate/tasks/components/TaskHeader.tsx
@@ -1,6 +1,14 @@
 import { memo, type ReactNode } from 'react';
 import { Task } from '../types';
 
+const TASK_DAY_TITLES: Record<number, string> = {
+  1: 'Planning & Design Doc',
+  2: 'Implementation Kickoff',
+  3: 'Implementation Wrap-Up',
+  4: 'Handoff + Demo',
+  5: 'Reflection Essay',
+};
+
 type TaskHeaderProps = {
   task: Task;
   statusSlot?: ReactNode;
@@ -10,11 +18,12 @@ export const TaskHeader = memo(function TaskHeader({
   task,
   statusSlot,
 }: TaskHeaderProps) {
+  const dayLabel = TASK_DAY_TITLES[task.dayIndex] ?? task.title;
   return (
     <div className="flex items-start justify-between gap-4">
       <div>
         <div className="text-sm text-gray-500">
-          Day {task.dayIndex} • {String(task.type)}
+          Day {task.dayIndex} • {dayLabel}
         </div>
         <div className="mt-1 text-2xl font-bold">{task.title}</div>
       </div>

--- a/src/features/candidate/tasks/components/day5Reflection/Day5ReflectionActions.tsx
+++ b/src/features/candidate/tasks/components/day5Reflection/Day5ReflectionActions.tsx
@@ -1,5 +1,5 @@
+import { useState } from 'react';
 import Button from '@/shared/ui/Button';
-import { DAY5_REFLECTION_MIN_SECTION_CHARS } from '../../utils/day5ReflectionUtils';
 
 type Props = {
   displayStatus: string;
@@ -18,6 +18,35 @@ export function Day5ReflectionActions({
   onSaveDraft,
   onSubmitReflection,
 }: Props) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmPending, setConfirmPending] = useState(false);
+  const submitLabel =
+    displayStatus === 'submitting'
+      ? 'Submitting…'
+      : displayStatus === 'submitted'
+        ? 'Submitted ✓'
+        : 'Submit Reflection Essay';
+
+  const handleSubmitClick = () => {
+    if (displayStatus !== 'idle' || submitDisabled || submitting) return;
+    setConfirmOpen(true);
+  };
+
+  const handleConfirmSubmit = () => {
+    if (
+      confirmPending ||
+      displayStatus !== 'idle' ||
+      submitDisabled ||
+      submitting
+    )
+      return;
+    setConfirmPending(true);
+    setConfirmOpen(false);
+    Promise.resolve(onSubmitReflection()).finally(() => {
+      setConfirmPending(false);
+    });
+  };
+
   return (
     <div className="mt-4 space-y-2">
       <div className="flex items-center justify-between gap-2">
@@ -29,19 +58,59 @@ export function Day5ReflectionActions({
         >
           Save draft
         </button>
-        <Button disabled={submitDisabled} onClick={onSubmitReflection}>
-          {displayStatus === 'submitting'
-            ? 'Submitting…'
-            : displayStatus === 'submitted'
-              ? 'Submitted ✓'
-              : 'Submit & Continue'}
+        <Button
+          disabled={submitDisabled || displayStatus !== 'idle'}
+          onClick={handleSubmitClick}
+        >
+          {submitLabel}
         </Button>
       </div>
       {hasClientValidationErrors ? (
         <p className="text-xs text-gray-600">
-          Complete all sections with at least{' '}
-          {String(DAY5_REFLECTION_MIN_SECTION_CHARS)} characters to submit.
+          Add reflection text before submitting.
         </p>
+      ) : null}
+      {confirmOpen ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          role="presentation"
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="submit-day5-confirm-title"
+            className="w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl"
+          >
+            <h2
+              id="submit-day5-confirm-title"
+              className="text-lg font-semibold text-gray-950"
+            >
+              Submit your Reflection Essay?
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-gray-700">
+              This will complete Day 5 and mark your active Trial as finished.
+            </p>
+            <div className="mt-5 flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="secondary"
+                disabled={confirmPending}
+                onClick={() => setConfirmOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                disabled={
+                  confirmPending || submitDisabled || displayStatus !== 'idle'
+                }
+                onClick={handleConfirmSubmit}
+              >
+                Submit Reflection Essay
+              </Button>
+            </div>
+          </div>
+        </div>
       ) : null}
     </div>
   );

--- a/src/features/candidate/tasks/components/day5Reflection/Day5ReflectionClosedView.tsx
+++ b/src/features/candidate/tasks/components/day5Reflection/Day5ReflectionClosedView.tsx
@@ -1,0 +1,29 @@
+type Props = {
+  reason: string | null;
+  variant: 'not_open' | 'closed';
+};
+
+export function Day5ReflectionClosedView({ reason, variant }: Props) {
+  const eyebrow =
+    variant === 'not_open' ? 'Day 5 not open yet' : 'Day 5 closed';
+  const title =
+    variant === 'not_open'
+      ? 'Day 5 opens at 9:00 AM local time'
+      : 'The Day 5 reflection window has closed';
+  const fallback =
+    variant === 'not_open'
+      ? 'Day 5 opens from 9:00 AM to 9:00 PM your local time. Come back when the reflection window opens.'
+      : 'Day 5 closes at 9:00 PM your local time. The reflection window is no longer available.';
+
+  return (
+    <section className="mt-6 rounded-2xl border border-amber-200 bg-amber-50 p-5 shadow-sm">
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-amber-700">
+        {eyebrow}
+      </p>
+      <h2 className="mt-1 text-xl font-semibold text-slate-950">{title}</h2>
+      <p className="mt-2 text-sm leading-6 text-slate-700">
+        {reason ?? fallback}
+      </p>
+    </section>
+  );
+}

--- a/src/features/candidate/tasks/components/day5Reflection/Day5ReflectionCompletionView.tsx
+++ b/src/features/candidate/tasks/components/day5Reflection/Day5ReflectionCompletionView.tsx
@@ -1,0 +1,56 @@
+import Button from '@/shared/ui/Button';
+import {
+  TECH_TRIAL_DAY_SUMMARY,
+  TRIAL_COMPLETION_COPY,
+  TRIAL_COMPLETION_DETAIL,
+} from '@/features/candidate/session/views/completeView.copy';
+
+type Props = {
+  onReview?: () => void;
+  onDashboard?: () => void;
+};
+
+export function Day5ReflectionCompletionView({ onReview, onDashboard }: Props) {
+  return (
+    <section className="mt-6 rounded-2xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-white p-6 shadow-sm">
+      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-700">
+        Congratulations
+      </p>
+      <h2 className="mt-2 text-2xl font-semibold text-gray-950">
+        {TRIAL_COMPLETION_COPY}
+      </h2>
+      <p className="mt-3 max-w-2xl text-sm leading-6 text-gray-700">
+        {TRIAL_COMPLETION_DETAIL}
+      </p>
+
+      <div className="mt-5 rounded-xl border border-gray-200 bg-white p-4">
+        <p className="text-sm font-semibold text-gray-950">
+          Completed 5-day Trial
+        </p>
+        <ol className="mt-3 grid gap-2 sm:grid-cols-2">
+          {TECH_TRIAL_DAY_SUMMARY.map((day) => (
+            <li
+              key={day}
+              className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-800"
+            >
+              {day}
+            </li>
+          ))}
+        </ol>
+      </div>
+
+      {onReview || onDashboard ? (
+        <div className="mt-5 flex flex-wrap gap-2">
+          {onReview ? (
+            <Button onClick={onReview}>Review submissions</Button>
+          ) : null}
+          {onDashboard ? (
+            <Button variant="secondary" onClick={onDashboard}>
+              Back to Candidate Dashboard
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/features/candidate/tasks/components/day5Reflection/Day5ReflectionEditableView.tsx
+++ b/src/features/candidate/tasks/components/day5Reflection/Day5ReflectionEditableView.tsx
@@ -1,63 +1,91 @@
 import { DraftSaveStatus } from '../DraftSaveStatus';
-import { DAY5_REFLECTION_SECTIONS } from '../../utils/day5ReflectionUtils';
-import { Day5ReflectionEditorToolbar } from './Day5ReflectionEditorToolbar';
-import { Day5ReflectionSectionField } from './Day5ReflectionSectionField';
 import type { Day5ReflectionEditableViewProps } from './day5ReflectionEditable.types';
 
 export function Day5ReflectionEditableView({
   mode,
   previewPending,
+  markdown,
   markdownPreview,
-  submitAttempted,
-  touched,
-  backendFieldErrors,
-  clientFieldMessages,
-  sections,
   displayStatus,
   submitting,
   draftAutosave,
   PreviewComponent,
   onModeChange,
-  onSectionChange,
-  onSectionBlur,
+  onMarkdownChange,
 }: Day5ReflectionEditableViewProps) {
   return (
-    <div className="mt-6 space-y-4">
-      <Day5ReflectionEditorToolbar mode={mode} onModeChange={onModeChange} />
-
-      {mode === 'preview' ? (
-        <div className="min-h-[360px] rounded-md border bg-white p-3">
-          {previewPending ? (
-            <div className="mb-2 text-xs text-gray-500">
-              Refreshing preview…
-            </div>
-          ) : null}
-          <PreviewComponent
-            content={markdownPreview}
-            emptyPlaceholder="Complete each reflection section to preview markdown."
-          />
+    <section aria-labelledby="day5-editor-heading" className="mt-6 space-y-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <h2
+            id="day5-editor-heading"
+            className="text-lg font-semibold text-gray-950"
+          >
+            Reflection Essay editor
+          </h2>
+          <p className="text-sm text-gray-600">
+            Write one markdown essay. The preview updates live so you can check
+            headings, structure, and emphasis before submitting.
+          </p>
         </div>
-      ) : (
-        DAY5_REFLECTION_SECTIONS.map((section) => {
-          const shouldShowClientError = submitAttempted || touched[section];
-          const fieldError =
-            backendFieldErrors[section] ??
-            (shouldShowClientError ? clientFieldMessages[section] : null) ??
-            null;
-          return (
-            <Day5ReflectionSectionField
-              key={section}
-              section={section}
-              value={sections[section]}
-              fieldError={fieldError}
-              disabled={displayStatus !== 'idle' || submitting}
-              onChange={onSectionChange}
-              onBlur={onSectionBlur}
+        <div className="inline-flex overflow-hidden rounded-md border border-gray-200 bg-white text-xs font-medium">
+          <button
+            type="button"
+            aria-pressed={mode === 'write'}
+            className={
+              mode === 'write'
+                ? 'bg-sky-50 px-3 py-1 text-sky-700'
+                : 'px-3 py-1 text-gray-700 hover:bg-gray-50'
+            }
+            onClick={() => onModeChange('write')}
+          >
+            Write
+          </button>
+          <button
+            type="button"
+            aria-pressed={mode === 'preview'}
+            className={
+              mode === 'preview'
+                ? 'border-l border-gray-200 bg-sky-50 px-3 py-1 text-sky-700'
+                : 'border-l border-gray-200 px-3 py-1 text-gray-700 hover:bg-gray-50'
+            }
+            onClick={() => onModeChange('preview')}
+          >
+            Preview
+          </button>
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <label className="block">
+          <span className="mb-2 block text-sm font-medium text-gray-800">
+            Markdown editor
+          </span>
+          <textarea
+            className="min-h-[520px] w-full resize-y rounded-md border border-gray-300 bg-white p-4 text-sm leading-6 text-gray-950 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/30 disabled:bg-gray-100 disabled:text-gray-600"
+            value={markdown}
+            onChange={(event) => onMarkdownChange(event.target.value)}
+            disabled={displayStatus !== 'idle' || submitting}
+            placeholder="Write your Day 5 reflection essay in markdown."
+          />
+        </label>
+        <div>
+          <p className="mb-2 text-sm font-medium text-gray-800">Live preview</p>
+          <div className="min-h-[520px] rounded-md border border-gray-200 bg-white p-4 shadow-sm">
+            {previewPending ? (
+              <div className="mb-2 text-xs text-gray-500">
+                Refreshing preview…
+              </div>
+            ) : null}
+            <PreviewComponent
+              content={markdownPreview}
+              emptyPlaceholder="Start writing to preview your reflection essay."
             />
-          );
-        })
-      )}
-      <div className="sticky bottom-2 z-20 mt-3 rounded-md border border-gray-200 bg-white/95 px-3 py-2 shadow-sm backdrop-blur">
+          </div>
+        </div>
+      </div>
+
+      <div className="sticky bottom-2 z-20 rounded-md border border-gray-200 bg-white/95 px-3 py-2 shadow-sm backdrop-blur">
         <DraftSaveStatus
           status={draftAutosave.status}
           lastSavedAt={draftAutosave.lastSavedAt}
@@ -65,6 +93,6 @@ export function Day5ReflectionEditableView({
           error={draftAutosave.error}
         />
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/features/candidate/tasks/components/day5Reflection/Day5ReflectionEditorToolbar.tsx
+++ b/src/features/candidate/tasks/components/day5Reflection/Day5ReflectionEditorToolbar.tsx
@@ -11,7 +11,9 @@ export function Day5ReflectionEditorToolbar({ mode, onModeChange }: Props) {
       <div className="flex items-center gap-2">
         <span className="leading-5">
           Each section is required and must include at least{' '}
-          {String(DAY5_REFLECTION_MIN_SECTION_CHARS)} characters.
+          {String(DAY5_REFLECTION_MIN_SECTION_CHARS)} characters. Use the
+          prompts to reflect on your Trial, your growth, and how you used your
+          tools.
         </span>
       </div>
       <div className="inline-flex overflow-hidden rounded-md border border-gray-200 bg-white text-xs font-medium">

--- a/src/features/candidate/tasks/components/day5Reflection/Day5ReflectionGuidance.tsx
+++ b/src/features/candidate/tasks/components/day5Reflection/Day5ReflectionGuidance.tsx
@@ -1,0 +1,42 @@
+import {
+  DAY5_REFLECTION_OPENING_COPY,
+  DAY5_REFLECTION_PROMPTS,
+  DAY5_REFLECTION_WINDOW_COPY,
+} from '../../utils/day5Reflection.copyUtils';
+
+export function Day5ReflectionGuidance() {
+  return (
+    <section className="mt-6 rounded-2xl border border-sky-200 bg-sky-50 p-5 shadow-sm">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="max-w-3xl">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-sky-700">
+            Day 5 reflection essay
+          </p>
+          <h2 className="mt-1 text-xl font-semibold text-slate-950">
+            Today is for reflection, not more implementation.
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-slate-700">
+            {DAY5_REFLECTION_OPENING_COPY}
+          </p>
+        </div>
+        <div className="rounded-xl border border-sky-200 bg-white px-4 py-3 text-sm text-slate-700">
+          <p className="font-semibold text-slate-950">Window</p>
+          <p className="mt-1">{DAY5_REFLECTION_WINDOW_COPY}</p>
+        </div>
+      </div>
+
+      <div className="mt-5 rounded-xl border border-sky-100 bg-white/90 p-4">
+        <p className="text-sm font-semibold text-slate-950">
+          Use these prompts to shape your essay
+        </p>
+        <ul className="mt-3 grid gap-2 text-sm leading-6 text-slate-700 md:grid-cols-2">
+          {DAY5_REFLECTION_PROMPTS.map((prompt) => (
+            <li key={prompt} className="rounded-lg bg-slate-50 px-3 py-2">
+              {prompt}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/features/candidate/tasks/components/day5Reflection/Day5ReflectionSectionField.tsx
+++ b/src/features/candidate/tasks/components/day5Reflection/Day5ReflectionSectionField.tsx
@@ -25,6 +25,17 @@ export const Day5ReflectionSectionField = memo(
   }: Props) {
     const fieldId = `reflection-${section}`;
     const length = value.trim().length;
+    const placeholderBySection: Record<Day5ReflectionSectionKey, string> = {
+      challenges:
+        'Describe your overall Trial experience, the hardest challenges, and how you worked through them.',
+      decisions:
+        'Explain the decisions that mattered most and why you made them.',
+      tradeoffs:
+        'Describe the tradeoffs you made, what you learned, and how your thinking changed.',
+      communication:
+        'Explain how you collaborated, communicated, and prepared the work for others.',
+      next: 'Reflect on what you would do differently, including how you used tools or AI assistants.',
+    };
 
     return (
       <section className="space-y-2">
@@ -40,7 +51,7 @@ export const Day5ReflectionSectionField = memo(
           onChange={(event) => onChange(section, event.target.value)}
           onBlur={() => onBlur(section)}
           className="min-h-[120px] w-full resize-y rounded-md border p-3 text-sm leading-6"
-          placeholder={`Write your ${day5SectionLabel(section).toLowerCase()} reflection…`}
+          placeholder={placeholderBySection[section]}
           disabled={disabled}
         />
         <div className="flex items-center justify-between text-xs text-gray-500">

--- a/src/features/candidate/tasks/components/day5Reflection/day5ReflectionEditable.types.ts
+++ b/src/features/candidate/tasks/components/day5Reflection/day5ReflectionEditable.types.ts
@@ -1,11 +1,6 @@
 import type { ComponentType } from 'react';
 import type { MarkdownPreviewProps } from '@/shared/ui/Markdown';
 import type { TaskDraftAutosaveStatus } from '../../hooks/useTaskDraftAutosave';
-import type {
-  Day5FieldErrors,
-  Day5ReflectionSectionKey,
-  Day5ReflectionSections,
-} from '../../utils/day5ReflectionUtils';
 
 export type Day5DraftAutosaveState = {
   status: TaskDraftAutosaveStatus;
@@ -17,17 +12,12 @@ export type Day5DraftAutosaveState = {
 export type Day5ReflectionEditableViewProps = {
   mode: 'write' | 'preview';
   previewPending: boolean;
+  markdown: string;
   markdownPreview: string;
-  submitAttempted: boolean;
-  touched: Record<Day5ReflectionSectionKey, boolean>;
-  backendFieldErrors: Day5FieldErrors;
-  clientFieldMessages: Day5FieldErrors;
-  sections: Day5ReflectionSections;
   displayStatus: string;
   submitting: boolean;
   draftAutosave: Day5DraftAutosaveState;
   PreviewComponent: ComponentType<MarkdownPreviewProps>;
   onModeChange: (next: 'write' | 'preview') => void;
-  onSectionChange: (section: Day5ReflectionSectionKey, value: string) => void;
-  onSectionBlur: (section: Day5ReflectionSectionKey) => void;
+  onMarkdownChange: (value: string) => void;
 };

--- a/src/features/candidate/tasks/components/day5Reflection/day5ReflectionForm.types.ts
+++ b/src/features/candidate/tasks/components/day5Reflection/day5ReflectionForm.types.ts
@@ -1,21 +1,5 @@
-import type { Dispatch, SetStateAction } from 'react';
 import type { WindowActionGate } from '@/features/candidate/session/lib/windowState';
 import type { SubmitPayload, SubmitResponse, Task } from '../../types';
-import type {
-  Day5FieldErrors,
-  Day5ReflectionSectionKey,
-  Day5ReflectionSections,
-} from '../../utils/day5ReflectionUtils';
-
-export function emptyTouchedMap(): Record<Day5ReflectionSectionKey, boolean> {
-  return {
-    challenges: false,
-    decisions: false,
-    tradeoffs: false,
-    communication: false,
-    next: false,
-  };
-}
 
 export type UseDay5ReflectionFormStateArgs = {
   candidateSessionId: number | null;
@@ -27,14 +11,4 @@ export type UseDay5ReflectionFormStateArgs = {
   onSubmit: (
     payload: SubmitPayload,
   ) => Promise<SubmitResponse | void> | SubmitResponse | void;
-};
-
-export type Day5FormSetters = {
-  setSections: Dispatch<SetStateAction<Day5ReflectionSections>>;
-  setTouched: Dispatch<
-    SetStateAction<Record<Day5ReflectionSectionKey, boolean>>
-  >;
-  setSubmitAttempted: Dispatch<SetStateAction<boolean>>;
-  setBackendFieldErrors: Dispatch<SetStateAction<Day5FieldErrors>>;
-  setLocalFormError: Dispatch<SetStateAction<string | null>>;
 };

--- a/src/features/candidate/tasks/components/day5Reflection/day5ReflectionFormDerived.ts
+++ b/src/features/candidate/tasks/components/day5Reflection/day5ReflectionFormDerived.ts
@@ -7,16 +7,23 @@ import {
 export function deriveReadOnlyReason(params: {
   actionGateReadOnly: boolean;
   actionGateReason: string | null;
+  comeBackAt: string | null;
   submittedTerminal: boolean;
 }) {
   if (params.actionGateReadOnly) {
+    if (params.comeBackAt) {
+      return (
+        params.actionGateReason ??
+        'Day 5 opens at 9:00 AM local time. This reflection window is not open yet.'
+      );
+    }
     return (
       params.actionGateReason ??
-      'Day closed. Reflection is read-only outside the scheduled window.'
+      'The Day 5 reflection window has closed for the day.'
     );
   }
   if (params.submittedTerminal)
-    return 'Submitted. Reflection is now read-only.';
+    return 'Submitted. Your Reflection Essay is now finalized.';
   return null;
 }
 

--- a/src/features/candidate/tasks/components/day5Reflection/useDay5ReflectionDraftAutosave.ts
+++ b/src/features/candidate/tasks/components/day5Reflection/useDay5ReflectionDraftAutosave.ts
@@ -3,60 +3,62 @@ import { useTaskDraftAutosave } from '../../hooks/useTaskDraftAutosave';
 import { markTextDraftSavedAt } from '../../utils/draftStorageUtils';
 import {
   buildDay5ReflectionContentText,
-  buildDay5ReflectionPayload,
+  buildDay5ReflectionMarkdownTemplate,
   extractDay5SectionsFromContentJson,
   hasDay5SectionContent,
-  type Day5ReflectionSections,
 } from '../../utils/day5ReflectionUtils';
-import {
-  emptyTouchedMap,
-  type Day5FormSetters,
-} from './day5ReflectionForm.types';
 
 type UseDay5ReflectionDraftAutosaveArgs = {
   taskId: number;
   candidateSessionId: number | null;
   readOnly: boolean;
-  sections: Day5ReflectionSections;
+  markdown: string;
   onTaskWindowClosed?: (err: unknown) => void;
-  setters: Day5FormSetters;
+  onRestore: (markdown: string) => void;
 };
 
 export function useDay5ReflectionDraftAutosave({
   taskId,
   candidateSessionId,
   readOnly,
-  sections,
+  markdown,
   onTaskWindowClosed,
-  setters,
+  onRestore,
 }: UseDay5ReflectionDraftAutosaveArgs) {
-  return useTaskDraftAutosave<Day5ReflectionSections>({
+  return useTaskDraftAutosave<string>({
     taskId,
     candidateSessionId,
     isEditable: !readOnly,
     hasFinalizedContent: readOnly,
-    value: sections,
+    value: markdown,
     serialize: useCallback((value) => {
-      const reflection = buildDay5ReflectionPayload(value);
       return {
-        contentText: buildDay5ReflectionContentText(reflection),
-        contentJson: { reflection },
+        contentText: value,
+        contentJson: {
+          reflectionMarkdown: value,
+          reflection: extractDay5SectionsFromContentJson({
+            reflectionMarkdown: value,
+          }),
+        },
       };
     }, []),
     deserialize: useCallback((draft) => {
-      const fromJson = extractDay5SectionsFromContentJson(draft.contentJson);
-      if (hasDay5SectionContent(fromJson)) return fromJson;
-      return null;
+      const contentText =
+        typeof draft.contentText === 'string' ? draft.contentText : '';
+      if (contentText.trim()) return contentText;
+      const structured = extractDay5SectionsFromContentJson(draft.contentJson);
+      if (hasDay5SectionContent(structured)) {
+        const markdown = buildDay5ReflectionContentText(structured).trim();
+        if (markdown) return markdown;
+      }
+      const template = buildDay5ReflectionMarkdownTemplate().trim();
+      return template || null;
     }, []),
     onRestore: useCallback(
       (restored) => {
-        setters.setSections(restored);
-        setters.setTouched(emptyTouchedMap());
-        setters.setSubmitAttempted(false);
-        setters.setBackendFieldErrors({});
-        setters.setLocalFormError(null);
+        onRestore(restored);
       },
-      [setters],
+      [onRestore],
     ),
     onTaskWindowClosed,
     onSavedAt: useCallback(

--- a/src/features/candidate/tasks/components/day5Reflection/useDay5ReflectionFormState.ts
+++ b/src/features/candidate/tasks/components/day5Reflection/useDay5ReflectionFormState.ts
@@ -1,35 +1,43 @@
-import {
-  useCallback,
-  useDeferredValue,
-  useMemo,
-  useState,
-  useTransition,
-} from 'react';
+import { useCallback, useDeferredValue, useState, useTransition } from 'react';
 import { useSubmitHandler } from '../../hooks/useSubmitHandler';
 import {
-  buildDay5ReflectionContentText,
-  buildDay5ReflectionPayload,
-  day5ValidationMessages,
-  emptyDay5ReflectionSections,
+  buildDay5ReflectionMarkdownTemplate,
   extractDay5SectionsFromContentJson,
+  buildDay5ReflectionContentText,
+  hasMeaningfulDay5ReflectionMarkdown,
   type Day5FieldErrors,
-  type Day5ReflectionSectionKey,
-  hasDay5SectionContent,
-  hasDay5ValidationErrors,
-  validateDay5ReflectionSections,
 } from '../../utils/day5ReflectionUtils';
 import {
   deriveDay5ErrorToShow,
   deriveDisplayStatus,
-  deriveReadOnlyContent,
   deriveReadOnlyReason,
 } from './day5ReflectionFormDerived';
-import {
-  emptyTouchedMap,
-  type UseDay5ReflectionFormStateArgs,
-} from './day5ReflectionForm.types';
+import type { UseDay5ReflectionFormStateArgs } from './day5ReflectionForm.types';
 import { useDay5ReflectionDraftAutosave } from './useDay5ReflectionDraftAutosave';
 import { useDay5ReflectionSubmitActions } from './useDay5ReflectionSubmitActions';
+
+function extractInitialMarkdown(
+  task: UseDay5ReflectionFormStateArgs['task'],
+): string {
+  const recordedSubmission = task.recordedSubmission ?? null;
+  const contentText =
+    typeof recordedSubmission?.contentText === 'string'
+      ? recordedSubmission.contentText
+      : '';
+  if (contentText.trim()) return contentText;
+
+  const structured = extractDay5SectionsFromContentJson(
+    recordedSubmission?.contentJson,
+  );
+  const hasStructuredContent = Object.values(structured).some(
+    (value) => value.trim().length > 0,
+  );
+  if (hasStructuredContent) {
+    return buildDay5ReflectionContentText(structured);
+  }
+
+  return buildDay5ReflectionMarkdownTemplate();
+}
 
 export function useDay5ReflectionFormState({
   candidateSessionId,
@@ -41,26 +49,9 @@ export function useDay5ReflectionFormState({
   onSubmit,
 }: UseDay5ReflectionFormStateArgs) {
   const recordedSubmission = task.recordedSubmission ?? null;
-  const recordedSections = useMemo(
-    () => extractDay5SectionsFromContentJson(recordedSubmission?.contentJson),
-    [recordedSubmission?.contentJson],
-  );
-  const hasStructuredRecordedContent = useMemo(
-    () => hasDay5SectionContent(recordedSections),
-    [recordedSections],
-  );
-  const recordedContentText =
-    typeof recordedSubmission?.contentText === 'string'
-      ? recordedSubmission.contentText
-      : '';
   const hasRecordedSubmission = Boolean(recordedSubmission?.submittedAt);
-  const [sections, setSections] = useState(
-    hasStructuredRecordedContent
-      ? recordedSections
-      : emptyDay5ReflectionSections(),
-  );
+  const [markdown, setMarkdown] = useState(() => extractInitialMarkdown(task));
   const [mode, setMode] = useState<'write' | 'preview'>('write');
-  const [touched, setTouched] = useState(emptyTouchedMap());
   const [submitAttempted, setSubmitAttempted] = useState(false);
   const [backendFieldErrors, setBackendFieldErrors] = useState<Day5FieldErrors>(
     {},
@@ -72,79 +63,44 @@ export function useDay5ReflectionFormState({
   const [previewPending, startPreviewTransition] = useTransition();
   const { submitStatus, lastProgress, getLastError, handleSubmit } =
     useSubmitHandler(onSubmit);
+
   const readOnly = actionGate.isReadOnly || submittedTerminal;
   const readOnlyReason = deriveReadOnlyReason({
     actionGateReadOnly: actionGate.isReadOnly,
     actionGateReason: actionGate.disabledReason ?? null,
+    comeBackAt: actionGate.comeBackAt,
     submittedTerminal,
   });
-  const validationCodes = useMemo(
-    () => validateDay5ReflectionSections(sections),
-    [sections],
-  );
-  const clientFieldMessages = useMemo(
-    () => day5ValidationMessages(validationCodes),
-    [validationCodes],
-  );
-  const hasClientValidationErrors = hasDay5ValidationErrors(validationCodes);
   const displayStatus = deriveDisplayStatus({
     submitting,
     submittedTerminal,
     submitStatus,
   });
+  const hasClientValidationErrors =
+    !hasMeaningfulDay5ReflectionMarkdown(markdown);
+  const markdownPreview = useDeferredValue(markdown);
   const draftAutosave = useDay5ReflectionDraftAutosave({
     taskId: task.id,
     candidateSessionId,
     readOnly,
-    sections,
+    markdown,
     onTaskWindowClosed,
-    setters: {
-      setSections,
-      setTouched,
-      setSubmitAttempted,
-      setBackendFieldErrors,
-      setLocalFormError,
-    },
+    onRestore: setMarkdown,
   });
-  const deferredSections = useDeferredValue(sections);
-  const markdownPreview = useMemo(
-    () =>
-      mode === 'preview'
-        ? buildDay5ReflectionContentText(
-            buildDay5ReflectionPayload(deferredSections),
-          )
-        : '',
-    [deferredSections, mode],
-  );
-  const { readOnlySections, readOnlyFallbackMarkdown } = deriveReadOnlyContent({
-    actionGateReadOnly: actionGate.isReadOnly,
-    hasRecordedSubmission,
-    hasStructuredRecordedContent,
-    recordedContentText,
-    recordedSections,
-    sections,
+  const { onSubmitReflection } = useDay5ReflectionSubmitActions({
+    readOnly,
+    displayStatus,
+    submitting,
+    markdown,
+    hasClientValidationErrors,
+    handleSubmit,
+    getLastError,
+    setSubmitAttempted,
+    setBackendFieldErrors,
+    setLocalFormError,
+    setSubmittedTerminal,
   });
-  const { handleSectionChange, onSubmitReflection } =
-    useDay5ReflectionSubmitActions({
-      readOnly,
-      displayStatus,
-      submitting,
-      sections,
-      hasClientValidationErrors,
-      handleSubmit,
-      getLastError,
-      setSections,
-      setTouched,
-      setSubmitAttempted,
-      setBackendFieldErrors,
-      setLocalFormError,
-      setSubmittedTerminal,
-    });
-  const handleSectionBlur = useCallback(
-    (key: Day5ReflectionSectionKey) =>
-      setTouched((prev) => ({ ...prev, [key]: true })),
-    [],
-  );
+
   const handleModeChange = useCallback(
     (next: 'write' | 'preview') => startPreviewTransition(() => setMode(next)),
     [startPreviewTransition],
@@ -158,17 +114,14 @@ export function useDay5ReflectionFormState({
   return {
     readOnly,
     readOnlyReason,
-    readOnlySections,
-    readOnlyFallbackMarkdown,
+    readOnlyMarkdown: markdown,
     mode,
     handleModeChange,
     previewPending,
+    markdown,
     markdownPreview,
     submitAttempted,
-    touched,
     backendFieldErrors,
-    clientFieldMessages,
-    sections,
     displayStatus,
     draftAutosave,
     hasClientValidationErrors,
@@ -180,8 +133,7 @@ export function useDay5ReflectionFormState({
       submitError,
     }),
     submitDisabled,
-    handleSectionChange,
-    handleSectionBlur,
+    handleMarkdownChange: setMarkdown,
     onSaveDraft: () => void draftAutosave.flushNow(),
     onSubmitReflection,
   };

--- a/src/features/candidate/tasks/components/day5Reflection/useDay5ReflectionSubmitActions.ts
+++ b/src/features/candidate/tasks/components/day5Reflection/useDay5ReflectionSubmitActions.ts
@@ -2,26 +2,19 @@ import { useCallback } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
 import type { SubmitPayload } from '../../types';
 import {
-  buildDay5ReflectionContentText,
-  buildDay5ReflectionPayload,
+  buildDay5ReflectionPayloadFromMarkdown,
   mapDay5BackendValidationErrors,
   type Day5FieldErrors,
-  type Day5ReflectionSectionKey,
-  type Day5ReflectionSections,
 } from '../../utils/day5ReflectionUtils';
 
 type UseDay5ReflectionSubmitActionsArgs = {
   readOnly: boolean;
   displayStatus: 'idle' | 'submitting' | 'submitted';
   submitting: boolean;
-  sections: Day5ReflectionSections;
+  markdown: string;
   hasClientValidationErrors: boolean;
   handleSubmit: (payload: SubmitPayload) => Promise<unknown>;
   getLastError: () => unknown;
-  setSections: Dispatch<SetStateAction<Day5ReflectionSections>>;
-  setTouched: Dispatch<
-    SetStateAction<Record<Day5ReflectionSectionKey, boolean>>
-  >;
   setSubmitAttempted: Dispatch<SetStateAction<boolean>>;
   setBackendFieldErrors: Dispatch<SetStateAction<Day5FieldErrors>>;
   setLocalFormError: Dispatch<SetStateAction<string | null>>;
@@ -32,42 +25,28 @@ export function useDay5ReflectionSubmitActions({
   readOnly,
   displayStatus,
   submitting,
-  sections,
+  markdown,
   hasClientValidationErrors,
   handleSubmit,
   getLastError,
-  setSections,
-  setTouched,
   setSubmitAttempted,
   setBackendFieldErrors,
   setLocalFormError,
   setSubmittedTerminal,
 }: UseDay5ReflectionSubmitActionsArgs) {
-  const handleSectionChange = useCallback(
-    (key: Day5ReflectionSectionKey, value: string) => {
-      setSections((prev) => ({ ...prev, [key]: value }));
-      setTouched((prev) => ({ ...prev, [key]: true }));
-      setBackendFieldErrors((prev) => {
-        if (!prev[key]) return prev;
-        const next = { ...prev };
-        delete next[key];
-        return next;
-      });
-      setLocalFormError((prev) => (prev ? null : prev));
-    },
-    [setBackendFieldErrors, setLocalFormError, setSections, setTouched],
-  );
-
   const onSubmitReflection = useCallback(async () => {
     if (readOnly || displayStatus !== 'idle' || submitting) return;
     setSubmitAttempted(true);
     setBackendFieldErrors({});
     setLocalFormError(null);
-    if (hasClientValidationErrors) return;
-    const reflection = buildDay5ReflectionPayload(sections);
+    if (hasClientValidationErrors) {
+      setLocalFormError('Add reflection text before submitting.');
+      return;
+    }
+    const reflection = buildDay5ReflectionPayloadFromMarkdown(markdown);
     const payload: SubmitPayload = {
       reflection,
-      contentText: buildDay5ReflectionContentText(reflection),
+      contentText: markdown,
     };
     const response = await handleSubmit(payload);
     if (response === 'submit-failed') {
@@ -85,13 +64,13 @@ export function useDay5ReflectionSubmitActions({
     handleSubmit,
     hasClientValidationErrors,
     readOnly,
-    sections,
     setBackendFieldErrors,
     setLocalFormError,
     setSubmitAttempted,
     setSubmittedTerminal,
     submitting,
+    markdown,
   ]);
 
-  return { handleSectionChange, onSubmitReflection };
+  return { onSubmitReflection };
 }

--- a/src/features/candidate/tasks/handoff/panelUtils.ts
+++ b/src/features/candidate/tasks/handoff/panelUtils.ts
@@ -116,5 +116,5 @@ export async function validateVideoDuration(
       )}.`,
     );
   }
-  return durationSeconds;
+  return Math.max(1, Math.round(durationSeconds));
 }

--- a/src/features/candidate/tasks/utils/day5Reflection.backendValidationUtils.ts
+++ b/src/features/candidate/tasks/utils/day5Reflection.backendValidationUtils.ts
@@ -64,20 +64,20 @@ export function mapDay5BackendValidationErrors(
     normalizeCodeList(fieldMap.reflection).length > 0;
   const hasContentTextError =
     normalizeCodeList(fieldMap.contentText).length > 0;
+  const hasSectionFieldErrors = DAY5_REFLECTION_SECTIONS.some((section) =>
+    Boolean(fieldErrors[section]),
+  );
 
   const hasValidationErrors =
-    hasRootReflectionError ||
-    hasContentTextError ||
-    DAY5_REFLECTION_SECTIONS.some((section) => Boolean(fieldErrors[section]));
+    hasRootReflectionError || hasContentTextError || hasSectionFieldErrors;
 
   if (!hasValidationErrors) {
     return { fieldErrors: {}, formError: null, hasValidationErrors: false };
   }
 
   let formError: string | null = null;
-  if (hasContentTextError) {
-    formError =
-      'Please complete all reflection sections before submitting your reflection.';
+  if (hasSectionFieldErrors || hasContentTextError) {
+    formError = 'Please complete the reflection essay before submitting.';
   } else if (hasRootReflectionError) {
     formError = 'Reflection payload is invalid. Refresh and try again.';
   }

--- a/src/features/candidate/tasks/utils/day5Reflection.contentUtils.ts
+++ b/src/features/candidate/tasks/utils/day5Reflection.contentUtils.ts
@@ -2,6 +2,30 @@ import { DAY5_REFLECTION_SECTIONS } from './day5Reflection.constantsUtils';
 import type { Day5ReflectionSections } from './day5Reflection.typesUtils';
 import { day5SectionMarkdownHeading } from './day5Reflection.sectionsUtils';
 
+const DAY5_MARKDOWN_SECTION_HEADINGS: Record<string, string[]> = {
+  challenges: [
+    'experience & approach',
+    'experience & challenges',
+    'challenges',
+  ],
+  decisions: ['decisions & tradeoffs', 'decisions'],
+  tradeoffs: ['learnings & growth', 'tradeoffs'],
+  communication: [
+    'collaboration & communication',
+    'tool usage',
+    'communication / handoff',
+  ],
+  next: ['what i would do differently'],
+};
+
+const DAY5_MARKDOWN_TEMPLATE_HEADINGS = [
+  'Experience & Challenges',
+  'Decisions & Tradeoffs',
+  'Learnings & Growth',
+  'Collaboration & Communication',
+  'What I Would Do Differently',
+] as const;
+
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   return value as Record<string, unknown>;
@@ -11,6 +35,64 @@ function normalizeText(value: unknown): string | null {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
   return trimmed ? trimmed : null;
+}
+
+function isMarkdownHeadingLine(line: string): boolean {
+  return /^\s{0,3}#{1,6}\s+/.test(line);
+}
+
+function stripListPrefix(line: string): string {
+  return line.replace(/^\s{0,3}(?:[-*+]|(?:\d+\.))\s+/, '');
+}
+
+function hasMarkdownBodyText(line: string): boolean {
+  return /[\p{L}\p{N}]/u.test(stripListPrefix(line).trim());
+}
+
+function normalizeHeading(value: string): string {
+  return value
+    .trim()
+    .replace(/^#+\s*/, '')
+    .replace(/\s+/g, ' ')
+    .toLowerCase();
+}
+
+function splitMarkdownSections(markdown: string): Record<string, string> {
+  const sections: Record<string, string> = {};
+  let currentHeading: string | null = null;
+  let currentLines: string[] = [];
+
+  const flush = () => {
+    if (!currentHeading) return;
+    const content = currentLines.join('\n').trim();
+    if (content) sections[currentHeading] = content;
+    currentLines = [];
+  };
+
+  for (const line of markdown.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    const headingMatch = trimmed.match(/^#{1,3}\s+(.+)$/);
+    if (headingMatch) {
+      flush();
+      currentHeading = normalizeHeading(headingMatch[1]);
+      continue;
+    }
+    if (currentHeading) currentLines.push(line);
+  }
+  flush();
+  return sections;
+}
+
+function getSectionContent(
+  parsed: Record<string, string>,
+  keys: string[],
+): string {
+  const chunks = keys
+    .map((key) => parsed[key])
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  return chunks.join('\n\n');
 }
 
 export function emptyDay5ReflectionSections(): Day5ReflectionSections {
@@ -44,11 +126,25 @@ export function hasDay5SectionContent(
   );
 }
 
+export function hasMeaningfulDay5ReflectionMarkdown(markdown: string): boolean {
+  if (typeof markdown !== 'string' || !markdown.trim()) return false;
+  return markdown
+    .split(/\r?\n/)
+    .some((line) => !isMarkdownHeadingLine(line) && hasMarkdownBodyText(line));
+}
+
 export function extractDay5SectionsFromContentJson(
   contentJson: unknown,
 ): Day5ReflectionSections {
   const root = asRecord(contentJson);
   if (!root) return emptyDay5ReflectionSections();
+
+  const markdown =
+    normalizeText(root.reflectionMarkdown) ?? normalizeText(root.markdown);
+  if (markdown) {
+    const fromMarkdown = extractDay5SectionsFromMarkdown(markdown);
+    if (hasDay5SectionContent(fromMarkdown)) return fromMarkdown;
+  }
 
   const fromSections = mergeSections(asRecord(root.sections));
   if (hasDay5SectionContent(fromSections)) return fromSections;
@@ -59,12 +155,62 @@ export function extractDay5SectionsFromContentJson(
   return mergeSections(root);
 }
 
+export function extractDay5SectionsFromMarkdown(
+  markdown: string,
+): Day5ReflectionSections {
+  const parsed = splitMarkdownSections(markdown);
+  const merged = emptyDay5ReflectionSections();
+  let hasRecognizedContent = false;
+  for (const key of DAY5_REFLECTION_SECTIONS) {
+    const sectionKeys = DAY5_MARKDOWN_SECTION_HEADINGS[key];
+    const content = getSectionContent(parsed, sectionKeys);
+    if (content) {
+      merged[key] = content;
+      hasRecognizedContent = true;
+    }
+  }
+  if (hasRecognizedContent) return merged;
+  if (!hasMeaningfulDay5ReflectionMarkdown(markdown)) return merged;
+  for (const key of DAY5_REFLECTION_SECTIONS) {
+    merged[key] = markdown.trim();
+  }
+  return merged;
+}
+
+export function buildDay5ReflectionMarkdownTemplate(): string {
+  return DAY5_MARKDOWN_TEMPLATE_HEADINGS.map(
+    (heading) => `## ${heading}\n`,
+  ).join('\n');
+}
+
 export function buildDay5ReflectionContentText(
   sections: Day5ReflectionSections,
 ): string {
   return DAY5_REFLECTION_SECTIONS.map(
     (key) => `## ${day5SectionMarkdownHeading(key)}\n${sections[key].trim()}`,
   ).join('\n\n');
+}
+
+export function buildDay5ReflectionPayloadFromMarkdown(
+  markdown: string,
+): Day5ReflectionSections {
+  const parsed = extractDay5SectionsFromMarkdown(markdown);
+  const payload = emptyDay5ReflectionSections();
+  const hasRecognizedContent = hasDay5SectionContent(parsed);
+  const hasMeaningfulContent = hasMeaningfulDay5ReflectionMarkdown(markdown);
+
+  if (!hasMeaningfulContent) return payload;
+
+  for (const key of DAY5_REFLECTION_SECTIONS) {
+    payload[key] = parsed[key].trim();
+  }
+
+  if (hasRecognizedContent) return payload;
+
+  for (const key of DAY5_REFLECTION_SECTIONS) {
+    payload[key] = markdown.trim();
+  }
+  return payload;
 }
 
 export function buildDay5ReflectionPayload(

--- a/src/features/candidate/tasks/utils/day5Reflection.copyUtils.ts
+++ b/src/features/candidate/tasks/utils/day5Reflection.copyUtils.ts
@@ -1,0 +1,32 @@
+export const DAY5_REFLECTION_WINDOW_COPY = '9:00 AM–9:00 PM your local time';
+
+export const DAY5_REFLECTION_OPENING_COPY =
+  'Today is for reflection, not more implementation. Use this final day to look back across your full Trial and write one markdown essay about how you approached the work, what challenged you, which decisions mattered, the tradeoffs you made, what you learned, how you collaborated, how you used tools including AI assistants, and what you would do differently with more time.';
+
+export const DAY5_REFLECTION_LOCKED_COPY =
+  'Day 5 opens at 9:00 AM your local time. This final day is for reflecting on your full Trial experience.';
+
+export const DAY5_REFLECTION_COMPLETION_COPY =
+  'Congratulations - your 5-day Trial is complete.';
+
+export const DAY5_REFLECTION_COMPLETION_DETAIL =
+  'Your active work is finished. Your Evidence Trail is now ready for review. Winoe will evaluate the artifacts from your Trial and produce a Winoe Report for the Talent Partner.';
+
+export const DAY5_REFLECTION_PROMPTS = [
+  'Experience and approach: how did you frame the Trial and decide what to do first?',
+  'Challenges: what was hardest, and how did you work through it?',
+  'Decisions: which technical or product choices mattered most?',
+  'Tradeoffs and learnings: what did you trade away, and what did you learn?',
+  'Collaboration and communication: how did you keep others informed and prepared?',
+  'Growth and self-awareness: how did you change during the Trial?',
+  'Tool usage: how did you use tools, including AI assistants, if relevant?',
+  'What I would do differently: what would you change with more time?',
+] as const;
+
+export const DAY5_TRIAL_DAY_SUMMARY = [
+  'Day 1: Planning & Design Doc',
+  'Day 2: Implementation Kickoff',
+  'Day 3: Implementation Wrap-Up',
+  'Day 4: Handoff + Demo',
+  'Day 5: Reflection Essay',
+] as const;

--- a/src/features/candidate/tasks/utils/day5Reflection.sectionsUtils.ts
+++ b/src/features/candidate/tasks/utils/day5Reflection.sectionsUtils.ts
@@ -1,19 +1,19 @@
 import type { Day5ReflectionSectionKey } from './day5Reflection.typesUtils';
 
 const SECTION_LABELS: Record<Day5ReflectionSectionKey, string> = {
-  challenges: 'Challenges',
-  decisions: 'Decisions',
-  tradeoffs: 'Tradeoffs',
-  communication: 'Communication / handoff',
-  next: 'What you would do next',
+  challenges: 'Experience & challenges',
+  decisions: 'Decisions & tradeoffs',
+  tradeoffs: 'Learnings & growth',
+  communication: 'Collaboration & communication',
+  next: 'What I would do differently',
 };
 
 const SECTION_MARKDOWN_HEADINGS: Record<Day5ReflectionSectionKey, string> = {
-  challenges: 'Challenges',
-  decisions: 'Decisions',
-  tradeoffs: 'Tradeoffs',
-  communication: 'Communication / Handoff',
-  next: 'What I Would Do Next',
+  challenges: 'Experience & Challenges',
+  decisions: 'Decisions & Tradeoffs',
+  tradeoffs: 'Learnings & Growth',
+  communication: 'Collaboration & Communication',
+  next: 'What I Would Do Differently',
 };
 
 export function day5SectionLabel(key: Day5ReflectionSectionKey): string {

--- a/src/features/candidate/tasks/utils/day5Reflection.taskCopyUtils.ts
+++ b/src/features/candidate/tasks/utils/day5Reflection.taskCopyUtils.ts
@@ -1,0 +1,23 @@
+import type { Task } from '../types';
+import {
+  DAY5_REFLECTION_COMPLETION_DETAIL,
+  DAY5_REFLECTION_OPENING_COPY,
+  DAY5_REFLECTION_WINDOW_COPY,
+} from './day5Reflection.copyUtils';
+
+export const DAY5_REFLECTION_TITLE = 'Reflection Essay';
+
+export const DAY5_REFLECTION_DESCRIPTION = [
+  DAY5_REFLECTION_OPENING_COPY,
+  `Day 5 is open from ${DAY5_REFLECTION_WINDOW_COPY}.`,
+  DAY5_REFLECTION_COMPLETION_DETAIL,
+].join('\n\n');
+
+export function withDay5ReflectionCopy(task: Task): Task {
+  if (task.dayIndex !== 5) return task;
+  return {
+    ...task,
+    title: DAY5_REFLECTION_TITLE,
+    description: DAY5_REFLECTION_DESCRIPTION,
+  };
+}

--- a/src/features/candidate/tasks/utils/day5Reflection.taskUtils.ts
+++ b/src/features/candidate/tasks/utils/day5Reflection.taskUtils.ts
@@ -8,6 +8,6 @@ export function isDay5ReflectionTask(task: Task): boolean {
   const type = String(task.type ?? '')
     .trim()
     .toLowerCase();
-  if (type !== DAY5_REFLECTION_TASK_TYPE) return false;
+  if (type !== DAY5_REFLECTION_TASK_TYPE && type !== 'reflection') return false;
   return task.dayIndex === DAY5_REFLECTION_DAY_INDEX;
 }

--- a/src/features/candidate/tasks/utils/day5ReflectionUtils.ts
+++ b/src/features/candidate/tasks/utils/day5ReflectionUtils.ts
@@ -7,10 +7,14 @@ export {
 } from './day5Reflection.constantsUtils';
 export {
   buildDay5ReflectionContentText,
+  buildDay5ReflectionMarkdownTemplate,
+  buildDay5ReflectionPayloadFromMarkdown,
   buildDay5ReflectionPayload,
   emptyDay5ReflectionSections,
   extractDay5SectionsFromContentJson,
+  extractDay5SectionsFromMarkdown,
   hasDay5SectionContent,
+  hasMeaningfulDay5ReflectionMarkdown,
 } from './day5Reflection.contentUtils';
 export { mapDay5BackendValidationErrors } from './day5Reflection.backendValidationUtils';
 export {
@@ -23,6 +27,7 @@ export {
   day5SectionMarkdownHeading,
 } from './day5Reflection.sectionsUtils';
 export { isDay5ReflectionTask } from './day5Reflection.taskUtils';
+export { withDay5ReflectionCopy } from './day5Reflection.taskCopyUtils';
 export type {
   Day5BackendValidationMapping,
   Day5FieldErrors,

--- a/src/platform/server/backendProxy/proxy.ts
+++ b/src/platform/server/backendProxy/proxy.ts
@@ -42,10 +42,6 @@ export async function proxyToBackend(
   }
   const headers = forwardHeaders(req);
   headers.Authorization = `Bearer ${auth.accessToken}`;
-  const devUserEmail = req.headers.get('x-dev-user-email') ?? undefined;
-  if (devUserEmail) {
-    headers['x-dev-user-email'] = devUserEmail;
-  }
 
   try {
     if (DEBUG_PROXY) {

--- a/src/platform/server/bffAuth.ts
+++ b/src/platform/server/bffAuth.ts
@@ -11,6 +11,54 @@ import {
   buildNotAuthenticatedResult,
 } from './bffAuth.helpers';
 
+function resolveLocalDevAuthFallback(req: NextRequest) {
+  if (!allowLocalTokenFallback()) return null;
+
+  const authorization = req.headers?.get('authorization') ?? '';
+  const match = authorization.match(/^Bearer\s+(.+)$/i);
+  const accessToken = normalizeAccessToken(match?.[1]);
+  if (!accessToken) return null;
+
+  const devUserEmail = req.headers?.get('x-dev-user-email')?.trim() ?? '';
+  const tokenUserEmail = accessToken.includes(':')
+    ? accessToken.slice(accessToken.indexOf(':') + 1)
+    : '';
+  const email = devUserEmail || tokenUserEmail || undefined;
+  const roles = accessToken.startsWith('talent_partner:')
+    ? ['talent_partner']
+    : ['candidate'];
+  const permissions = roles.includes('talent_partner')
+    ? ['talent_partner:access']
+    : ['candidate:access'];
+
+  return {
+    accessToken,
+    permissions,
+    session: {
+      user: {
+        sub: email ?? 'local-dev',
+        name: email ?? 'Local Dev User',
+        email,
+        email_verified: true,
+        roles,
+        permissions,
+      },
+      tokenSet: {
+        accessToken,
+        token_type: 'Bearer',
+        scope: '',
+        audience: '',
+        expiresAt: 0,
+      },
+      internal: {
+        sid: 'local-dev',
+        createdAt: 0,
+      },
+      accessToken,
+    },
+  };
+}
+
 export function mergeResponseCookies(
   from: NextResponse | null | undefined,
   into: NextResponse,
@@ -36,6 +84,17 @@ export async function requireBffAuth(
       `[perf:bff-auth] permission=${options?.requirePermission ?? 'any'} status=${status} ${Date.now() - start}ms`,
     );
   };
+
+  const localDevFallback = resolveLocalDevAuthFallback(req);
+  if (localDevFallback) {
+    logPerf('local-dev-fallback');
+    return buildAuthSuccessResult({
+      accessToken: localDevFallback.accessToken,
+      permissions: localDevFallback.permissions,
+      session: localDevFallback.session,
+      cookies: cookieCarrier,
+    });
+  }
 
   const session = await getSessionNormalized();
   if (!session) {

--- a/tests/e2e/contract-live/global-setup.ts
+++ b/tests/e2e/contract-live/global-setup.ts
@@ -1,15 +1,23 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { chromium, type FullConfig, type Page } from '@playwright/test';
+import { generateSessionCookie } from '@auth0/nextjs-auth0/testing';
 import {
   parseEnvFile,
   readEnv,
+  resolveClaimNamespace,
   type EnvMap,
 } from '../flow-qa/global-setup.env';
 import {
   resolveBaseURL,
   resolveStorageDir,
 } from '../flow-qa/global-setup.paths';
+import {
+  buildSession,
+  resolveDevIdentity,
+  toStorageStateCookie,
+  writeStorageState,
+} from '../flow-qa/global-setup.session';
 
 type LiveRole = 'talent_partner' | 'candidate';
 
@@ -28,6 +36,10 @@ const REQUIRED_QA_AUTH_ENV_KEYS = [
   'QA_E2E_CANDIDATE_EMAIL',
   'QA_E2E_CANDIDATE_PASSWORD',
 ] as const;
+const LOCAL_DEV_ROLE_EMAILS = {
+  talent_partner: 'talent_partner1@local.test',
+  candidate: 'candidate1@local.test',
+} as const;
 
 async function loadEnvMapFrom(paths: string[]): Promise<EnvMap> {
   const merged: EnvMap = {};
@@ -68,6 +80,42 @@ function validateRequiredQaAuthEnv(envMap: EnvMap): void {
   );
 }
 
+function hasRequiredQaAuthEnv(envMap: EnvMap): boolean {
+  return REQUIRED_QA_AUTH_ENV_KEYS.every((key) =>
+    Boolean(readEnv(key, envMap)),
+  );
+}
+
+async function createLocalDevStorageState(params: {
+  baseURL: string;
+  envMap: EnvMap;
+  identity: LiveIdentity;
+  storagePath: string;
+}): Promise<void> {
+  const secret = requireEnv('WINOE_AUTH0_SECRET', params.envMap);
+  const claimNamespace = resolveClaimNamespace(params.envMap);
+  const roles =
+    params.identity.mode === 'candidate' ? ['candidate'] : ['talent_partner'];
+  const identity = resolveDevIdentity(roles);
+  const session = buildSession({
+    permissions:
+      params.identity.mode === 'candidate'
+        ? ['candidate:access']
+        : ['talent_partner:access'],
+    roles,
+    claimNamespace,
+    accessToken: identity.accessToken,
+    email: identity.email,
+    sub: identity.sub,
+  });
+  const encrypted = await generateSessionCookie(session, { secret });
+  const cookie = toStorageStateCookie({
+    value: encrypted,
+    baseURL: params.baseURL,
+  });
+  await writeStorageState(params.storagePath, cookie);
+}
+
 function resolveIdentity(role: LiveRole, envMap: EnvMap): LiveIdentity {
   if (role === 'talent_partner') {
     return {
@@ -91,6 +139,31 @@ function resolveIdentity(role: LiveRole, envMap: EnvMap): LiveIdentity {
     fileName: 'candidate-only.json',
     mode: 'candidate',
     password: requireEnv('QA_E2E_CANDIDATE_PASSWORD', envMap),
+    returnTo: '/candidate/dashboard',
+  };
+}
+
+function resolveLocalDevIdentity(role: LiveRole, envMap: EnvMap): LiveIdentity {
+  if (role === 'talent_partner') {
+    return {
+      connection: 'local-dev',
+      email:
+        readEnv('QA_E2E_TALENT_PARTNER_EMAIL', envMap) ||
+        LOCAL_DEV_ROLE_EMAILS.talent_partner,
+      fileName: 'talent-partner-only.json',
+      mode: 'talent_partner',
+      password: 'local-dev',
+      returnTo: '/dashboard',
+    };
+  }
+  return {
+    connection: 'local-dev',
+    email:
+      readEnv('QA_E2E_CANDIDATE_EMAIL', envMap) ||
+      LOCAL_DEV_ROLE_EMAILS.candidate,
+    fileName: 'candidate-only.json',
+    mode: 'candidate',
+    password: 'local-dev',
     returnTo: '/candidate/dashboard',
   };
 }
@@ -262,23 +335,40 @@ export default async function globalSetup(config: FullConfig) {
   const storageDir = resolveStorageDir(repoRoot);
 
   await fs.mkdir(storageDir, { recursive: true });
-  validateRequiredQaAuthEnv(envMap);
+
+  const useRealAuthBootstrap = hasRequiredQaAuthEnv(envMap);
+  if (useRealAuthBootstrap) {
+    validateRequiredQaAuthEnv(envMap);
+  }
 
   for (const role of ['talent_partner', 'candidate'] as const) {
-    const identity = resolveIdentity(role, envMap);
-    const sourcePath =
-      role === 'talent_partner'
-        ? readEnv('CONTRACT_LIVE_TALENT_PARTNER_STORAGE_STATE', envMap)
-        : readEnv('CONTRACT_LIVE_CANDIDATE_STORAGE_STATE', envMap);
-    const reused = await reuseStorageStateIfAvailable({
-      storagePath: path.join(storageDir, identity.fileName),
-      sourcePath,
-    });
-    if (reused) {
+    const identity = useRealAuthBootstrap
+      ? resolveIdentity(role, envMap)
+      : resolveLocalDevIdentity(role, envMap);
+    if (useRealAuthBootstrap) {
+      const sourcePath =
+        role === 'talent_partner'
+          ? readEnv('CONTRACT_LIVE_TALENT_PARTNER_STORAGE_STATE', envMap)
+          : readEnv('CONTRACT_LIVE_CANDIDATE_STORAGE_STATE', envMap);
+      const reused = await reuseStorageStateIfAvailable({
+        storagePath: path.join(storageDir, identity.fileName),
+        sourcePath,
+      });
+      if (reused) {
+        continue;
+      }
+      await createStorageState({
+        baseURL,
+        identity,
+        storagePath: path.join(storageDir, identity.fileName),
+      });
       continue;
     }
-    await createStorageState({
+    // Local-dev auth cookies are cheap to recreate and can go stale when the
+    // auth secret or generated session payload changes between runs.
+    await createLocalDevStorageState({
       baseURL,
+      envMap,
       identity,
       storagePath: path.join(storageDir, identity.fileName),
     });

--- a/tests/e2e/flow-qa/candidate-critical-journey.spec.ts
+++ b/tests/e2e/flow-qa/candidate-critical-journey.spec.ts
@@ -8,6 +8,26 @@ import {
 } from './fixtures/candidateMocks';
 import { CandidateSessionQaPage } from './pages';
 
+const sampleDay5Markdown = `## Experience & Challenges
+
+Handled ambiguous requirements by validating assumptions early in the flow.
+
+## Decisions & Tradeoffs
+
+I chose deterministic contracts first so UI and backend validation stayed aligned.
+
+## Learnings & Growth
+
+I traded breadth for reliability and learned to keep the evaluation path simple.
+
+## Collaboration & Communication
+
+I documented risks, handoff notes, and verification steps for reviewers.
+
+## What I Would Do Differently
+
+Next I would add stronger evidence links and broader failure-mode tests.`;
+
 test.describe('Candidate Critical Journey (flow-qa mocked)', () => {
   test.use({ storageState: storageStates.candidateOnly });
 
@@ -27,8 +47,8 @@ test.describe('Candidate Critical Journey (flow-qa mocked)', () => {
         id: 5,
         dayIndex: 5,
         type: 'documentation',
-        title: 'Final reflection',
-        description: 'Document your decisions and next steps.',
+        title: 'Reflection Essay',
+        description: 'Reflect on your full Trial experience.',
       }),
       completedTaskIds: [],
       completedTaskIdsAfterSubmit: [1, 2, 3, 4],
@@ -57,9 +77,18 @@ test.describe('Candidate Critical Journey (flow-qa mocked)', () => {
     await submitResponsePromise;
 
     await sessionPage.expectDay(5);
-    await expect(page.getByText(/^day 5 • documentation$/i)).toBeVisible();
-    await expect(page.getByLabel(/^challenges$/i)).toBeVisible();
-    await expect(page.getByLabel(/^what you would do next$/i)).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /reflection essay editor/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('textbox', { name: /markdown editor/i }),
+    ).toBeVisible();
+    await page
+      .getByRole('textbox', { name: /markdown editor/i })
+      .fill(sampleDay5Markdown);
+    await expect(
+      page.getByRole('button', { name: /^preview$/i }),
+    ).toBeVisible();
   });
 
   test('Day4 upload state checkpoint', async ({ page }) => {
@@ -107,8 +136,8 @@ test.describe('Candidate Critical Journey (flow-qa mocked)', () => {
         id: 5,
         dayIndex: 5,
         type: 'documentation',
-        title: 'Final reflection',
-        description: 'Document your decisions and next steps.',
+        title: 'Reflection Essay',
+        description: 'Reflect on your full Trial experience.',
       }),
       nextTaskAfterSubmit: null,
       completedTaskIds: [1, 2, 3, 4],
@@ -122,30 +151,8 @@ test.describe('Candidate Critical Journey (flow-qa mocked)', () => {
     await sessionPage.expectDay(5);
 
     await page
-      .getByLabel(/^challenges$/i)
-      .fill(
-        'I balanced speed, correctness, and clear communication with tradeoffs.',
-      );
-    await page
-      .getByLabel(/^decisions$/i)
-      .fill(
-        'I prioritized deterministic behavior and test coverage for critical user journeys.',
-      );
-    await page
-      .getByLabel(/^tradeoffs$/i)
-      .fill(
-        'I deferred optional polish to keep key flows stable and observable.',
-      );
-    await page
-      .getByLabel(/^communication \/ handoff$/i)
-      .fill(
-        'I documented release steps, known risks, and fallback plans for reviewers.',
-      );
-    await page
-      .getByLabel(/^what you would do next$/i)
-      .fill(
-        'Next, I would improve diagnostics around flaky transitions and artifact retries.',
-      );
+      .getByRole('textbox', { name: /markdown editor/i })
+      .fill(sampleDay5Markdown);
 
     const submitResponsePromise = page.waitForResponse(
       (resp) =>
@@ -153,9 +160,15 @@ test.describe('Candidate Critical Journey (flow-qa mocked)', () => {
         resp.request().method() === 'POST' &&
         resp.status() === 200,
     );
-    await page.getByRole('button', { name: /submit & continue/i }).click();
+    await page
+      .getByRole('button', { name: /submit reflection essay/i })
+      .click();
+    await page
+      .getByRole('dialog', { name: /submit your reflection essay/i })
+      .getByRole('button', { name: /submit reflection essay/i })
+      .click();
     await submitResponsePromise;
 
-    await expect(page.getByText(/trial complete/i)).toBeVisible();
+    await expect(page.getByText(/congratulations/i)).toBeVisible();
   });
 });

--- a/tests/e2e/flow-qa/candidate-day5.spec.ts
+++ b/tests/e2e/flow-qa/candidate-day5.spec.ts
@@ -7,10 +7,30 @@ import {
 } from './fixtures/candidateMocks';
 import { CandidateSessionQaPage } from './pages';
 
+const sampleDay5Markdown = `## Experience & Challenges
+
+Handled ambiguous requirements by validating assumptions early in the flow.
+
+## Decisions & Tradeoffs
+
+I chose deterministic contracts first so UI and backend validation stayed aligned.
+
+## Learnings & Growth
+
+I traded breadth for reliability and learned to keep the evaluation path simple.
+
+## Collaboration & Communication
+
+I documented risks, handoff notes, and verification steps for reviewers.
+
+## What I Would Do Differently
+
+Next I would add stronger evidence links and broader failure-mode tests.`;
+
 test.describe('Candidate Day 5 Flow', () => {
   test.use({ storageState: storageStates.candidateOnly });
 
-  test('day 5 reflection validates fields, supports preview, and submits to completion', async ({
+  test('day 5 reflection markdown editor supports preview and submits to completion', async ({
     page,
   }) => {
     await installCandidateSessionMocks(page, {
@@ -19,8 +39,8 @@ test.describe('Candidate Day 5 Flow', () => {
         id: 5,
         dayIndex: 5,
         type: 'documentation',
-        title: 'Final reflection',
-        description: 'Document your decisions and next steps.',
+        title: 'Reflection Essay',
+        description: 'Reflect on your full Trial experience.',
       }),
       nextTaskAfterSubmit: null,
       completedTaskIds: [1, 2, 3, 4],
@@ -31,52 +51,31 @@ test.describe('Candidate Day 5 Flow', () => {
     await sessionPage.gotoWithToken(QA_INVITE_TOKEN);
     await sessionPage.startTrial();
     await sessionPage.expectDay(5);
-    await expect(page.getByText(/^day 5 • documentation$/i)).toBeVisible();
-    const submitButton = page.getByRole('button', {
-      name: /submit & continue/i,
-    });
-    await expect(submitButton).toBeDisabled();
+
     await expect(
-      page.getByText(
-        /complete all sections with at least 20 characters to submit\./i,
-      ),
+      page.getByRole('heading', { name: /reflection essay editor/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/9:00 AM–9:00 PM your local time/i),
     ).toBeVisible();
 
-    const challengesField = page.getByLabel(/^challenges$/i);
-    await challengesField.focus();
-    await page.keyboard.press('Tab');
-    await expect(
-      page.getByText(/this section is required\./i).first(),
-    ).toBeVisible();
+    const editor = page.getByRole('textbox', { name: /markdown editor/i });
+    await editor.fill(sampleDay5Markdown);
 
-    await challengesField.fill(
-      'The hardest challenge was sequencing Day 2 and Day 3 work while preserving test stability.',
-    );
-    await page
-      .getByLabel(/^decisions$/i)
-      .fill(
-        'I chose a typed API layer first so behavior changes were safer and easier to validate.',
-      );
-    await page
-      .getByLabel(/^tradeoffs$/i)
-      .fill(
-        'I traded breadth for reliability, prioritizing deterministic workflows over optional enhancements.',
-      );
-    await page
-      .getByLabel(/^communication \/ handoff$/i)
-      .fill(
-        'I documented release notes, risks, and verification steps to make execution transparent for reviewers.',
-      );
-    await page
-      .getByLabel(/^what you would do next$/i)
-      .fill(
-        'Next I would add failure-mode tests, telemetry for flaky transitions, and improve regression dashboards.',
-      );
     await page.getByRole('button', { name: /^preview$/i }).click();
-    await expect(page.getByText(/what i would do next/i)).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /experience & challenges/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /what i would do differently/i }),
+    ).toBeVisible();
     await page.getByRole('button', { name: /^write$/i }).click();
+
+    const submitButton = page.getByRole('button', {
+      name: /submit reflection essay/i,
+    });
     await expect(submitButton).toBeEnabled();
-    await page.getByRole('button', { name: /save draft/i }).click();
+
     const submitResponsePromise = page.waitForResponse(
       (resp) =>
         resp.url().includes('/api/backend/tasks/5/submit') &&
@@ -84,9 +83,13 @@ test.describe('Candidate Day 5 Flow', () => {
         resp.status() === 200,
     );
     await submitButton.click();
+    await page
+      .getByRole('dialog', { name: /submit your reflection essay/i })
+      .getByRole('button', { name: /submit reflection essay/i })
+      .click();
     const submitResponse = await submitResponsePromise;
     expect(submitResponse.status()).toBe(200);
-    await expect(page.getByText(/trial complete/i)).toBeVisible({
+    await expect(page.getByText(/congratulations/i)).toBeVisible({
       timeout: 8000,
     });
   });

--- a/tests/integration/candidate/CandidateSessionPageClient.behavior.scheduleSuccess.test.tsx
+++ b/tests/integration/candidate/CandidateSessionPageClient.behavior.scheduleSuccess.test.tsx
@@ -12,6 +12,8 @@ import {
 } from './CandidateSessionPageClient.behavior.testlib';
 import { jsonResponse } from '../../setup/responseHelpers';
 
+jest.setTimeout(15000);
+
 describe('CandidateSessionPage auth flow schedule success', () => {
   beforeEach(() => {
     resetBehaviorEnv('valid-token');

--- a/tests/integration/candidate/CandidateTrialContent.test.tsx
+++ b/tests/integration/candidate/CandidateTrialContent.test.tsx
@@ -35,6 +35,8 @@ const renderWithProvider = (ui: React.ReactNode) =>
 const realFetch = global.fetch;
 const fetchMock = jest.fn();
 
+jest.setTimeout(15000);
+
 describe('CandidateSessionPage', () => {
   beforeEach(() => {
     jest.resetAllMocks();

--- a/tests/integration/talent-partner/TrialDetailPageClient.compareRetry.test.tsx
+++ b/tests/integration/talent-partner/TrialDetailPageClient.compareRetry.test.tsx
@@ -3,6 +3,7 @@ import {
   mockFetchHandlers,
   renderPage,
   screen,
+  waitFor,
   userEvent,
 } from './TrialDetailPageClient.testlib';
 
@@ -52,8 +53,11 @@ describe('TalentPartnerTrialDetailPage - compare retry', () => {
     renderPage();
 
     expect(await screen.findByText('Benchmarks')).toBeInTheDocument();
+    await waitFor(() => expect(compareCalls).toBe(1));
     expect(
-      await screen.findByText('Request failed with status 500'),
+      await screen.findByText('Request failed with status 500', undefined, {
+        timeout: 5000,
+      }),
     ).toBeInTheDocument();
     expect(compareCalls).toBe(1);
 

--- a/tests/setup/jest/reactMarkdownMock.ts
+++ b/tests/setup/jest/reactMarkdownMock.ts
@@ -53,13 +53,15 @@ jest.mock('react-markdown', () => {
     };
 
     lines.forEach((line, idx) => {
-      if (line.startsWith('# ')) {
+      const headingMatch = line.match(/^(#{1,3})\s+(.+)$/);
+      if (headingMatch) {
         flushList();
+        const headingLevel = Math.min(headingMatch[1].length, 3);
         elements.push(
           React.createElement(
-            'h1',
-            { key: `h1-${idx}` },
-            parseInline(line.slice(2)),
+            `h${headingLevel}`,
+            { key: `h${headingLevel}-${idx}` },
+            parseInline(headingMatch[2]),
           ),
         );
         return;

--- a/tests/unit/app/api/backend/route.coverage.test.ts
+++ b/tests/unit/app/api/backend/route.coverage.test.ts
@@ -48,6 +48,12 @@ jest.mock('@/platform/server/bff', () => ({
     body: null,
   }),
 }));
+jest.mock('@/platform/auth0', () => ({
+  getSessionNormalized: jest.fn(async () => ({
+    user: { email: 'candidate@example.com' },
+    accessToken: 'token',
+  })),
+}));
 describe('api/backend/route.ts coverage completion', () => {
   it('imports route', async () => {
     const mod = await import('@/app/api/backend/[...path]/route');

--- a/tests/unit/app/api/backendProxy.testlib.ts
+++ b/tests/unit/app/api/backendProxy.testlib.ts
@@ -19,6 +19,12 @@ jest.mock('@/platform/server/bff', () => ({
   getBackendBaseUrl: () => getBackendBaseUrlMock(),
   resolveRequestId: () => resolveRequestIdMock(),
 }));
+jest.mock('@/platform/auth0', () => ({
+  getSessionNormalized: jest.fn(async () => ({
+    user: { email: 'candidate@example.com' },
+    accessToken: 'token',
+  })),
+}));
 
 const modulePath = '@/app/api/backend/[...path]/route';
 const originalEnv = { ...process.env };

--- a/tests/unit/candidateApi.submit.success.test.ts
+++ b/tests/unit/candidateApi.submit.success.test.ts
@@ -84,7 +84,8 @@ describe('candidateApi submit success paths', () => {
     await submitCandidateTask({
       taskId: 5,
       candidateSessionId: 1,
-      contentText: '## Challenges\n...\n## Decisions\n...',
+      contentText:
+        '## Experience & Challenges\n...\n## Decisions & Tradeoffs\n...',
       reflection: {
         challenges: 'a',
         decisions: 'b',
@@ -99,7 +100,7 @@ describe('candidateApi submit success paths', () => {
       unknown
     >;
     expect(body).toMatchObject({
-      contentText: expect.stringContaining('## Challenges'),
+      contentText: expect.stringContaining('## Experience & Challenges'),
       reflection: expect.objectContaining({
         challenges: expect.any(String),
         decisions: expect.any(String),

--- a/tests/unit/features/candidate/session/CandidateSessionPage.view.startComplete.test.tsx
+++ b/tests/unit/features/candidate/session/CandidateSessionPage.view.startComplete.test.tsx
@@ -35,10 +35,13 @@ describe('CandidateSessionPage view - completion and start state', () => {
     );
     render(<CandidateSessionPage token="inv" />);
     await waitFor(() =>
-      expect(screen.getByTestId('state-message')).toHaveTextContent(
-        'Trial complete',
-      ),
+      expect(
+        screen.getByText(/congratulations - your 5-day trial is complete/i),
+      ).toBeInTheDocument(),
     );
+    expect(
+      screen.getByText(/day 1: planning & design doc/i),
+    ).toBeInTheDocument();
   });
 
   it('renders start view and triggers start fetch when not started', async () => {

--- a/tests/unit/features/candidate/session/CandidateSessionView.dayProgression.test.tsx
+++ b/tests/unit/features/candidate/session/CandidateSessionView.dayProgression.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { CandidateSessionView } from '@/features/candidate/session/CandidateSessionView';
 import { buildCandidateSessionViewProps } from './CandidateSessionView.windowGating.testProps';
 
@@ -38,14 +38,14 @@ describe('CandidateSessionView day progression checkpoints', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders Day 5 reflection fields in editable mode', () => {
+  it('renders Day 5 reflection markdown editor in editable mode', () => {
     const props = buildCandidateSessionViewProps();
     props.currentTask = {
       id: 15,
       dayIndex: 5,
       type: 'documentation',
-      title: 'Final reflection',
-      description: 'Summarize your decisions and next steps.',
+      title: 'Reflection Essay',
+      description: 'Reflect on your full Trial experience.',
     };
     props.currentDayIndex = 5;
     props.actionGate = {
@@ -64,13 +64,20 @@ describe('CandidateSessionView day progression checkpoints', () => {
 
     render(<CandidateSessionView {...props} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /^Write$/i }));
     expect(
-      screen.getByPlaceholderText(/Write your response here/i),
+      screen.getByRole('heading', { name: /reflection essay editor/i }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Markdown is supported/i)).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/9:00 AM–9:00 PM your local time/i).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getByRole('textbox', { name: /markdown editor/i }),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /^Preview$/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /submit reflection essay/i }),
     ).toBeInTheDocument();
   });
 
@@ -80,13 +87,13 @@ describe('CandidateSessionView day progression checkpoints', () => {
       id: 15,
       dayIndex: 5,
       type: 'documentation',
-      title: 'Final reflection',
-      description: 'Summarize your decisions and next steps.',
+      title: 'Reflection Essay',
+      description: 'Reflect on your full Trial experience.',
     };
     props.currentDayIndex = 5;
     props.actionGate = {
       isReadOnly: true,
-      disabledReason: 'Day 5 locked until the active window opens.',
+      disabledReason: null,
       comeBackAt: '2099-01-05T14:00:00Z',
     };
     props.windowState = {
@@ -104,10 +111,13 @@ describe('CandidateSessionView day progression checkpoints', () => {
 
     expect(screen.getByText(/^Day 5 is not open yet$/i)).toBeInTheDocument();
     expect(
-      screen.getAllByText(/Day 5 locked until the active window opens\./i),
-    ).toHaveLength(2);
+      screen.getByRole('heading', {
+        name: /day 5 opens at 9:00 am local time/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/come back at/i)).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /Submit & Continue/i }),
-    ).toBeDisabled();
+      screen.queryByRole('button', { name: /submit reflection essay/i }),
+    ).toBeNull();
   });
 });

--- a/tests/unit/features/candidate/tasks/CandidateTaskView.closedReadOnly.test.tsx
+++ b/tests/unit/features/candidate/tasks/CandidateTaskView.closedReadOnly.test.tsx
@@ -23,7 +23,7 @@ describe('CandidateTaskView closed/read-only states', () => {
       },
       actionGate: {
         isReadOnly: true,
-        disabledReason: 'Day closed.',
+        disabledReason: null,
         comeBackAt: null,
       },
     });
@@ -36,15 +36,15 @@ describe('CandidateTaskView closed/read-only states', () => {
     expect(getCandidateTaskDraftMock).not.toHaveBeenCalled();
   });
 
-  it('shows placeholder when no finalized reflection content exists', async () => {
+  it('shows the closed Day 5 copy when the deadline has passed', async () => {
     renderTaskView({
       task: {
         ...baseTask,
         id: 5,
         dayIndex: 5,
         type: 'documentation',
-        title: 'Reflection',
-        description: 'Submit your structured reflection.',
+        title: 'Reflection Essay',
+        description: 'Reflect on your full Trial experience.',
       },
       actionGate: {
         isReadOnly: true,
@@ -53,15 +53,15 @@ describe('CandidateTaskView closed/read-only states', () => {
       },
     });
     await waitFor(() =>
-      expect(screen.getAllByText(/day closed/i)).toHaveLength(2),
+      expect(
+        screen.getByText(/the day 5 reflection window has closed/i),
+      ).toBeInTheDocument(),
     );
-    expect(
-      screen.getByText(/no finalized submission is available for this day\./i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/day closed/i)).toBeInTheDocument();
     expect(screen.queryByRole('textbox')).toBeNull();
     expect(
-      screen.getByRole('button', { name: /submit & continue/i }),
-    ).toBeDisabled();
+      screen.queryByRole('button', { name: /submit reflection essay/i }),
+    ).toBeNull();
     expect(getCandidateTaskDraftMock).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/features/candidate/tasks/CandidateTaskView.closedReflectionContent.test.tsx
+++ b/tests/unit/features/candidate/tasks/CandidateTaskView.closedReflectionContent.test.tsx
@@ -11,7 +11,7 @@ describe('CandidateTaskView finalized day5 reflection rendering', () => {
     primeDraftMocks();
   });
 
-  it('renders structured finalized reflection sections in read-only mode', async () => {
+  it('renders congratulations when day 5 is finalized', async () => {
     renderTaskView({
       task: {
         ...baseTask,
@@ -41,13 +41,18 @@ describe('CandidateTaskView finalized day5 reflection rendering', () => {
       },
     });
     await waitFor(() =>
-      expect(screen.getByText(/Final challenges/i)).toBeInTheDocument(),
+      expect(
+        screen.getByText(/congratulations - your 5-day trial is complete/i),
+      ).toBeInTheDocument(),
     );
     expect(screen.queryByRole('textbox')).toBeNull();
+    expect(
+      screen.getByText(/your 5-day trial is complete/i),
+    ).toBeInTheDocument();
     expect(getCandidateTaskDraftMock).not.toHaveBeenCalled();
   });
 
-  it('prefers finalized contentText when both text and structured content exist', async () => {
+  it('keeps the congratulations screen when both text and structured content exist', async () => {
     renderTaskView({
       task: {
         ...baseTask,
@@ -77,9 +82,10 @@ describe('CandidateTaskView finalized day5 reflection rendering', () => {
       },
     });
     await waitFor(() =>
-      expect(screen.getByText(/Finalized text body/i)).toBeInTheDocument(),
+      expect(
+        screen.getByText(/your 5-day trial is complete/i),
+      ).toBeInTheDocument(),
     );
-    expect(screen.queryByText(/Structured challenges body/i)).toBeNull();
     expect(screen.queryByRole('textbox')).toBeNull();
     expect(getCandidateTaskDraftMock).not.toHaveBeenCalled();
   });

--- a/tests/unit/features/candidate/tasks/CandidateTaskView.reflectionValidationDraft.test.tsx
+++ b/tests/unit/features/candidate/tasks/CandidateTaskView.reflectionValidationDraft.test.tsx
@@ -1,10 +1,18 @@
-import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import {
   baseTask,
+  fillDay5Markdown,
   getCandidateTaskDraftMock,
   primeDraftMocks,
   putCandidateTaskDraftMock,
   renderTaskView,
+  sampleDay5Markdown,
 } from './CandidateTaskView.testlib';
 
 describe('CandidateTaskView reflection validation and editable draft behavior', () => {
@@ -17,7 +25,7 @@ describe('CandidateTaskView reflection validation and editable draft behavior', 
     jest.useRealTimers();
   });
 
-  it('uses generic markdown validation for day 5 reflection submission', async () => {
+  it('opens confirmation and submits the Day 5 reflection payload', async () => {
     const onSubmit = jest.fn().mockResolvedValue(undefined);
     renderTaskView({
       task: {
@@ -25,39 +33,54 @@ describe('CandidateTaskView reflection validation and editable draft behavior', 
         id: 5,
         dayIndex: 5,
         type: 'documentation',
-        title: 'Reflection',
-        description: 'Submit your structured reflection.',
+        title: 'Reflection Essay',
+        description: 'Reflect on your full Trial experience.',
       },
       onSubmit,
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /submit & continue/i }));
-    await waitFor(() =>
-      expect(
-        screen.getByText(/please enter an answer before submitting\./i),
-      ).toBeInTheDocument(),
+    await screen.findByRole('heading', { name: /reflection essay editor/i });
+    fillDay5Markdown();
+    fireEvent.click(
+      screen.getByRole('button', { name: /submit reflection essay/i }),
     );
-    fireEvent.change(screen.getByRole('textbox'), {
-      target: {
-        value:
-          '# Reflection\n\nHandled ambiguous requirements by validating assumptions early in the flow.',
-      },
-    });
-    fireEvent.click(screen.getByRole('button', { name: /submit & continue/i }));
+    fireEvent.click(
+      within(
+        screen.getByRole('dialog', {
+          name: /submit your reflection essay/i,
+        }),
+      ).getByRole('button', { name: /submit reflection essay/i }),
+    );
     await waitFor(() =>
       expect(onSubmit).toHaveBeenCalledWith({
-        contentText:
-          '# Reflection\n\nHandled ambiguous requirements by validating assumptions early in the flow.',
+        reflection: expect.objectContaining({
+          challenges: expect.any(String),
+          decisions: expect.any(String),
+          tradeoffs: expect.any(String),
+          communication: expect.any(String),
+          next: expect.any(String),
+        }),
+        contentText: sampleDay5Markdown,
       }),
     );
-    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(
+      await screen.findByText(/your 5-day trial is complete/i),
+    ).toBeInTheDocument();
   });
 
-  it('keeps draft restore/autosave active when recordedSubmission exists but task is editable', async () => {
+  it('keeps draft restore and autosave active for editable drafts', async () => {
     getCandidateTaskDraftMock.mockResolvedValue({
-      taskId: 1,
-      contentText: 'Recovered editable draft',
-      contentJson: null,
+      taskId: 5,
+      contentText: null,
+      contentJson: {
+        reflection: {
+          challenges: 'Recovered editable draft',
+          decisions: 'Recovered decisions',
+          tradeoffs: 'Recovered tradeoffs',
+          communication: 'Recovered communication',
+          next: 'Recovered next',
+        },
+      },
       updatedAt: '2026-03-07T09:00:00.000Z',
       finalizedAt: null,
       finalizedSubmissionId: null,
@@ -65,21 +88,25 @@ describe('CandidateTaskView reflection validation and editable draft behavior', 
     renderTaskView({
       task: {
         ...baseTask,
-        recordedSubmission: {
-          submissionId: 77,
-          submittedAt: '2026-03-07T08:00:00.000Z',
-        },
+        id: 5,
+        dayIndex: 5,
+        type: 'documentation',
+        title: 'Reflection Essay',
+        description: 'Reflect on your full Trial experience.',
       },
       actionGate: { isReadOnly: false, disabledReason: null, comeBackAt: null },
     });
     await waitFor(() =>
       expect(
-        screen.getByDisplayValue('Recovered editable draft'),
+        screen.getByDisplayValue(/Recovered editable draft/),
       ).toBeInTheDocument(),
     );
-    fireEvent.change(screen.getByRole('textbox'), {
-      target: { value: 'Keep editing' },
-    });
+    fireEvent.change(
+      screen.getByRole('textbox', { name: /markdown editor/i }),
+      {
+        target: { value: 'Keep editing' },
+      },
+    );
     await act(async () => {
       jest.advanceTimersByTime(1500);
     });

--- a/tests/unit/features/candidate/tasks/CandidateTaskView.routingPanels.test.tsx
+++ b/tests/unit/features/candidate/tasks/CandidateTaskView.routingPanels.test.tsx
@@ -11,7 +11,7 @@ describe('CandidateTaskView task-type panel routing', () => {
     primeDraftMocks();
   });
 
-  it('routes day 5 documentation to the markdown reflection editor', async () => {
+  it('routes day 5 documentation to the reflection panel', async () => {
     getCandidateTaskDraftMock.mockResolvedValue({
       taskId: 5,
       contentText: null,
@@ -34,16 +34,36 @@ describe('CandidateTaskView task-type panel routing', () => {
     });
     await waitFor(() =>
       expect(
-        (screen.getByRole('textbox') as HTMLTextAreaElement).value,
-      ).toContain('Recovered challenge notes'),
+        screen.getByRole('heading', { name: /reflection essay editor/i }),
+      ).toBeInTheDocument(),
     );
     expect(
-      (screen.getByRole('textbox') as HTMLTextAreaElement).value,
-    ).toContain('Recovered tradeoff notes');
-    expect(
-      screen.queryByRole('button', { name: /preview/i }),
+      screen.getByRole('textbox', { name: /markdown editor/i }),
     ).toBeInTheDocument();
-    expect(screen.queryByLabelText(/challenges/i)).toBeNull();
+    expect(
+      screen.getByRole('button', { name: /preview/i }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole('textbox').length).toBe(1);
+  });
+
+  it('routes day 5 reflection tasks to the reflection panel', async () => {
+    renderTaskView({
+      task: {
+        ...baseTask,
+        id: 5,
+        dayIndex: 5,
+        type: 'reflection',
+        title: 'Reflection',
+      },
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByRole('heading', { name: /reflection essay editor/i }),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole('button', { name: /submit reflection essay/i }),
+    ).toBeInTheDocument();
   });
 
   it('keeps non-day5 docs on generic text panel', () => {

--- a/tests/unit/features/candidate/tasks/CandidateTaskView.testlib.tsx
+++ b/tests/unit/features/candidate/tasks/CandidateTaskView.testlib.tsx
@@ -48,6 +48,28 @@ export const baseTask: Task = {
   description: 'Write a design doc',
 };
 
+export const sampleDay5Markdown = `## Experience & Challenges
+
+Handled ambiguous requirements by validating assumptions early in the flow.
+
+The hardest part was keeping the essay focused while preserving enough detail.
+
+## Decisions & Tradeoffs
+
+Chose deterministic contracts so UI and backend validation align.
+
+## Learnings & Growth
+
+Accepted stricter rules to improve evaluation consistency across candidates.
+
+## Collaboration & Communication
+
+Documented risks and handoff notes clearly at each implementation milestone.
+
+## What I Would Do Differently
+
+Next I would add rubric-linked evidence references and quality checks.`;
+
 export const primeDraftMocks = () => {
   jest.clearAllMocks();
   getCandidateTaskDraftMock.mockResolvedValue(null);
@@ -74,35 +96,10 @@ export const renderTaskView = (
   return { onSubmit };
 };
 
-export const fillAllReflectionSections = () => {
-  fireEvent.change(screen.getByLabelText(/challenges/i), {
+export const fillDay5Markdown = () => {
+  fireEvent.change(screen.getByRole('textbox', { name: /markdown editor/i }), {
     target: {
-      value:
-        'Handled ambiguous requirements by validating assumptions early in the flow.',
-    },
-  });
-  fireEvent.change(screen.getByLabelText(/^decisions$/i), {
-    target: {
-      value:
-        'Chose deterministic contracts so UI and backend validation align.',
-    },
-  });
-  fireEvent.change(screen.getByLabelText(/tradeoffs/i), {
-    target: {
-      value:
-        'Accepted stricter rules to improve evaluation consistency across candidates.',
-    },
-  });
-  fireEvent.change(screen.getByLabelText(/communication/i), {
-    target: {
-      value:
-        'Documented risks and handoff notes clearly at each implementation milestone.',
-    },
-  });
-  fireEvent.change(screen.getByLabelText(/what you would do next/i), {
-    target: {
-      value:
-        'Next I would add rubric-linked evidence references and quality checks.',
+      value: sampleDay5Markdown,
     },
   });
 };

--- a/tests/unit/features/candidate/tasks/components/Day5ReflectionPanel.submit.test.tsx
+++ b/tests/unit/features/candidate/tasks/components/Day5ReflectionPanel.submit.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import {
-  fillAllSections,
+  fillDay5Markdown,
   renderPanel,
   resetDay5PanelMocks,
+  sampleDay5Markdown,
 } from './Day5ReflectionPanel.testlib';
 
 describe('Day5ReflectionPanel submit flow', () => {
@@ -14,17 +15,43 @@ describe('Day5ReflectionPanel submit flow', () => {
     jest.useRealTimers();
   });
 
-  it('keeps submit disabled until all sections are valid', async () => {
+  it('shows a single markdown editor and keeps submit disabled for scaffold-only content', () => {
     renderPanel();
-    const submitButton = screen.getByRole('button', {
-      name: /submit & continue/i,
-    });
-    expect(submitButton).toBeDisabled();
-    fillAllSections();
-    expect(submitButton).toBeEnabled();
+    expect(
+      screen.getByRole('textbox', { name: /markdown editor/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /submit reflection essay/i }),
+    ).toBeDisabled();
+    expect(
+      screen.getByText(/add reflection text before submitting/i),
+    ).toBeInTheDocument();
   });
 
-  it('submits structured reflection payload with markdown contentText', async () => {
+  it('enables submit after body content is written and opens confirmation', () => {
+    renderPanel();
+    fireEvent.change(
+      screen.getByRole('textbox', { name: /markdown editor/i }),
+      {
+        target: {
+          value: sampleDay5Markdown,
+        },
+      },
+    );
+    expect(
+      screen.getByRole('button', { name: /submit reflection essay/i }),
+    ).toBeEnabled();
+    fireEvent.click(
+      screen.getByRole('button', { name: /submit reflection essay/i }),
+    );
+    expect(
+      screen.getByRole('dialog', {
+        name: /submit your reflection essay/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('submits structured reflection payload with exact markdown contentText', async () => {
     const onSubmit = jest.fn().mockResolvedValue({
       submissionId: 10,
       taskId: 5,
@@ -35,8 +62,16 @@ describe('Day5ReflectionPanel submit flow', () => {
     });
     renderPanel({ onSubmit });
 
-    fillAllSections();
-    fireEvent.click(screen.getByRole('button', { name: /submit & continue/i }));
+    fillDay5Markdown();
+    fireEvent.click(
+      screen.getByRole('button', { name: /submit reflection essay/i }),
+    );
+    const dialog = screen.getByRole('dialog', {
+      name: /submit your reflection essay/i,
+    });
+    fireEvent.click(
+      within(dialog).getByRole('button', { name: /submit reflection essay/i }),
+    );
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     expect(onSubmit).toHaveBeenCalledWith(
@@ -48,16 +83,14 @@ describe('Day5ReflectionPanel submit flow', () => {
           communication: expect.any(String),
           next: expect.any(String),
         }),
-        contentText: expect.stringContaining('## Challenges'),
+        contentText: sampleDay5Markdown,
       }),
     );
     expect(
-      await screen.findByText(
-        /submitted\. your day 5 reflection is finalized/i,
-      ),
+      await screen.findByText(/your 5-day trial is complete/i),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: /submit & continue/i }),
+      screen.queryByRole('button', { name: /submit reflection essay/i }),
     ).toBeNull();
   });
 });

--- a/tests/unit/features/candidate/tasks/components/Day5ReflectionPanel.testlib.tsx
+++ b/tests/unit/features/candidate/tasks/components/Day5ReflectionPanel.testlib.tsx
@@ -2,6 +2,8 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import type { ComponentProps } from 'react';
 import { Day5ReflectionPanel } from '@/features/candidate/tasks/components/Day5ReflectionPanel';
 import type { Task } from '@/features/candidate/tasks/types';
+import { sampleDay5Markdown } from '../CandidateTaskView.testlib';
+export { sampleDay5Markdown } from '../CandidateTaskView.testlib';
 
 export const getCandidateTaskDraftMock = jest.fn();
 export const putCandidateTaskDraftMock = jest.fn();
@@ -21,39 +23,14 @@ export const baseTask: Task = {
   id: 5,
   dayIndex: 5,
   type: 'documentation',
-  title: 'Reflection',
-  description: 'Submit your structured reflection.',
+  title: 'Reflection Essay',
+  description: 'Reflect on your full Trial experience.',
 };
 
-export function fillAllSections() {
-  fireEvent.change(screen.getByLabelText(/challenges/i), {
+export function fillDay5Markdown() {
+  fireEvent.change(screen.getByRole('textbox', { name: /markdown editor/i }), {
     target: {
-      value:
-        'Handled ambiguous requirements by validating assumptions early in the flow.',
-    },
-  });
-  fireEvent.change(screen.getByLabelText(/^decisions$/i), {
-    target: {
-      value:
-        'Chose deterministic contracts so UI and backend validation align.',
-    },
-  });
-  fireEvent.change(screen.getByLabelText(/tradeoffs/i), {
-    target: {
-      value:
-        'Accepted stricter rules to improve evaluation consistency across candidates.',
-    },
-  });
-  fireEvent.change(screen.getByLabelText(/communication/i), {
-    target: {
-      value:
-        'Documented risks and handoff notes clearly at each implementation milestone.',
-    },
-  });
-  fireEvent.change(screen.getByLabelText(/what you would do next/i), {
-    target: {
-      value:
-        'Next I would add rubric-linked evidence references and quality checks.',
+      value: sampleDay5Markdown,
     },
   });
 }

--- a/tests/unit/features/candidate/tasks/components/Day5ReflectionPanel.validation.test.tsx
+++ b/tests/unit/features/candidate/tasks/components/Day5ReflectionPanel.validation.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import {
   baseTask,
-  fillAllSections,
+  fillDay5Markdown,
   renderPanel,
   resetDay5PanelMocks,
 } from './Day5ReflectionPanel.testlib';
@@ -15,7 +15,7 @@ describe('Day5ReflectionPanel validation and read-only states', () => {
     jest.useRealTimers();
   });
 
-  it('maps backend validation errors to inline section fields', async () => {
+  it('surfaces backend validation errors for the markdown essay', async () => {
     const onSubmit = jest.fn().mockRejectedValue({
       status: 422,
       details: {
@@ -28,20 +28,28 @@ describe('Day5ReflectionPanel validation and read-only states', () => {
       onSubmit,
     });
 
-    fillAllSections();
-    fireEvent.click(screen.getByRole('button', { name: /submit & continue/i }));
+    fillDay5Markdown();
+    fireEvent.click(
+      screen.getByRole('button', { name: /submit reflection essay/i }),
+    );
+    fireEvent.click(
+      within(
+        screen.getByRole('dialog', {
+          name: /submit your reflection essay/i,
+        }),
+      ).getByRole('button', { name: /submit reflection essay/i }),
+    );
 
     await waitFor(() => {
-      const communicationField = screen.getByLabelText(/communication/i);
-      const section = communicationField.closest('section');
-      expect(section).not.toBeNull();
       expect(
-        within(section as HTMLElement).getByText(/add at least 20 characters/i),
+        screen.getByText(
+          /please complete the reflection essay before submitting/i,
+        ),
       ).toBeInTheDocument();
     });
   });
 
-  it('renders canonical read-only markdown when day is closed', () => {
+  it('renders congratulations when the backend reports completion', () => {
     renderPanel({
       task: {
         ...baseTask,
@@ -49,7 +57,7 @@ describe('Day5ReflectionPanel validation and read-only states', () => {
           submissionId: 99,
           submittedAt: '2026-03-08T15:20:00.000Z',
           contentText:
-            '## Challenges\nCanonical finalized markdown from backend',
+            '## Experience & Challenges\nCanonical finalized markdown from backend',
           contentJson: {
             kind: 'day5_reflection',
             sections: {
@@ -72,16 +80,15 @@ describe('Day5ReflectionPanel validation and read-only states', () => {
       },
     });
 
-    expect(screen.getByText(/day closed/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/congratulations - your 5-day trial is complete/i),
+    ).toBeInTheDocument();
     expect(screen.queryByRole('textbox')).toBeNull();
     expect(
-      screen.queryByRole('button', { name: /submit & continue/i }),
+      screen.queryByRole('button', { name: /submit reflection essay/i }),
     ).toBeNull();
     expect(
-      screen.getByText(/canonical finalized markdown from backend/i),
+      screen.getByText(/day 1: planning & design doc/i),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByText(/structured challenges should not be preferred/i),
-    ).toBeNull();
   });
 });

--- a/tests/unit/features/candidate/tasks/handoff/panelUtils.test.ts
+++ b/tests/unit/features/candidate/tasks/handoff/panelUtils.test.ts
@@ -1,0 +1,14 @@
+import { setMockVideoDuration } from './HandoffUploadPanel.testlib';
+import { validateVideoDuration } from '@/features/candidate/tasks/handoff/panelUtils';
+
+describe('panelUtils validateVideoDuration', () => {
+  it('rounds browser metadata to an integer before upload-init', async () => {
+    jest.useRealTimers();
+    setMockVideoDuration(14.303991);
+    const file = new File(['video'], 'day4-demo.mp4', {
+      type: 'video/mp4',
+    });
+
+    await expect(validateVideoDuration(file)).resolves.toBe(14);
+  });
+});

--- a/tests/unit/features/candidate/tasks/utils/day5Reflection.test.ts
+++ b/tests/unit/features/candidate/tasks/utils/day5Reflection.test.ts
@@ -1,8 +1,10 @@
 import {
   buildDay5ReflectionContentText,
+  buildDay5ReflectionPayloadFromMarkdown,
   buildDay5ReflectionPayload,
   DAY5_REFLECTION_MIN_SECTION_CHARS,
   extractDay5SectionsFromContentJson,
+  hasMeaningfulDay5ReflectionMarkdown,
   isDay5ReflectionTask,
   mapDay5BackendValidationErrors,
   validateDay5ReflectionSections,
@@ -40,11 +42,40 @@ describe('day5Reflection utils', () => {
     const markdown = buildDay5ReflectionContentText(
       buildDay5ReflectionPayload(buildSections()),
     );
-    expect(markdown).toMatch(/^## Challenges\n/);
-    expect(markdown).toContain('\n\n## Decisions\n');
-    expect(markdown).toContain('\n\n## Tradeoffs\n');
-    expect(markdown).toContain('\n\n## Communication / Handoff\n');
-    expect(markdown).toContain('\n\n## What I Would Do Next\n');
+    expect(markdown).toMatch(/^## Experience & Challenges\n/);
+    expect(markdown).toContain('\n\n## Decisions & Tradeoffs\n');
+    expect(markdown).toContain('\n\n## Learnings & Growth\n');
+    expect(markdown).toContain('\n\n## Collaboration & Communication\n');
+    expect(markdown).toContain('\n\n## What I Would Do Differently\n');
+    expect(markdown).not.toContain('Tool Usage');
+  });
+
+  it('treats scaffold-only markdown as meaningless', () => {
+    const scaffold = `## Experience & Challenges\n\n## Decisions & Tradeoffs\n\n## Learnings & Growth\n`;
+    expect(hasMeaningfulDay5ReflectionMarkdown(scaffold)).toBe(false);
+    expect(buildDay5ReflectionPayloadFromMarkdown(scaffold)).toEqual(
+      buildDay5ReflectionPayload({
+        challenges: '',
+        decisions: '',
+        tradeoffs: '',
+        communication: '',
+        next: '',
+      }),
+    );
+  });
+
+  it('accepts freeform markdown without headings only when it has body text', () => {
+    const freeform = `I focused on shipping the core flow, documented risks, and tightened the review loop.`;
+    expect(hasMeaningfulDay5ReflectionMarkdown(freeform)).toBe(true);
+    expect(buildDay5ReflectionPayloadFromMarkdown(freeform)).toEqual(
+      buildDay5ReflectionPayload({
+        challenges: freeform,
+        decisions: freeform,
+        tradeoffs: freeform,
+        communication: freeform,
+        next: freeform,
+      }),
+    );
   });
 
   it('extracts structured reflection sections from contentJson', () => {
@@ -81,7 +112,9 @@ describe('day5Reflection utils', () => {
       String(DAY5_REFLECTION_MIN_SECTION_CHARS),
     );
     expect(mapped.fieldErrors.decisions).toMatch(/required/i);
-    expect(mapped.formError).toMatch(/complete all reflection sections/i);
+    expect(mapped.formError).toBe(
+      'Please complete the reflection essay before submitting.',
+    );
   });
 
   it('detects day 5 reflection task without matching non-day5 docs', () => {

--- a/tests/unit/lib/api/candidate.submit.test.ts
+++ b/tests/unit/lib/api/candidate.submit.test.ts
@@ -74,7 +74,8 @@ describe('candidate api submit-task helpers', () => {
     await submitCandidateTask({
       taskId: 10,
       candidateSessionId: 10,
-      contentText: '## Challenges\n...\n## Decisions\n...',
+      contentText:
+        '## Experience & Challenges\n...\n## Decisions & Tradeoffs\n...',
       reflection: {
         challenges: 'a',
         decisions: 'b',
@@ -86,7 +87,7 @@ describe('candidate api submit-task helpers', () => {
     expect(mockPost).toHaveBeenCalledWith(
       '/tasks/10/submit',
       expect.objectContaining({
-        contentText: expect.stringContaining('## Challenges'),
+        contentText: expect.stringContaining('## Experience & Challenges'),
         reflection: expect.objectContaining({
           challenges: expect.any(String),
           decisions: expect.any(String),

--- a/tests/unit/lib/server/bffAuth.test.ts
+++ b/tests/unit/lib/server/bffAuth.test.ts
@@ -59,12 +59,19 @@ jest.mock('@/platform/auth0/claims', () => {
 });
 
 describe('bffAuth utilities', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
   beforeEach(() => {
     jest.clearAllMocks();
     delete process.env.WINOE_DEBUG_PERF;
+    process.env.NODE_ENV = 'development';
     auth0Mock = jest.requireMock('@/platform/auth0').auth0 as {
       getAccessToken: jest.Mock;
     };
+  });
+
+  afterAll(() => {
+    process.env.NODE_ENV = originalNodeEnv;
   });
 
   it('merges response cookies', () => {
@@ -80,6 +87,44 @@ describe('bffAuth utilities', () => {
     const res = await requireBffAuth(new NextRequest('http://x'));
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.response.status).toBe(401);
+  });
+
+  it('uses local-dev bearer headers when Auth0 session is unavailable', async () => {
+    getSessionNormalizedMock.mockResolvedValue(null);
+    const req = {
+      headers: new Headers({
+        authorization: 'Bearer candidate:alice@example.com',
+        'x-dev-user-email': 'alice@example.com',
+      }),
+    } as unknown as NextRequest;
+
+    const res = await requireBffAuth(req);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.accessToken).toBe('candidate:alice@example.com');
+      expect(res.session?.user?.email).toBe('alice@example.com');
+    }
+  });
+
+  it('prefers local-dev bearer headers over a stale Auth0 session', async () => {
+    getSessionNormalizedMock.mockResolvedValue({
+      user: { email: 'candidate1@local.test' },
+      accessToken: 'candidate:candidate1@local.test',
+    });
+    const req = {
+      headers: new Headers({
+        authorization: 'Bearer candidate:alice@example.com',
+        'x-dev-user-email': 'alice@example.com',
+      }),
+    } as unknown as NextRequest;
+
+    const res = await requireBffAuth(req);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.accessToken).toBe('candidate:alice@example.com');
+      expect(res.session?.user?.email).toBe('alice@example.com');
+    }
+    expect(getSessionNormalizedMock).not.toHaveBeenCalled();
   });
 
   it('returns 403 when permission missing', async () => {


### PR DESCRIPTION
# Complete Day 5 reflection essay UI with extended window and completion transition

## Summary

This PR completes the Day 5 Reflection Essay flow for issue #186.

- Day 5 is now a markdown-first Reflection Essay experience.
- Day 5 uses the extended 9:00 AM-9:00 PM candidate local window.
- Candidate-facing copy frames Day 5 as reflection, not documentation.
- The editor supports markdown writing and preview.
- Autosave persists the full markdown essay.
- Scaffold-only markdown cannot be submitted.
- Submit confirmation appears before final submission.
- Successful submission transitions to a congratulations screen.
- The congratulations screen summarizes the completed 5-day Trial.

## What Changed

- Added and refined the Day 5 reflection essay UI in `src/features/candidate/tasks/`.
- Updated prompt framing so the page is clearly about reflection, not a documentation task.
- Added guided prompts covering:
  - experience
  - challenges
  - decisions
  - tradeoffs
  - learnings
  - collaboration / communication
  - growth / self-awareness
  - tool usage / AI assistants
  - what they would do differently
- Kept the editor flow markdown-first with live preview and draft autosave.
- Blocked submission when the content is only scaffold headings or otherwise lacks meaningful body content.
- Added submit confirmation before the final submission action.
- Added the completion transition so a submitted Day 5 lands on the congratulations screen.
- Preserved completion state across refresh.

## Day 5 Behavior

Day 5 now behaves as a source-of-truth markdown reflection, not a checklist or documentation stub.

- `contentText` preserves the exact candidate markdown.
- `contentJson.reflectionMarkdown` mirrors the full markdown where used.
- Legacy `contentJson.reflection` is derived from meaningful markdown body content.
- Heading-only scaffold content does not get promoted into fake legacy reflection fields.

Completion behavior:

- Submitted/completed Day 5 renders the congratulations screen.
- Completion survives refresh.
- The completed summary shows:
  - Day 1: Planning & Design Doc
  - Day 2: Implementation Kickoff
  - Day 3: Implementation Wrap-Up
  - Day 4: Handoff + Demo
  - Day 5: Reflection Essay

## Local QA / Auth Notes

The contract-live local-dev auth fallback was kept intentionally for local QA only.

- Why it was needed: contract-live / local browser QA needs a deterministic way to bootstrap sessions when real Auth0 QA credentials are unavailable or when the lane is running in a local-dev fallback mode.
- Scope: this is intended for local/dev QA only.
- Production safety: `allowLocalTokenFallback()` in `src/platform/server/bffAuth.helpers.ts` only enables the fallback in `development` or `VERCEL_ENV=development`, so it does not weaken production auth.
- Request handling: `src/platform/server/bffAuth.ts` accepts the local bearer-token path and `x-dev-user-email` only through that gated fallback.
- Tests updated: `tests/unit/lib/server/bffAuth.test.ts` covers the fallback path and the production-safe failure cases.

Contract-live harness details kept for QA:

- Deterministic Day 5 command/path is driven through `qa_verifications/Contract-Live-QA/run_contract_live.sh` and the Day 5 driver sequence.
- Fresh local storage-state handling is preserved so browser sessions are regenerated for the active environment instead of reusing stale state.
- Candidate Day 5 setup uses the live harness candidate session path and the Day 5 alias flow.
- QA-only headers used by the harness include `x-dev-user-email`, `x-candidate-session-id`, and the bearer authorization header that the BFF fallback reads in local-dev mode.

## Verification

- `npm run lint` - pass
- `npm run typecheck` - pass
- `npx jest --runInBand` - pass
  - 502 test suites passed
  - 1565 tests passed
  - 3 snapshots passed
- `npm run build` - pass
  - Next.js production build completed successfully
  - Static pages generated successfully

## Real Browser QA Evidence

Local QA identity and session:

- Candidate email: `robiemelaku@gmail.com`
- Candidate session id: `3`
- Invite token: `mH8KXs3FKiT6u6JnL1gLyUkFxDAhNwdwB1ExH2wtdcg`

Local stack and harness:

- Backend/frontend local stack command: `bash qa_verifications/Contract-Live-QA/run_contract_live.sh`
- Stack boot path used by the harness:
  - `poetry run uvicorn app.main:app --host 127.0.0.1 --port 8000`
  - `poetry run python -m app.shared.jobs.shared_jobs_worker_service`
  - `npm run dev -- --hostname 127.0.0.1 --port 3000`
- Browser QA used the real local backend and frontend, with fresh storage-state handling and QA-only headers in the harness.

Evidence paths:

- `/tmp/winoe-qa-iter11-day5-browser/day5-initial.png`
- `/tmp/winoe-qa-iter11-day5-browser/day5-complete-refresh.png`
- `/tmp/winoe-qa-iter11-day5-browser/day5-complete-refresh-after.png`
- `/tmp/winoe-qa-iter11-day5-browser/day5-initial.txt`
- `/tmp/winoe-qa-iter11-day5-browser/day5-complete-refresh.txt`

Observed QA results:

- Direct backend and BFF candidate session routes returned `200`.
- Backend current task after completion returned `200`.
- `isComplete: true`
- `completedTaskIds: [16,17,18,19,20]`
- Day 5 rendered in the browser.
- Autosave persisted after refresh.
- Submit returned success.
- Frontend logs showed `POST /api/backend/tasks/20/submit 201`.
- Frontend logs showed `GET /api/backend/tasks/20/draft 200` after refresh.
- Congratulations persisted after refresh.

## Terminology Check

- Command run: `rg -n "Tenon|SimuHire|recruiter|simulation|Fit Profile|Fit Score|template|precommit|Specializor|offline work|local work" src/features/candidate tests`
- Result: no candidate-facing retired terminology was found.
- Any remaining hits are internal or test-only and are not user-facing.

## Risks / Reviewer Notes

- This PR does not claim to fix any separate Day 4 golden-path upload-init instability. If that remains separate, it is outside #186.
- #186 itself was verified through deterministic Day 5 setup against the real local backend and frontend.
- The local-dev auth fallback is deliberately limited to development / local QA paths and must stay that way.
- No new product changes were made after QA approval; this update is PR-material only.

## Linked Issue
Fixes #186 
