### PR TITLE
Rename Day 4 handoff API clients from presentation to handoff/demo endpoints

### DIFF
--- a/pr.md
+++ b/pr.md
@@ -1,102 +1,119 @@
+# PR: Fix Trial-scoped Benchmarks comparison
+
 ## Summary
 
-- Replaced Day 4 Talent Partner review copy from legacy "presentation" wording to **Handoff + Demo** terminology.
-- Updated affected tests to assert the new Day 4 Handoff + Demo copy.
-- Verified frontend handoff clients use the handoff endpoint family and no active `/presentation/upload/*` references remain.
+Closes #189.
 
-## Files Changed
+This PR fixes the Talent Partner Trial detail Benchmarks panel so it only renders eligible candidates from the selected Trial and displays the required Benchmarks framing, cohort context, and Winoe Report links.
 
-- `src/features/talent-partner/submission-review/components/LatestDay4Handoff.tsx`
-- `src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4Handoff.tsx`
-- `tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.day4Handoff.test.tsx`
-- `tests/unit/features/talent-partner/submission-review/ArtifactDay4Handoff.test.tsx`
+## What changed
 
-## Route Verification
+- Renamed the Trial detail comparison surface to `Benchmarks`.
+- Added cohort-size copy, for example `Comparing 2 candidates for this Trial`.
+- Added the limited-comparison note when the rendered cohort has fewer than 3 candidates.
+- Added decision-boundary copy clarifying that Winoe surfaces evidence and the Talent Partner makes the hiring decision.
+- Preserved Trial identifiers during compare normalization.
+- Added defensive same-Trial filtering when row-level Trial identifiers are present.
+- Restricted Benchmarks rows to terminal/report-ready candidates:
+  - `completed + ready`
+  - `evaluated + ready`
+- Excluded in-progress, non-ready, and unrelated-Trial rows.
+- Simplified the Benchmarks table to the required fields:
+  - candidate name
+  - Winoe Score
+  - dimensional summary
+  - evidence/recommendation summary
+  - Winoe Report link
+- Kept the Benchmarks surface read-only; Winoe Report generation remains on the dedicated Winoe Report page.
+- Avoided retired terminology and deterministic hiring language.
 
-Frontend request clients inspected:
+## Why
 
-- `src/features/candidate/tasks/handoff/handoffApi.requests.init.ts`
-  - uses `/tasks/{taskId}/handoff/upload/init`
-- `src/features/candidate/tasks/handoff/handoffApi.requests.complete.ts`
-  - uses `/tasks/{taskId}/handoff/upload/complete`
-- `src/features/candidate/tasks/handoff/handoffApi.requests.status.ts`
-  - uses `/tasks/{taskId}/handoff/status`
+Benchmarks are only trustworthy if they compare candidates from the same Trial, under the same Winoe instance and same evaluation lens. The previous comparison surface could show unrelated candidates, which broke the trust model for Talent Partners.
 
-Backend runtime OpenAPI verification:
+This PR makes the UI match the product promise: same-Trial Benchmarks with evidence-backed, non-deterministic framing.
 
-- Present:
-  - `/api/tasks/{task_id}/handoff/status`
-  - `/api/tasks/{task_id}/handoff/upload/complete`
-  - `/api/tasks/{task_id}/handoff/upload/init`
-- Absent:
-  - `/presentation/upload/*`
+## Acceptance criteria
 
-## QA Evidence
+- [x] Benchmarks table only shows candidates invited to / associated with the selected Trial.
+- [x] Each row shows candidate name, Winoe Score, dimensional summary, evidence/recommendation summary, and Winoe Report link.
+- [x] No-data state appears when no eligible completed/report-ready candidates exist.
+- [x] Primary label is `Benchmarks`, not just `Compare`.
+- [x] Copy avoids implying Winoe makes the hiring decision.
+- [x] Header displays cohort size.
+- [x] Limited-comparison note appears when rendered cohort size is less than 3.
+- [x] Verified with at least 2 same-Trial candidates rendering as distinct rows with distinct Winoe Scores.
+- [x] `in_progress + ready` rows are excluded.
+- [x] `evaluated + ready` rows from the live backend payload are included.
+- [x] No retired terminology introduced.
 
-### Automated / code checks
+## Testing
 
-- Targeted Day 4 handoff tests passed:
-  - `tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.day4Handoff.test.tsx`
-  - `tests/unit/features/talent-partner/submission-review/ArtifactDay4Handoff.test.tsx`
-  - `tests/unit/features/candidate/tasks/handoff/HandoffUploadPanel.day4Requirements.test.tsx`
-- Grep checks passed:
-  - zero `/presentation/upload` hits in frontend source/tests
-  - zero `presentationUpload|PresentationUpload` hits in frontend source/tests
-  - zero active Day 4 user-facing "presentation" copy hits
-- `npm run lint` passed
-- `npm run typecheck` passed
-- `npm run build` passed
-- `./precommit.sh` passed:
-  - 503/503 test suites passed
-  - 1573/1573 tests passed
-  - coverage passed
-  - typecheck passed
-  - build passed
+Automated checks run:
 
-### Manual browser QA
+```bash
+npx jest tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.component.interactions.test.tsx --runInBand
+npx jest tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.component.interactions.test.tsx --runInBand --detectOpenHandles
+npx jest tests/unit/features/talent-partner/trial-management/detail/candidatesCompareNormalize.test.ts tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.rows.test.tsx tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.states.test.tsx tests/integration/talent-partner/TrialDetailPageClient.compareStates.test.tsx tests/integration/talent-partner/TrialDetailPageClient.compareRetry.test.tsx --runInBand
+npm run typecheck
+npm run lint:eslint
+npm run lint:prettier
+./precommit.sh
+```
 
-Backend:
-- `./runBackend.sh api` started successfully
-- `GET /health` returned `200 OK`
-- live OpenAPI exposed handoff routes and no presentation upload routes
+All passed.
 
-Frontend:
-- `npm run dev` started successfully on `http://localhost:3000`
+Full precommit result:
 
-Talent Partner browser QA:
-- login succeeded for the provided Talent Partner account
-- reached:
-  - `/dashboard`
-  - `/dashboard/trials/2`
-  - `/dashboard/trials/2/candidates/1`
-- Day 4 review surface reached
-- observed **Handoff + Demo** copy:
-  - `Day 4 Handoff + Demo evidence`
-  - `Playback and transcript review for the latest Day 4 Handoff + Demo`
-- no visible Day 4 "presentation" copy observed
-- no `/presentation/upload/*` network requests observed
-- no relevant console errors observed
+- Test Suites: 502 passed, 502 total
+- Tests: 1566 passed, 1566 total
+- Snapshots: 3 passed, 3 total
+- Typecheck: pass
+- Build: pass
+- Precommit: pass
 
-Candidate browser QA:
-- login succeeded for the provided Candidate account
-- reached:
-  - `/candidate/dashboard`
-  - `/candidate/session/OklvcvQxuQIIxzcmdrXxNK5i0Jl07GHokd6zG7KHqD8`
-- candidate session remained on Day 1
-- Day 4 upload surface was not reachable because backend state did not advance to Day 4 during QA
-- no visible Day 4 "presentation" copy observed
-- no `/presentation/upload/*` network requests observed
+## Manual QA
 
-## Known Limitation
+Manual QA was performed against the local frontend and backend.
 
-Candidate Day 4 upload browser proof was not completed because the local seeded/backend state kept the candidate session on Day 1. The schedule endpoint rejected backdating, and the admin day-window control returned `ok` but did not move `currentTask` to Day 4.
+Environment:
 
-This is an environment/seed-state limitation, not a #192 implementation defect. The API client source, backend OpenAPI contract, targeted tests, Talent Partner Day 4 browser review, and full precommit gate all support the #192 acceptance criteria.
+- Backend: local backend via `./runBackend.sh up`
+- Frontend: local frontend via `npm run dev`
+- Talent Partner account used for login
+- Trial tested: seeded Trial 1 because Trial 2 was unavailable in the local DB after reseeding
 
-## Risk
+Evidence saved under:
 
-Low. The only incomplete proof is live Candidate Day 4 upload UI access under local seeded state. The upload client route strings are directly verified in source and backend OpenAPI confirms the matching handoff endpoints exist while legacy presentation upload endpoints do not.
+```txt
+.ai_flow/qa/issue-189/
+```
 
-## Final Status
+Artifacts:
 
-Fixes #192
+- `01-dashboard.png`
+- `02-trial-detail.png`
+- `03-benchmarks-panel.png`
+- `04-winoe-report.png`
+- `summary.json`
+
+Observed QA result:
+
+- Compare endpoint observed: `/api/trials/1/candidates/compare`
+- Rendered rows:
+  - `Avery Chen — 91%`
+  - `Jordan Patel — 74%`
+- Header rendered: `Comparing 2 candidates for this Trial`
+- Limited-comparison note rendered: `Limited comparison — results are more meaningful with additional candidates.`
+- Decision-boundary copy rendered: `Winoe surfaces evidence from each Trial. The Talent Partner makes the hiring decision.`
+- Winoe Report link navigation checked.
+- Empty state did not render when eligible rows existed.
+- No retired terminology observed.
+- No deterministic hiring language observed.
+
+## Notes / risks
+
+- Frontend same-Trial filtering is defensive when row-level Trial IDs are present.
+- If the backend omits row-level Trial IDs, the UI relies on the Trial-scoped endpoint contract: `/api/trials/:trialId/candidates/compare`.
+- The live backend uses `evaluated` as a terminal compare status, so the frontend treats both `completed` and `evaluated` as eligible terminal states.
+- The final diff is scoped to #189; unrelated Jest/global timeout changes were removed.

--- a/pr.md
+++ b/pr.md
@@ -1,119 +1,102 @@
-# PR: Fix Trial-scoped Benchmarks comparison
-
 ## Summary
 
-Closes #189.
+- Replaced Day 4 Talent Partner review copy from legacy "presentation" wording to **Handoff + Demo** terminology.
+- Updated affected tests to assert the new Day 4 Handoff + Demo copy.
+- Verified frontend handoff clients use the handoff endpoint family and no active `/presentation/upload/*` references remain.
 
-This PR fixes the Talent Partner Trial detail Benchmarks panel so it only renders eligible candidates from the selected Trial and displays the required Benchmarks framing, cohort context, and Winoe Report links.
+## Files Changed
 
-## What changed
+- `src/features/talent-partner/submission-review/components/LatestDay4Handoff.tsx`
+- `src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4Handoff.tsx`
+- `tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.day4Handoff.test.tsx`
+- `tests/unit/features/talent-partner/submission-review/ArtifactDay4Handoff.test.tsx`
 
-- Renamed the Trial detail comparison surface to `Benchmarks`.
-- Added cohort-size copy, for example `Comparing 2 candidates for this Trial`.
-- Added the limited-comparison note when the rendered cohort has fewer than 3 candidates.
-- Added decision-boundary copy clarifying that Winoe surfaces evidence and the Talent Partner makes the hiring decision.
-- Preserved Trial identifiers during compare normalization.
-- Added defensive same-Trial filtering when row-level Trial identifiers are present.
-- Restricted Benchmarks rows to terminal/report-ready candidates:
-  - `completed + ready`
-  - `evaluated + ready`
-- Excluded in-progress, non-ready, and unrelated-Trial rows.
-- Simplified the Benchmarks table to the required fields:
-  - candidate name
-  - Winoe Score
-  - dimensional summary
-  - evidence/recommendation summary
-  - Winoe Report link
-- Kept the Benchmarks surface read-only; Winoe Report generation remains on the dedicated Winoe Report page.
-- Avoided retired terminology and deterministic hiring language.
+## Route Verification
 
-## Why
+Frontend request clients inspected:
 
-Benchmarks are only trustworthy if they compare candidates from the same Trial, under the same Winoe instance and same evaluation lens. The previous comparison surface could show unrelated candidates, which broke the trust model for Talent Partners.
+- `src/features/candidate/tasks/handoff/handoffApi.requests.init.ts`
+  - uses `/tasks/{taskId}/handoff/upload/init`
+- `src/features/candidate/tasks/handoff/handoffApi.requests.complete.ts`
+  - uses `/tasks/{taskId}/handoff/upload/complete`
+- `src/features/candidate/tasks/handoff/handoffApi.requests.status.ts`
+  - uses `/tasks/{taskId}/handoff/status`
 
-This PR makes the UI match the product promise: same-Trial Benchmarks with evidence-backed, non-deterministic framing.
+Backend runtime OpenAPI verification:
 
-## Acceptance criteria
+- Present:
+  - `/api/tasks/{task_id}/handoff/status`
+  - `/api/tasks/{task_id}/handoff/upload/complete`
+  - `/api/tasks/{task_id}/handoff/upload/init`
+- Absent:
+  - `/presentation/upload/*`
 
-- [x] Benchmarks table only shows candidates invited to / associated with the selected Trial.
-- [x] Each row shows candidate name, Winoe Score, dimensional summary, evidence/recommendation summary, and Winoe Report link.
-- [x] No-data state appears when no eligible completed/report-ready candidates exist.
-- [x] Primary label is `Benchmarks`, not just `Compare`.
-- [x] Copy avoids implying Winoe makes the hiring decision.
-- [x] Header displays cohort size.
-- [x] Limited-comparison note appears when rendered cohort size is less than 3.
-- [x] Verified with at least 2 same-Trial candidates rendering as distinct rows with distinct Winoe Scores.
-- [x] `in_progress + ready` rows are excluded.
-- [x] `evaluated + ready` rows from the live backend payload are included.
-- [x] No retired terminology introduced.
+## QA Evidence
 
-## Testing
+### Automated / code checks
 
-Automated checks run:
+- Targeted Day 4 handoff tests passed:
+  - `tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.day4Handoff.test.tsx`
+  - `tests/unit/features/talent-partner/submission-review/ArtifactDay4Handoff.test.tsx`
+  - `tests/unit/features/candidate/tasks/handoff/HandoffUploadPanel.day4Requirements.test.tsx`
+- Grep checks passed:
+  - zero `/presentation/upload` hits in frontend source/tests
+  - zero `presentationUpload|PresentationUpload` hits in frontend source/tests
+  - zero active Day 4 user-facing "presentation" copy hits
+- `npm run lint` passed
+- `npm run typecheck` passed
+- `npm run build` passed
+- `./precommit.sh` passed:
+  - 503/503 test suites passed
+  - 1573/1573 tests passed
+  - coverage passed
+  - typecheck passed
+  - build passed
 
-```bash
-npx jest tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.component.interactions.test.tsx --runInBand
-npx jest tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.component.interactions.test.tsx --runInBand --detectOpenHandles
-npx jest tests/unit/features/talent-partner/trial-management/detail/candidatesCompareNormalize.test.ts tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.rows.test.tsx tests/unit/features/talent-partner/trial-management/detail/components/CandidateCompareSection.states.test.tsx tests/integration/talent-partner/TrialDetailPageClient.compareStates.test.tsx tests/integration/talent-partner/TrialDetailPageClient.compareRetry.test.tsx --runInBand
-npm run typecheck
-npm run lint:eslint
-npm run lint:prettier
-./precommit.sh
-```
+### Manual browser QA
 
-All passed.
+Backend:
+- `./runBackend.sh api` started successfully
+- `GET /health` returned `200 OK`
+- live OpenAPI exposed handoff routes and no presentation upload routes
 
-Full precommit result:
+Frontend:
+- `npm run dev` started successfully on `http://localhost:3000`
 
-- Test Suites: 502 passed, 502 total
-- Tests: 1566 passed, 1566 total
-- Snapshots: 3 passed, 3 total
-- Typecheck: pass
-- Build: pass
-- Precommit: pass
+Talent Partner browser QA:
+- login succeeded for the provided Talent Partner account
+- reached:
+  - `/dashboard`
+  - `/dashboard/trials/2`
+  - `/dashboard/trials/2/candidates/1`
+- Day 4 review surface reached
+- observed **Handoff + Demo** copy:
+  - `Day 4 Handoff + Demo evidence`
+  - `Playback and transcript review for the latest Day 4 Handoff + Demo`
+- no visible Day 4 "presentation" copy observed
+- no `/presentation/upload/*` network requests observed
+- no relevant console errors observed
 
-## Manual QA
+Candidate browser QA:
+- login succeeded for the provided Candidate account
+- reached:
+  - `/candidate/dashboard`
+  - `/candidate/session/OklvcvQxuQIIxzcmdrXxNK5i0Jl07GHokd6zG7KHqD8`
+- candidate session remained on Day 1
+- Day 4 upload surface was not reachable because backend state did not advance to Day 4 during QA
+- no visible Day 4 "presentation" copy observed
+- no `/presentation/upload/*` network requests observed
 
-Manual QA was performed against the local frontend and backend.
+## Known Limitation
 
-Environment:
+Candidate Day 4 upload browser proof was not completed because the local seeded/backend state kept the candidate session on Day 1. The schedule endpoint rejected backdating, and the admin day-window control returned `ok` but did not move `currentTask` to Day 4.
 
-- Backend: local backend via `./runBackend.sh up`
-- Frontend: local frontend via `npm run dev`
-- Talent Partner account used for login
-- Trial tested: seeded Trial 1 because Trial 2 was unavailable in the local DB after reseeding
+This is an environment/seed-state limitation, not a #192 implementation defect. The API client source, backend OpenAPI contract, targeted tests, Talent Partner Day 4 browser review, and full precommit gate all support the #192 acceptance criteria.
 
-Evidence saved under:
+## Risk
 
-```txt
-.ai_flow/qa/issue-189/
-```
+Low. The only incomplete proof is live Candidate Day 4 upload UI access under local seeded state. The upload client route strings are directly verified in source and backend OpenAPI confirms the matching handoff endpoints exist while legacy presentation upload endpoints do not.
 
-Artifacts:
+## Final Status
 
-- `01-dashboard.png`
-- `02-trial-detail.png`
-- `03-benchmarks-panel.png`
-- `04-winoe-report.png`
-- `summary.json`
-
-Observed QA result:
-
-- Compare endpoint observed: `/api/trials/1/candidates/compare`
-- Rendered rows:
-  - `Avery Chen — 91%`
-  - `Jordan Patel — 74%`
-- Header rendered: `Comparing 2 candidates for this Trial`
-- Limited-comparison note rendered: `Limited comparison — results are more meaningful with additional candidates.`
-- Decision-boundary copy rendered: `Winoe surfaces evidence from each Trial. The Talent Partner makes the hiring decision.`
-- Winoe Report link navigation checked.
-- Empty state did not render when eligible rows existed.
-- No retired terminology observed.
-- No deterministic hiring language observed.
-
-## Notes / risks
-
-- Frontend same-Trial filtering is defensive when row-level Trial IDs are present.
-- If the backend omits row-level Trial IDs, the UI relies on the Trial-scoped endpoint contract: `/api/trials/:trialId/candidates/compare`.
-- The live backend uses `evaluated` as a terminal compare status, so the frontend treats both `completed` and `evaluated` as eligible terminal states.
-- The final diff is scoped to #189; unrelated Jest/global timeout changes were removed.
+Fixes #192

--- a/src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4Handoff.tsx
+++ b/src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4Handoff.tsx
@@ -47,7 +47,7 @@ export function ArtifactDay4Handoff({ artifact }: Props) {
   return (
     <div className="mt-3 rounded border border-slate-200 bg-slate-50 p-3">
       <div className="text-sm font-semibold text-gray-900">
-        Day 4 presentation playback
+        Day 4 Handoff + Demo playback
       </div>
       <div className="mt-2">
         <ArtifactDay4VideoPanel

--- a/src/features/talent-partner/submission-review/components/LatestDay4Handoff.tsx
+++ b/src/features/talent-partner/submission-review/components/LatestDay4Handoff.tsx
@@ -16,25 +16,25 @@ export function LatestDay4Handoff({
   return (
     <div className="rounded border border-gray-200 bg-white p-4">
       <div className="text-sm font-semibold text-gray-900">
-        Day 4 presentation evidence
+        Day 4 Handoff + Demo evidence
       </div>
       <div className="text-xs text-gray-600">
-        Playback and transcript review for the latest Day 4 demo presentation.
+        Playback and transcript review for the latest Day 4 Handoff + Demo.
       </div>
       <div className="mt-3">
         {artifact ? (
           <LazyArtifactCard artifact={artifact} />
         ) : loading ? (
           <div className="rounded border border-dashed border-gray-200 bg-gray-50 p-3 text-sm text-gray-700">
-            Loading Day 4 presentation details...
+            Loading Day 4 Handoff + Demo details...
           </div>
         ) : hasHandoffSubmission ? (
           <div className="rounded border border-dashed border-gray-200 bg-gray-50 p-3 text-sm text-gray-700">
-            Day 4 presentation found, but artifact details are unavailable.
+            Day 4 Handoff + Demo found, but artifact details are unavailable.
           </div>
         ) : (
           <div className="rounded border border-dashed border-gray-200 bg-gray-50 p-3 text-sm text-gray-700">
-            Day 4 presentation not available yet.
+            Day 4 Handoff + Demo not available yet.
           </div>
         )}
       </div>

--- a/tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.day4Handoff.test.tsx
+++ b/tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.day4Handoff.test.tsx
@@ -85,7 +85,7 @@ describe('CandidateSubmissionsPage - day 4 handoff evidence', () => {
     render(<CandidateSubmissionsPage />);
     expect(await screen.findByText(/Newest Handoff/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/Day 4 presentation playback/i),
+      screen.getByText(/Day 4 Handoff \+ Demo playback/i),
     ).toBeInTheDocument();
     const calledUrls = fetchMock.mock.calls.map((call) =>
       getRequestUrl(call[0]),

--- a/tests/unit/features/talent-partner/submission-review/ArtifactDay4Handoff.test.tsx
+++ b/tests/unit/features/talent-partner/submission-review/ArtifactDay4Handoff.test.tsx
@@ -28,7 +28,7 @@ describe('ArtifactDay4Handoff', () => {
     );
 
     expect(
-      screen.getByText(/Day 4 presentation playback/i),
+      screen.getByText(/Day 4 Handoff \+ Demo playback/i),
     ).toBeInTheDocument();
     expect(
       screen.getByText(/Video unavailable right now/i),
@@ -110,7 +110,7 @@ describe('ArtifactDay4Handoff', () => {
   it('does not render handoff playback UI for non-handoff Day 4 artifacts', () => {
     render(<ArtifactCard artifact={buildNonHandoffDay4Artifact()} />);
     expect(
-      screen.queryByText(/Day 4 presentation playback/i),
+      screen.queryByText(/Day 4 Handoff \+ Demo playback/i),
     ).not.toBeInTheDocument();
     expect(screen.getByText(/No text answer submitted/i)).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

- Replaced Day 4 Talent Partner review copy from legacy "presentation" wording to **Handoff + Demo** terminology.
- Updated affected tests to assert the new Day 4 Handoff + Demo copy.
- Verified frontend handoff clients use the handoff endpoint family and no active `/presentation/upload/*` references remain.

## Files Changed

- `src/features/talent-partner/submission-review/components/LatestDay4Handoff.tsx`
- `src/features/talent-partner/submission-review/components/ArtifactCard/ArtifactDay4Handoff.tsx`
- `tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.day4Handoff.test.tsx`
- `tests/unit/features/talent-partner/submission-review/ArtifactDay4Handoff.test.tsx`

## Route Verification

Frontend request clients inspected:

- `src/features/candidate/tasks/handoff/handoffApi.requests.init.ts`
  - uses `/tasks/{taskId}/handoff/upload/init`
- `src/features/candidate/tasks/handoff/handoffApi.requests.complete.ts`
  - uses `/tasks/{taskId}/handoff/upload/complete`
- `src/features/candidate/tasks/handoff/handoffApi.requests.status.ts`
  - uses `/tasks/{taskId}/handoff/status`

Backend runtime OpenAPI verification:

- Present:
  - `/api/tasks/{task_id}/handoff/status`
  - `/api/tasks/{task_id}/handoff/upload/complete`
  - `/api/tasks/{task_id}/handoff/upload/init`
- Absent:
  - `/presentation/upload/*`

## QA Evidence

### Automated / code checks

- Targeted Day 4 handoff tests passed:
  - `tests/integration/talent-partner/trials/candidates/CandidateSubmissionsContent.day4Handoff.test.tsx`
  - `tests/unit/features/talent-partner/submission-review/ArtifactDay4Handoff.test.tsx`
  - `tests/unit/features/candidate/tasks/handoff/HandoffUploadPanel.day4Requirements.test.tsx`
- Grep checks passed:
  - zero `/presentation/upload` hits in frontend source/tests
  - zero `presentationUpload|PresentationUpload` hits in frontend source/tests
  - zero active Day 4 user-facing "presentation" copy hits
- `npm run lint` passed
- `npm run typecheck` passed
- `npm run build` passed
- `./precommit.sh` passed:
  - 503/503 test suites passed
  - 1573/1573 tests passed
  - coverage passed
  - typecheck passed
  - build passed

### Manual browser QA

Backend:
- `./runBackend.sh api` started successfully
- `GET /health` returned `200 OK`
- live OpenAPI exposed handoff routes and no presentation upload routes

Frontend:
- `npm run dev` started successfully on `http://localhost:3000`

Talent Partner browser QA:
- login succeeded for the provided Talent Partner account
- reached:
  - `/dashboard`
  - `/dashboard/trials/2`
  - `/dashboard/trials/2/candidates/1`
- Day 4 review surface reached
- observed **Handoff + Demo** copy:
  - `Day 4 Handoff + Demo evidence`
  - `Playback and transcript review for the latest Day 4 Handoff + Demo`
- no visible Day 4 "presentation" copy observed
- no `/presentation/upload/*` network requests observed
- no relevant console errors observed

Candidate browser QA:
- login succeeded for the provided Candidate account
- reached:
  - `/candidate/dashboard`
  - `/candidate/session/OklvcvQxuQIIxzcmdrXxNK5i0Jl07GHokd6zG7KHqD8`
- candidate session remained on Day 1
- Day 4 upload surface was not reachable because backend state did not advance to Day 4 during QA
- no visible Day 4 "presentation" copy observed
- no `/presentation/upload/*` network requests observed

## Known Limitation

Candidate Day 4 upload browser proof was not completed because the local seeded/backend state kept the candidate session on Day 1. The schedule endpoint rejected backdating, and the admin day-window control returned `ok` but did not move `currentTask` to Day 4.

This is an environment/seed-state limitation, not a #192 implementation defect. The API client source, backend OpenAPI contract, targeted tests, Talent Partner Day 4 browser review, and full precommit gate all support the #192 acceptance criteria.

## Risk

Low. The only incomplete proof is live Candidate Day 4 upload UI access under local seeded state. The upload client route strings are directly verified in source and backend OpenAPI confirms the matching handoff endpoints exist while legacy presentation upload endpoints do not.

## Final Status

Fixes #192
