### PR TITLE
Fixed Talent Partner Day 4 playback with corrected handoff/demo terminology

### DIFF
--- a/pr.md
+++ b/pr.md
@@ -1,119 +1,74 @@
-# PR: Fix Trial-scoped Benchmarks comparison
+# PR: Fix Talent Partner Day 4 Handoff + Demo playback
 
 ## Summary
 
-Closes #189.
+* Replaced Talent Partner Day 4 playback/evidence copy with `Handoff + Demo`.
+* Preserved video playback through backend-provided handoff media/download URLs.
+* Added clear transcript states, including failed transcription handling.
+* Preserved searchable transcript behavior and timestamp seeking.
+* Ensured latest Day 4 handoff artifacts can be fetched/rendered for the submission review page.
+* Normalized backend transcript segment payloads that use `start` / `end` fields.
 
-This PR fixes the Talent Partner Trial detail Benchmarks panel so it only renders eligible candidates from the selected Trial and displays the required Benchmarks framing, cohort context, and Winoe Report links.
+## Issue
 
-## What changed
+Closes #190
 
-- Renamed the Trial detail comparison surface to `Benchmarks`.
-- Added cohort-size copy, for example `Comparing 2 candidates for this Trial`.
-- Added the limited-comparison note when the rendered cohort has fewer than 3 candidates.
-- Added decision-boundary copy clarifying that Winoe surfaces evidence and the Talent Partner makes the hiring decision.
-- Preserved Trial identifiers during compare normalization.
-- Added defensive same-Trial filtering when row-level Trial identifiers are present.
-- Restricted Benchmarks rows to terminal/report-ready candidates:
-  - `completed + ready`
-  - `evaluated + ready`
-- Excluded in-progress, non-ready, and unrelated-Trial rows.
-- Simplified the Benchmarks table to the required fields:
-  - candidate name
-  - Winoe Score
-  - dimensional summary
-  - evidence/recommendation summary
-  - Winoe Report link
-- Kept the Benchmarks surface read-only; Winoe Report generation remains on the dedicated Winoe Report page.
-- Avoided retired terminology and deterministic hiring language.
+## Acceptance Criteria
 
-## Why
+* [x] All Day 4 labels: Handoff + Demo, not presentation
+* [x] Video playback works with correct media URLs
+* [x] Transcript viewer with searchable text
+* [x] Failed transcription state clearly shown
 
-Benchmarks are only trustworthy if they compare candidates from the same Trial, under the same Winoe instance and same evaluation lens. The previous comparison surface could show unrelated candidates, which broke the trust model for Talent Partners.
+## Files Changed
 
-This PR makes the UI match the product promise: same-Trial Benchmarks with evidence-backed, non-deterministic framing.
+* `src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4Handoff.tsx` - Updated the Day 4 playback heading, passed transcript status through to the transcript panel, and kept playback wired to the handoff artifact.
+* `src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4TranscriptPanel.tsx` - Added transcript failed/processing states and the searchable transcript fallback copy for Handoff + Demo.
+* `src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4VideoPanel.tsx` - Updated unavailable/deleted playback messaging to use Handoff + Demo terminology.
+* `src/features/talent-partner/submission-review/components/ArtifactCard/artifactDay4Status.ts` - Added transcript processing and failed-status helpers plus normalization support.
+* `src/features/talent-partner/submission-review/components/LatestDay4Handoff.tsx` - Updated the latest Day 4 evidence panel copy to Handoff + Demo and preserved artifact rendering.
+* `src/features/talent-partner/submission-review/hooks/useCandidateLoader.ts` - Included the latest Day 4 handoff submission when preloading submission IDs.
+* `src/features/talent-partner/submission-review/hooks/useDeferredLatestDay4Artifact.ts` - Deferred loading only when the cached Day 4 artifact is incomplete.
+* `src/features/talent-partner/submission-review/utils/candidateSubmissionsApi.transcriptUtils.ts` - Normalized backend transcript segments that use `start` / `end` fields.
+* `tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.day4Handoff.test.tsx` - Updated the integration assertion to the new Handoff + Demo playback label.
+* `tests/unit/features/talent-partner/submission-review/ArtifactDay4Handoff.test.tsx` - Covered playback URL wiring, searchable transcript behavior, timestamp seeking, unavailable playback, and failed transcription states.
+* `tests/unit/features/talent-partner/submission-review/LatestDay4Handoff.test.tsx` - Added coverage for the latest Day 4 Handoff + Demo evidence copy and fallback states.
+* `tests/unit/features/talent-partner/submission-review/day4Transcript.test.ts` - Added transcript normalization coverage for backend `start` / `end` segment payloads.
 
-## Acceptance criteria
+## QA
 
-- [x] Benchmarks table only shows candidates invited to / associated with the selected Trial.
-- [x] Each row shows candidate name, Winoe Score, dimensional summary, evidence/recommendation summary, and Winoe Report link.
-- [x] No-data state appears when no eligible completed/report-ready candidates exist.
-- [x] Primary label is `Benchmarks`, not just `Compare`.
-- [x] Copy avoids implying Winoe makes the hiring decision.
-- [x] Header displays cohort size.
-- [x] Limited-comparison note appears when rendered cohort size is less than 3.
-- [x] Verified with at least 2 same-Trial candidates rendering as distinct rows with distinct Winoe Scores.
-- [x] `in_progress + ready` rows are excluded.
-- [x] `evaluated + ready` rows from the live backend payload are included.
-- [x] No retired terminology introduced.
+Commands and verified results:
 
-## Testing
+* `npm run lint` - PASS
+* `npm run typecheck` - PASS
+* `npm test -- --runInBand tests/unit/features/talent-partner/submission-review/ArtifactDay4Handoff.test.tsx tests/unit/features/talent-partner/submission-review/LatestDay4Handoff.test.tsx tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.day4Handoff.test.tsx tests/unit/features/talent-partner/submission-review/day4Transcript.test.ts` - PASS
+* `npx playwright test tests/e2e/flow-qa/tmp-day4-talent-partner-browser-qa.spec.ts -c tests/e2e/flow-qa/playwright.config.ts --project=chromium --workers=1` - PASS
+* `./precommit.sh` - PASS
 
-Automated checks run:
+Final precommit block:
 
-```bash
-npx jest tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.component.interactions.test.tsx --runInBand
-npx jest tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.component.interactions.test.tsx --runInBand --detectOpenHandles
-npx jest tests/unit/features/talent-partner/trial-management/detail/candidatesCompareNormalize.test.ts tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.rows.test.tsx tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.states.test.tsx tests/integration/talent-partner/TrialDetailPageClient.compareStates.test.tsx tests/integration/talent-partner/TrialDetailPageClient.compareRetry.test.tsx --runInBand
-npm run typecheck
-npm run lint:eslint
-npm run lint:prettier
-./precommit.sh
-```
+* Test Suites: 503 passed, 503 total
+* Tests: 1570 passed, 1570 total
+* Snapshots: 3 passed, 3 total
+* Typecheck passed
+* Production build passed
+* precommit checks passed
 
-All passed.
+## Browser QA Evidence
 
-Full precommit result:
+* Route tested: `/dashboard/trials/:trialId/candidates/:candidateSessionId`
+* `Day 4 Handoff + Demo evidence` visible
+* `Day 4 Handoff + Demo playback` visible
+* No visible Day 4 playback/evidence copy used `presentation`
+* Video `src` and download `href` matched backend-provided media/download URL
+* Transcript search updated match count and highlighted matching text
+* Timestamp click exercised seek behavior
+* Failed transcript state showed:
+  * `Transcript unavailable`
+  * `Transcript generation failed. The Handoff + Demo video is still available above when media access is permitted.`
 
-- Test Suites: 502 passed, 502 total
-- Tests: 1566 passed, 1566 total
-- Snapshots: 3 passed, 3 total
-- Typecheck: pass
-- Build: pass
-- Precommit: pass
+## Notes / Follow-ups
 
-## Manual QA
-
-Manual QA was performed against the local frontend and backend.
-
-Environment:
-
-- Backend: local backend via `./runBackend.sh up`
-- Frontend: local frontend via `npm run dev`
-- Talent Partner account used for login
-- Trial tested: seeded Trial 1 because Trial 2 was unavailable in the local DB after reseeding
-
-Evidence saved under:
-
-```txt
-.ai_flow/qa/issue-189/
-```
-
-Artifacts:
-
-- `01-dashboard.png`
-- `02-trial-detail.png`
-- `03-benchmarks-panel.png`
-- `04-winoe-report.png`
-- `summary.json`
-
-Observed QA result:
-
-- Compare endpoint observed: `/api/trials/1/candidates/compare`
-- Rendered rows:
-  - `Avery Chen — 91%`
-  - `Jordan Patel — 74%`
-- Header rendered: `Comparing 2 candidates for this Trial`
-- Limited-comparison note rendered: `Limited comparison — results are more meaningful with additional candidates.`
-- Decision-boundary copy rendered: `Winoe surfaces evidence from each Trial. The Talent Partner makes the hiring decision.`
-- Winoe Report link navigation checked.
-- Empty state did not render when eligible rows existed.
-- No retired terminology observed.
-- No deterministic hiring language observed.
-
-## Notes / risks
-
-- Frontend same-Trial filtering is defensive when row-level Trial IDs are present.
-- If the backend omits row-level Trial IDs, the UI relies on the Trial-scoped endpoint contract: `/api/trials/:trialId/candidates/compare`.
-- The live backend uses `evaluated` as a terminal compare status, so the frontend treats both `completed` and `evaluated` as eligible terminal states.
-- The final diff is scoped to #189; unrelated Jest/global timeout changes were removed.
+* Backend issues `winoe-ai-backend#290` and `winoe-ai-backend#294` remain the broader end-to-end reliability dependencies for Day 4 upload/transcription/media retention.
+* Candidate-side `candidate-day4.spec.ts` stale locator expecting `Upload video` while UI shows `Upload demo video` is unrelated to #190 and should be handled separately if still relevant.
+* No scoped user-facing Day 4 playback/evidence copy uses `presentation`; any remaining `presentation` match is a negative assertion in tests.

--- a/pr.md
+++ b/pr.md
@@ -2,12 +2,12 @@
 
 ## Summary
 
-* Replaced Talent Partner Day 4 playback/evidence copy with `Handoff + Demo`.
-* Preserved video playback through backend-provided handoff media/download URLs.
-* Added clear transcript states, including failed transcription handling.
-* Preserved searchable transcript behavior and timestamp seeking.
-* Ensured latest Day 4 handoff artifacts can be fetched/rendered for the submission review page.
-* Normalized backend transcript segment payloads that use `start` / `end` fields.
+- Replaced Talent Partner Day 4 playback/evidence copy with `Handoff + Demo`.
+- Preserved video playback through backend-provided handoff media/download URLs.
+- Added clear transcript states, including failed transcription handling.
+- Preserved searchable transcript behavior and timestamp seeking.
+- Ensured latest Day 4 handoff artifacts can be fetched/rendered for the submission review page.
+- Normalized backend transcript segment payloads that use `start` / `end` fields.
 
 ## Issue
 
@@ -15,60 +15,60 @@ Closes #190
 
 ## Acceptance Criteria
 
-* [x] All Day 4 labels: Handoff + Demo, not presentation
-* [x] Video playback works with correct media URLs
-* [x] Transcript viewer with searchable text
-* [x] Failed transcription state clearly shown
+- [x] All Day 4 labels: Handoff + Demo, not presentation
+- [x] Video playback works with correct media URLs
+- [x] Transcript viewer with searchable text
+- [x] Failed transcription state clearly shown
 
 ## Files Changed
 
-* `src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4Handoff.tsx` - Updated the Day 4 playback heading, passed transcript status through to the transcript panel, and kept playback wired to the handoff artifact.
-* `src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4TranscriptPanel.tsx` - Added transcript failed/processing states and the searchable transcript fallback copy for Handoff + Demo.
-* `src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4VideoPanel.tsx` - Updated unavailable/deleted playback messaging to use Handoff + Demo terminology.
-* `src/features/talent-partner/submission-review/components/ArtifactCard/artifactDay4Status.ts` - Added transcript processing and failed-status helpers plus normalization support.
-* `src/features/talent-partner/submission-review/components/LatestDay4Handoff.tsx` - Updated the latest Day 4 evidence panel copy to Handoff + Demo and preserved artifact rendering.
-* `src/features/talent-partner/submission-review/hooks/useCandidateLoader.ts` - Included the latest Day 4 handoff submission when preloading submission IDs.
-* `src/features/talent-partner/submission-review/hooks/useDeferredLatestDay4Artifact.ts` - Deferred loading only when the cached Day 4 artifact is incomplete.
-* `src/features/talent-partner/submission-review/utils/candidateSubmissionsApi.transcriptUtils.ts` - Normalized backend transcript segments that use `start` / `end` fields.
-* `tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.day4Handoff.test.tsx` - Updated the integration assertion to the new Handoff + Demo playback label.
-* `tests/unit/features/talent-partner/submission-review/ArtifactDay4Handoff.test.tsx` - Covered playback URL wiring, searchable transcript behavior, timestamp seeking, unavailable playback, and failed transcription states.
-* `tests/unit/features/talent-partner/submission-review/LatestDay4Handoff.test.tsx` - Added coverage for the latest Day 4 Handoff + Demo evidence copy and fallback states.
-* `tests/unit/features/talent-partner/submission-review/day4Transcript.test.ts` - Added transcript normalization coverage for backend `start` / `end` segment payloads.
+- `src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4Handoff.tsx` - Updated the Day 4 playback heading, passed transcript status through to the transcript panel, and kept playback wired to the handoff artifact.
+- `src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4TranscriptPanel.tsx` - Added transcript failed/processing states and the searchable transcript fallback copy for Handoff + Demo.
+- `src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4VideoPanel.tsx` - Updated unavailable/deleted playback messaging to use Handoff + Demo terminology.
+- `src/features/talent-partner/submission-review/components/ArtifactCard/artifactDay4Status.ts` - Added transcript processing and failed-status helpers plus normalization support.
+- `src/features/talent-partner/submission-review/components/LatestDay4Handoff.tsx` - Updated the latest Day 4 evidence panel copy to Handoff + Demo and preserved artifact rendering.
+- `src/features/talent-partner/submission-review/hooks/useCandidateLoader.ts` - Included the latest Day 4 handoff submission when preloading submission IDs.
+- `src/features/talent-partner/submission-review/hooks/useDeferredLatestDay4Artifact.ts` - Deferred loading only when the cached Day 4 artifact is incomplete.
+- `src/features/talent-partner/submission-review/utils/candidateSubmissionsApi.transcriptUtils.ts` - Normalized backend transcript segments that use `start` / `end` fields.
+- `tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.day4Handoff.test.tsx` - Updated the integration assertion to the new Handoff + Demo playback label.
+- `tests/unit/features/talent-partner/submission-review/ArtifactDay4Handoff.test.tsx` - Covered playback URL wiring, searchable transcript behavior, timestamp seeking, unavailable playback, and failed transcription states.
+- `tests/unit/features/talent-partner/submission-review/LatestDay4Handoff.test.tsx` - Added coverage for the latest Day 4 Handoff + Demo evidence copy and fallback states.
+- `tests/unit/features/talent-partner/submission-review/day4Transcript.test.ts` - Added transcript normalization coverage for backend `start` / `end` segment payloads.
 
 ## QA
 
 Commands and verified results:
 
-* `npm run lint` - PASS
-* `npm run typecheck` - PASS
-* `npm test -- --runInBand tests/unit/features/talent-partner/submission-review/ArtifactDay4Handoff.test.tsx tests/unit/features/talent-partner/submission-review/LatestDay4Handoff.test.tsx tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.day4Handoff.test.tsx tests/unit/features/talent-partner/submission-review/day4Transcript.test.ts` - PASS
-* `npx playwright test tests/e2e/flow-qa/tmp-day4-talent-partner-browser-qa.spec.ts -c tests/e2e/flow-qa/playwright.config.ts --project=chromium --workers=1` - PASS
-* `./precommit.sh` - PASS
+- `npm run lint` - PASS
+- `npm run typecheck` - PASS
+- `npm test -- --runInBand tests/unit/features/talent-partner/submission-review/ArtifactDay4Handoff.test.tsx tests/unit/features/talent-partner/submission-review/LatestDay4Handoff.test.tsx tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.day4Handoff.test.tsx tests/unit/features/talent-partner/submission-review/day4Transcript.test.ts` - PASS
+- `npx playwright test tests/e2e/flow-qa/tmp-day4-talent-partner-browser-qa.spec.ts -c tests/e2e/flow-qa/playwright.config.ts --project=chromium --workers=1` - PASS
+- `./precommit.sh` - PASS
 
 Final precommit block:
 
-* Test Suites: 503 passed, 503 total
-* Tests: 1570 passed, 1570 total
-* Snapshots: 3 passed, 3 total
-* Typecheck passed
-* Production build passed
-* precommit checks passed
+- Test Suites: 503 passed, 503 total
+- Tests: 1570 passed, 1570 total
+- Snapshots: 3 passed, 3 total
+- Typecheck passed
+- Production build passed
+- precommit checks passed
 
 ## Browser QA Evidence
 
-* Route tested: `/dashboard/trials/:trialId/candidates/:candidateSessionId`
-* `Day 4 Handoff + Demo evidence` visible
-* `Day 4 Handoff + Demo playback` visible
-* No visible Day 4 playback/evidence copy used `presentation`
-* Video `src` and download `href` matched backend-provided media/download URL
-* Transcript search updated match count and highlighted matching text
-* Timestamp click exercised seek behavior
-* Failed transcript state showed:
-  * `Transcript unavailable`
-  * `Transcript generation failed. The Handoff + Demo video is still available above when media access is permitted.`
+- Route tested: `/dashboard/trials/:trialId/candidates/:candidateSessionId`
+- `Day 4 Handoff + Demo evidence` visible
+- `Day 4 Handoff + Demo playback` visible
+- No visible Day 4 playback/evidence copy used `presentation`
+- Video `src` and download `href` matched backend-provided media/download URL
+- Transcript search updated match count and highlighted matching text
+- Timestamp click exercised seek behavior
+- Failed transcript state showed:
+  - `Transcript unavailable`
+  - `Transcript generation failed. The Handoff + Demo video is still available above when media access is permitted.`
 
 ## Notes / Follow-ups
 
-* Backend issues `winoe-ai-backend#290` and `winoe-ai-backend#294` remain the broader end-to-end reliability dependencies for Day 4 upload/transcription/media retention.
-* Candidate-side `candidate-day4.spec.ts` stale locator expecting `Upload video` while UI shows `Upload demo video` is unrelated to #190 and should be handled separately if still relevant.
-* No scoped user-facing Day 4 playback/evidence copy uses `presentation`; any remaining `presentation` match is a negative assertion in tests.
+- Backend issues `winoe-ai-backend#290` and `winoe-ai-backend#294` remain the broader end-to-end reliability dependencies for Day 4 upload/transcription/media retention.
+- Candidate-side `candidate-day4.spec.ts` stale locator expecting `Upload video` while UI shows `Upload demo video` is unrelated to #190 and should be handled separately if still relevant.
+- No scoped user-facing Day 4 playback/evidence copy uses `presentation`; any remaining `presentation` match is a negative assertion in tests.

--- a/src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4Handoff.tsx
+++ b/src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4Handoff.tsx
@@ -21,7 +21,7 @@ export function ArtifactDay4Handoff({ artifact }: Props) {
   const [failedVideoUrl, setFailedVideoUrl] = useState<string | null>(null);
   const downloadUrl = handoff?.downloadUrl ?? null;
   const transcript = handoff?.transcript ?? null;
-  const transcriptStatus = transcript?.status ?? 'processing';
+  const transcriptStatus = transcript?.status ?? null;
   const transcriptSegments = transcript?.segments ?? EMPTY_TRANSCRIPT_SEGMENTS;
   const transcriptIsReady =
     isTranscriptReady(transcriptStatus) && transcriptSegments.length > 0;
@@ -47,7 +47,7 @@ export function ArtifactDay4Handoff({ artifact }: Props) {
   return (
     <div className="mt-3 rounded border border-slate-200 bg-slate-50 p-3">
       <div className="text-sm font-semibold text-gray-900">
-        Day 4 presentation playback
+        Day 4 Handoff + Demo playback
       </div>
       <div className="mt-2">
         <ArtifactDay4VideoPanel
@@ -63,6 +63,7 @@ export function ArtifactDay4Handoff({ artifact }: Props) {
         <div className="text-sm font-semibold text-gray-900">Transcript</div>
         <ArtifactDay4TranscriptPanel
           submissionId={artifact.submissionId}
+          transcriptStatus={transcriptStatus}
           transcriptIsReady={transcriptIsReady}
           transcriptSegments={transcriptSegments}
           onSeek={onSeek}

--- a/src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4TranscriptPanel.tsx
+++ b/src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4TranscriptPanel.tsx
@@ -4,14 +4,21 @@ import {
   buildTranscriptSearchResults,
   formatTranscriptTimestamp,
 } from './day4Transcript';
+import {
+  isTranscriptFailed,
+  isTranscriptProcessing,
+  normalizeHandoffStatus,
+} from './artifactDay4Status';
 type ArtifactDay4TranscriptPanelProps = {
   submissionId: number;
+  transcriptStatus: string | null;
   transcriptIsReady: boolean;
   transcriptSegments: HandoffTranscriptSegment[];
   onSeek: (startMs: number) => void;
 };
 export function ArtifactDay4TranscriptPanel({
   submissionId,
+  transcriptStatus,
   transcriptIsReady,
   transcriptSegments,
   onSeek,
@@ -31,10 +38,28 @@ export function ArtifactDay4TranscriptPanel({
     if (!firstMatchKey) return;
     segmentRefs.current[firstMatchKey]?.scrollIntoView({ block: 'center' });
   }, [firstMatchKey]);
+  const normalizedStatus = normalizeHandoffStatus(transcriptStatus);
+  const transcriptFailed = isTranscriptFailed(normalizedStatus);
+  const transcriptProcessing = isTranscriptProcessing(normalizedStatus);
+
+  if (transcriptFailed) {
+    return (
+      <div className="mt-2 rounded border border-rose-200 bg-rose-50 p-3 text-sm text-rose-900">
+        <div className="font-semibold">Transcript unavailable</div>
+        <p className="mt-1">
+          Transcript generation failed. The Handoff + Demo video is still
+          available above when media access is permitted.
+        </p>
+      </div>
+    );
+  }
+
   if (!transcriptIsReady) {
     return (
       <div className="mt-2 text-sm text-gray-700">
-        Processing transcript. Refresh shortly for searchable segments.
+        {transcriptProcessing
+          ? 'Processing Handoff + Demo transcript. Refresh shortly for searchable segments.'
+          : 'Handoff + Demo transcript is not available yet.'}
       </div>
     );
   }

--- a/src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4VideoPanel.tsx
+++ b/src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4VideoPanel.tsx
@@ -40,8 +40,8 @@ export function ArtifactDay4VideoPanel({
   return (
     <div className="rounded border border-dashed border-gray-200 bg-white p-3 text-sm text-gray-700">
       {deleted
-        ? 'Video deleted or unavailable.'
-        : 'Video unavailable right now.'}
+        ? 'Handoff + Demo video deleted or unavailable.'
+        : 'Handoff + Demo video unavailable right now.'}
     </div>
   );
 }

--- a/src/features/talent-partner/submission-review/components/ArtifactCard/artifactDay4Status.ts
+++ b/src/features/talent-partner/submission-review/components/ArtifactCard/artifactDay4Status.ts
@@ -17,3 +17,30 @@ export function isTranscriptReady(status: string | null | undefined): boolean {
     normalized === 'success'
   );
 }
+
+export function isTranscriptProcessing(
+  status: string | null | undefined,
+): boolean {
+  const normalized = normalizeHandoffStatus(status);
+  return (
+    normalized === 'processing' ||
+    normalized === 'queued' ||
+    normalized === 'pending' ||
+    normalized === 'running' ||
+    normalized === 'in_progress' ||
+    normalized === 'transcribing'
+  );
+}
+
+export function isTranscriptFailed(status: string | null | undefined): boolean {
+  const normalized = normalizeHandoffStatus(status);
+  return (
+    normalized === 'failed' ||
+    normalized === 'error' ||
+    normalized === 'errored' ||
+    normalized === 'rejected' ||
+    normalized === 'canceled' ||
+    normalized === 'cancelled' ||
+    normalized === 'aborted'
+  );
+}

--- a/src/features/talent-partner/submission-review/components/LatestDay4Handoff.tsx
+++ b/src/features/talent-partner/submission-review/components/LatestDay4Handoff.tsx
@@ -16,25 +16,25 @@ export function LatestDay4Handoff({
   return (
     <div className="rounded border border-gray-200 bg-white p-4">
       <div className="text-sm font-semibold text-gray-900">
-        Day 4 presentation evidence
+        Day 4 Handoff + Demo evidence
       </div>
       <div className="text-xs text-gray-600">
-        Playback and transcript review for the latest Day 4 demo presentation.
+        Playback and transcript review for the latest Day 4 Handoff + Demo.
       </div>
       <div className="mt-3">
         {artifact ? (
           <LazyArtifactCard artifact={artifact} />
         ) : loading ? (
           <div className="rounded border border-dashed border-gray-200 bg-gray-50 p-3 text-sm text-gray-700">
-            Loading Day 4 presentation details...
+            Loading Day 4 Handoff + Demo details...
           </div>
         ) : hasHandoffSubmission ? (
           <div className="rounded border border-dashed border-gray-200 bg-gray-50 p-3 text-sm text-gray-700">
-            Day 4 presentation found, but artifact details are unavailable.
+            Day 4 Handoff + Demo found, but artifact details are unavailable.
           </div>
         ) : (
           <div className="rounded border border-dashed border-gray-200 bg-gray-50 p-3 text-sm text-gray-700">
-            Day 4 presentation not available yet.
+            Day 4 Handoff + Demo not available yet.
           </div>
         )}
       </div>

--- a/src/features/talent-partner/submission-review/hooks/useCandidateLoader.ts
+++ b/src/features/talent-partner/submission-review/hooks/useCandidateLoader.ts
@@ -2,7 +2,8 @@ import {
   fetchCandidateSubmissions,
   verifyCandidate,
 } from '../utils/candidateSubmissionsApiUtils';
-import { pickLatestByDay } from '../utils/pickLatestUtils';
+import { isHandoffSubmissionItem } from '../utils/handoffUtils';
+import { pickLatestByDay, pickLatestWhere } from '../utils/pickLatestUtils';
 import type { SubmissionListItem } from '../types';
 import type { CandidateSession } from '@/features/talent-partner/types';
 
@@ -55,9 +56,11 @@ export async function loadCandidateAndSubmissions({
     );
     const latest2 = pickLatestByDay(ordered, 2);
     const latest3 = pickLatestByDay(ordered, 3);
+    const latestDay4 = pickLatestWhere(ordered, isHandoffSubmissionItem);
     const ids = [
       ...(latest2 ? [latest2.submissionId] : []),
       ...(latest3 ? [latest3.submissionId] : []),
+      ...(latestDay4 ? [latestDay4.submissionId] : []),
     ];
     if (includePageItems && pageSize) {
       ids.push(...ordered.slice(0, pageSize).map((it) => it.submissionId));

--- a/src/features/talent-partner/submission-review/hooks/useDeferredLatestDay4Artifact.ts
+++ b/src/features/talent-partner/submission-review/hooks/useDeferredLatestDay4Artifact.ts
@@ -4,6 +4,16 @@ import { queryKeys } from '@/shared/query';
 import type { SubmissionArtifact } from '../types';
 import { fetchArtifactsWithLimit } from '../utils/candidateSubmissionsApiUtils';
 
+function hasCompleteDay4Artifact(artifact: SubmissionArtifact | undefined) {
+  const handoff = artifact?.handoff ?? null;
+  const transcript = handoff?.transcript ?? null;
+  return Boolean(
+    handoff?.downloadUrl &&
+    transcript?.status &&
+    (transcript.text !== undefined || transcript.segments !== undefined),
+  );
+}
+
 type UseDeferredLatestDay4ArtifactArgs = {
   trialId: string;
   candidateSessionId: string;
@@ -31,7 +41,7 @@ export function useDeferredLatestDay4Artifact({
 
   useEffect(() => {
     if (loading || showAll || latestDay4SubmissionId == null) return;
-    if (artifacts[latestDay4SubmissionId]) return;
+    if (hasCompleteDay4Artifact(artifacts[latestDay4SubmissionId])) return;
 
     const timer = window.setTimeout(() => {
       setLatestDay4Loading(true);

--- a/src/features/talent-partner/submission-review/utils/candidateSubmissionsApi.transcriptUtils.ts
+++ b/src/features/talent-partner/submission-review/utils/candidateSubmissionsApi.transcriptUtils.ts
@@ -10,8 +10,10 @@ function normalizeTranscriptSegment(
 ): HandoffTranscriptSegment | null {
   const record = asRecord(value);
   if (!record) return null;
-  const startMs = toNullableNumber(record.startMs ?? record.start_ms);
-  const endMs = toNullableNumber(record.endMs ?? record.end_ms);
+  const startMs = toNullableNumber(
+    record.startMs ?? record.start_ms ?? record.start,
+  );
+  const endMs = toNullableNumber(record.endMs ?? record.end_ms ?? record.end);
   const text = toNullableString(record.text);
   if (startMs === null || endMs === null || text === null) return null;
   const roundedStartMs = Math.max(0, Math.round(startMs));

--- a/tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.day4Handoff.test.tsx
+++ b/tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.day4Handoff.test.tsx
@@ -85,7 +85,7 @@ describe('CandidateSubmissionsPage - day 4 handoff evidence', () => {
     render(<CandidateSubmissionsPage />);
     expect(await screen.findByText(/Newest Handoff/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/Day 4 presentation playback/i),
+      screen.getByText(/Day 4 Handoff \+ Demo playback/i),
     ).toBeInTheDocument();
     const calledUrls = fetchMock.mock.calls.map((call) =>
       getRequestUrl(call[0]),

--- a/tests/unit/features/talent-partner/submission-review/ArtifactDay4Handoff.test.tsx
+++ b/tests/unit/features/talent-partner/submission-review/ArtifactDay4Handoff.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ArtifactCard } from '@/features/talent-partner/submission-review/CandidateSubmissionsPage';
+import { ArtifactDay4Handoff } from '@/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4Handoff';
 import {
   buildDay4Artifact,
   buildNonHandoffDay4Artifact,
@@ -14,38 +15,29 @@ describe('ArtifactDay4Handoff', () => {
     });
   });
 
-  it('renders processing state and missing video fallback', () => {
-    render(
-      <ArtifactCard
-        artifact={buildDay4Artifact({
-          handoff: {
-            recordingId: 'rec_999',
-            downloadUrl: null,
-            transcript: { status: 'processing', text: null, segments: [] },
-          },
-        })}
-      />,
+  it('renders Day 4 Handoff + Demo playback with the backend media URL', () => {
+    const { container } = render(
+      <ArtifactDay4Handoff artifact={buildDay4Artifact()} />,
     );
+    const video = container.querySelector('video');
 
     expect(
-      screen.getByText(/Day 4 presentation playback/i),
+      screen.getByText(/Day 4 Handoff \+ Demo playback/i),
     ).toBeInTheDocument();
+    expect(video).toHaveAttribute('src', 'https://cdn.example.com/rec_123.mp4');
     expect(
-      screen.getByText(/Video unavailable right now/i),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/Processing transcript/i)).toBeInTheDocument();
+      screen.getByRole('link', { name: /Download video/i }),
+    ).toHaveAttribute('href', 'https://cdn.example.com/rec_123.mp4');
+    expect(container.querySelector('video')).toBeInTheDocument();
   });
 
   it('renders transcript search, highlights matches, and exposes match count', async () => {
     const user = userEvent.setup();
     const { container } = render(
-      <ArtifactCard artifact={buildDay4Artifact()} />,
+      <ArtifactDay4Handoff artifact={buildDay4Artifact()} />,
     );
 
-    expect(
-      screen.getByRole('link', { name: /Download video/i }),
-    ).toBeInTheDocument();
-    await user.type(screen.getByPlaceholderText(/Search transcript/i), 'WORLD');
+    await user.type(screen.getByLabelText(/Search transcript/i), 'WORLD');
 
     expect(await screen.findByText('2 matches')).toBeInTheDocument();
     expect(container.querySelectorAll('mark').length).toBeGreaterThan(0);
@@ -58,7 +50,7 @@ describe('ArtifactDay4Handoff', () => {
   it('seeks video timestamp clicks and remains safe when player is unavailable', async () => {
     const user = userEvent.setup();
     const { container, rerender } = render(
-      <ArtifactCard artifact={buildDay4Artifact()} />,
+      <ArtifactDay4Handoff artifact={buildDay4Artifact()} />,
     );
 
     const video = container.querySelector('video') as HTMLVideoElement;
@@ -73,7 +65,7 @@ describe('ArtifactDay4Handoff', () => {
     expect(video.currentTime).toBe(5);
 
     rerender(
-      <ArtifactCard
+      <ArtifactDay4Handoff
         artifact={buildDay4Artifact({
           handoff: {
             recordingId: 'rec_123',
@@ -97,20 +89,63 @@ describe('ArtifactDay4Handoff', () => {
 
   it('shows unavailable fallback when playback fails to load', () => {
     const { container } = render(
-      <ArtifactCard artifact={buildDay4Artifact()} />,
+      <ArtifactDay4Handoff artifact={buildDay4Artifact()} />,
     );
     const video = container.querySelector('video');
     expect(video).toBeTruthy();
     fireEvent.error(video as HTMLVideoElement);
     expect(
-      screen.getByText(/Video unavailable right now/i),
+      screen.getByText(/Handoff \+ Demo video unavailable right now/i),
     ).toBeInTheDocument();
+  });
+
+  it('renders a failed transcription state for failed and error-like statuses', () => {
+    const { rerender } = render(
+      <ArtifactDay4Handoff
+        artifact={buildDay4Artifact({
+          handoff: {
+            recordingId: 'rec_123',
+            downloadUrl: 'https://cdn.example.com/rec_123.mp4',
+            transcript: {
+              status: 'failed',
+              text: null,
+              segments: [],
+            },
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText(/Transcript unavailable/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /The Handoff \+ Demo video is still available above when media access is permitted\./i,
+      ),
+    ).toBeInTheDocument();
+
+    rerender(
+      <ArtifactDay4Handoff
+        artifact={buildDay4Artifact({
+          handoff: {
+            recordingId: 'rec_123',
+            downloadUrl: 'https://cdn.example.com/rec_123.mp4',
+            transcript: {
+              status: 'errored',
+              text: null,
+              segments: [],
+            },
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText(/Transcript unavailable/i)).toBeInTheDocument();
   });
 
   it('does not render handoff playback UI for non-handoff Day 4 artifacts', () => {
     render(<ArtifactCard artifact={buildNonHandoffDay4Artifact()} />);
     expect(
-      screen.queryByText(/Day 4 presentation playback/i),
+      screen.queryByText(/Day 4 Handoff \+ Demo playback/i),
     ).not.toBeInTheDocument();
     expect(screen.getByText(/No text answer submitted/i)).toBeInTheDocument();
   });

--- a/tests/unit/features/talent-partner/submission-review/LatestDay4Handoff.test.tsx
+++ b/tests/unit/features/talent-partner/submission-review/LatestDay4Handoff.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { LatestDay4Handoff } from '@/features/talent-partner/submission-review/components/LatestDay4Handoff';
+
+describe('LatestDay4Handoff', () => {
+  it('renders Day 4 Handoff + Demo evidence copy', () => {
+    render(
+      <LatestDay4Handoff
+        artifact={null}
+        hasHandoffSubmission={false}
+        loading={false}
+      />,
+    );
+
+    expect(
+      screen.getByText(/Day 4 Handoff \+ Demo evidence/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Playback and transcript review for the latest Day 4 Handoff \+ Demo\./i,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/presentation/i)).toBeNull();
+  });
+
+  it('uses Handoff + Demo wording for loading and fallback states', () => {
+    const { rerender } = render(
+      <LatestDay4Handoff
+        artifact={null}
+        hasHandoffSubmission={false}
+        loading
+      />,
+    );
+
+    expect(
+      screen.getByText(/Loading Day 4 Handoff \+ Demo details/i),
+    ).toBeInTheDocument();
+
+    rerender(
+      <LatestDay4Handoff
+        artifact={null}
+        hasHandoffSubmission={true}
+        loading={false}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        /Day 4 Handoff \+ Demo found, but artifact details are unavailable\./i,
+      ),
+    ).toBeInTheDocument();
+
+    rerender(
+      <LatestDay4Handoff
+        artifact={null}
+        hasHandoffSubmission={false}
+        loading={false}
+      />,
+    );
+
+    expect(
+      screen.getByText(/Day 4 Handoff \+ Demo not available yet\./i),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/unit/features/talent-partner/submission-review/day4Transcript.test.ts
+++ b/tests/unit/features/talent-partner/submission-review/day4Transcript.test.ts
@@ -3,6 +3,7 @@ import {
   formatTranscriptTimestamp,
   highlightTranscriptText,
 } from '@/features/talent-partner/submission-review/components/ArtifactCard/day4Transcript';
+import { normalizeTranscript } from '@/features/talent-partner/submission-review/utils/candidateSubmissionsApi.transcriptUtils';
 
 describe('day4Transcript helpers', () => {
   it('formats transcript timestamps for mm:ss and hh:mm:ss', () => {
@@ -33,5 +34,21 @@ describe('day4Transcript helpers', () => {
 
     expect(tokens.some((token) => token.isMatch)).toBe(true);
     expect(tokens.map((token) => token.text).join('')).toContain('<script>');
+  });
+
+  it('normalizes backend transcript segments that use start/end fields', () => {
+    const transcript = normalizeTranscript({
+      transcript: {
+        status: 'ready',
+        text: 'Ready transcript',
+        segments: [{ start: 0, end: 60000, text: 'Segment text' }],
+      },
+    });
+
+    expect(transcript).toEqual({
+      status: 'ready',
+      text: 'Ready transcript',
+      segments: [{ id: null, startMs: 0, endMs: 60000, text: 'Segment text' }],
+    });
   });
 });


### PR DESCRIPTION
## Summary

* Replaced Talent Partner Day 4 playback/evidence copy with `Handoff + Demo`.
* Preserved video playback through backend-provided handoff media/download URLs.
* Added clear transcript states, including failed transcription handling.
* Preserved searchable transcript behavior and timestamp seeking.
* Ensured latest Day 4 handoff artifacts can be fetched/rendered for the submission review page.
* Normalized backend transcript segment payloads that use `start` / `end` fields.

## Issue

Closes #190

## Acceptance Criteria

* [x] All Day 4 labels: Handoff + Demo, not presentation
* [x] Video playback works with correct media URLs
* [x] Transcript viewer with searchable text
* [x] Failed transcription state clearly shown

## Files Changed

* `src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4Handoff.tsx` - Updated the Day 4 playback heading, passed transcript status through to the transcript panel, and kept playback wired to the handoff artifact.
* `src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4TranscriptPanel.tsx` - Added transcript failed/processing states and the searchable transcript fallback copy for Handoff + Demo.
* `src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4VideoPanel.tsx` - Updated unavailable/deleted playback messaging to use Handoff + Demo terminology.
* `src/features/talent-partner/submission-review/components/ArtifactCard/artifactDay4Status.ts` - Added transcript processing and failed-status helpers plus normalization support.
* `src/features/talent-partner/submission-review/components/LatestDay4Handoff.tsx` - Updated the latest Day 4 evidence panel copy to Handoff + Demo and preserved artifact rendering.
* `src/features/talent-partner/submission-review/hooks/useCandidateLoader.ts` - Included the latest Day 4 handoff submission when preloading submission IDs.
* `src/features/talent-partner/submission-review/hooks/useDeferredLatestDay4Artifact.ts` - Deferred loading only when the cached Day 4 artifact is incomplete.
* `src/features/talent-partner/submission-review/utils/candidateSubmissionsApi.transcriptUtils.ts` - Normalized backend transcript segments that use `start` / `end` fields.
* `tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.day4Handoff.test.tsx` - Updated the integration assertion to the new Handoff + Demo playback label.
* `tests/unit/features/talent-partner/submission-review/ArtifactDay4Handoff.test.tsx` - Covered playback URL wiring, searchable transcript behavior, timestamp seeking, unavailable playback, and failed transcription states.
* `tests/unit/features/talent-partner/submission-review/LatestDay4Handoff.test.tsx` - Added coverage for the latest Day 4 Handoff + Demo evidence copy and fallback states.
* `tests/unit/features/talent-partner/submission-review/day4Transcript.test.ts` - Added transcript normalization coverage for backend `start` / `end` segment payloads.

## QA

Commands and verified results:

* `npm run lint` - PASS
* `npm run typecheck` - PASS
* `npm test -- --runInBand tests/unit/features/talent-partner/submission-review/ArtifactDay4Handoff.test.tsx tests/unit/features/talent-partner/submission-review/LatestDay4Handoff.test.tsx tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.day4Handoff.test.tsx tests/unit/features/talent-partner/submission-review/day4Transcript.test.ts` - PASS
* `npx playwright test tests/e2e/flow-qa/tmp-day4-talent-partner-browser-qa.spec.ts -c tests/e2e/flow-qa/playwright.config.ts --project=chromium --workers=1` - PASS
* `./precommit.sh` - PASS

Final precommit block:

* Test Suites: 503 passed, 503 total
* Tests: 1570 passed, 1570 total
* Snapshots: 3 passed, 3 total
* Typecheck passed
* Production build passed
* precommit checks passed

## Browser QA Evidence

* Route tested: `/dashboard/trials/:trialId/candidates/:candidateSessionId`
* `Day 4 Handoff + Demo evidence` visible
* `Day 4 Handoff + Demo playback` visible
* No visible Day 4 playback/evidence copy used `presentation`
* Video `src` and download `href` matched backend-provided media/download URL
* Transcript search updated match count and highlighted matching text
* Timestamp click exercised seek behavior
* Failed transcript state showed:
  * `Transcript unavailable`
  * `Transcript generation failed. The Handoff + Demo video is still available above when media access is permitted.`

## Notes / Follow-ups

* Backend issues `winoe-ai-backend#290` and `winoe-ai-backend#294` remain the broader end-to-end reliability dependencies for Day 4 upload/transcription/media retention.
* Candidate-side `candidate-day4.spec.ts` stale locator expecting `Upload video` while UI shows `Upload demo video` is unrelated to #190 and should be handled separately if still relevant.
* No scoped user-facing Day 4 playback/evidence copy uses `presentation`; any remaining `presentation` match is a negative assertion in tests.

Fixes #190 