### PR TITLE
Task 5: Trial Preview + Trial Detail + Candidate Invite

### DIFF
--- a/pr.md
+++ b/pr.md
@@ -1,362 +1,222 @@
-# Iteration 3 Summary
-
-Closed the remaining code-ready regressions without redesigning the report surface:
-
-- Corrected the hero `ScoreRing` to show the headline Winoe Score only
-- Restored the full persona note, including `Disagree? Send feedback →`
-- Grouped Evidence Trail citations by artifact day/type group in the drawer
-- Grouped Evidence Appendix citations by artifact day/type group in print
-- Replaced cohort-median fallback wording with Benchmarks language
-- Switched the modal backdrop close handler to `onClick`
-- Removed the active `#` compare fallback and added a disabled benchmarks state
-- Updated accessible radar chart copy to reference Winoe Report dimensional scoring
-- Added and updated tests covering the visible UI and fallback states
-
-## Commands Run
-
-- `npx jest tests/integration/talent-partner/trials/candidates/WinoeReportPage.rendering.test.tsx --runInBand` - pass
-- `npx jest tests/integration/talent-partner/trials/candidates/WinoeReportPage.interactions.test.tsx --runInBand` - pass
-- `npx jest tests/integration/talent-partner/trials/candidates/WinoeReportPage.printProof.test.tsx --runInBand` - pass
-- `npx jest tests/unit/features/talent-partner/winoe-report/reportFormatting.test.ts --runInBand` - pass
-- `npx jest tests/unit/features/talent-partner/winoe-report/WinoeReportComponents.test.tsx --runInBand` - pass
-- `npm run lint` - pass
-- `npm run typecheck` - pass
-- `npm test -- --runInBand` - pass
-- `npm run build` - pass
-
-# Iteration 2 Summary
-
-Refined the Winoe Report into a maintainable, product-grade artifact:
-
-- Broke the monolithic report view into a composition shell plus focused components
-- Removed the hidden legacy compatibility bridge
-- Hardened score normalization for ambiguous backend scales
-- Reworded implementation-facing copy into product-facing language
-- Added stable print/no-print class contracts and tighter print CSS
-- Made the compare and share flows honest about what exists today
-- Improved modal accessibility and evidence drawer semantics
-- Updated tests to validate the visible report surface instead of hidden compatibility text
-
-# Component Decomposition
-
-The report now lives under `src/features/talent-partner/winoe-report/` with focused pieces for:
-
-- Identity bar
-- Score headline and ScoreRing
-- Dimensional breakdown and radar chart
-- Evidence trail drawer and citation rendering
-- Artifact modal and share modal
-- Narrative assessment
-- Per-day artifacts
-- Evidence appendix
-- Footer actions
-- Formatting utilities and view-model helpers
-
-`WinoeReportView.tsx` is now composition-only and stays well under the original monolith size.
-
-# Copy And Behavior Changes
-
-- Removed the invisible `sr-only` compatibility bridge entirely
-- Replaced backend/payload/implementation caveats with product copy
-- Changed per-day section labeling to `Candidate's Work`
-- Changed the visible footer section heading to `Next steps`
-- Updated compare navigation to the trial-specific benchmarks anchor
-- Kept share unavailable state explicit and removed fake expiry/copy controls
-- Added `data-winoe-report-no-print="true"` and `.evidence-drawer` contracts for print handling
-
-# Score Normalization
-
-- Added explicit helpers for ambiguous backend scales:
-  - `normalizeScoreOutOf100(value: number): number`
-  - `normalizeScoreOutOf10(value: number): number`
-- Covered:
-  - `null`, `undefined`, `NaN`
-  - negative values
-  - values already on display scale
-  - values above the expected range
-- Added unit tests for the formatting helpers and normalization behavior
-
-# Evidence And Print Refinements
-
-- Evidence Trail drawer now has a stable no-print class contract
-- Evidence appendix renders:
-  - code citations as monospace blocks
-  - demo citations as transcript-style blocks
-  - reflection/markdown citations as quoted prose
-- Print CSS now hides the app shell, drawer, and footer actions intentionally instead of relying on broad button suppression
-- Narrative and appendix sections keep the expected print-friendly structure
-
-# Test Updates
-
-- Updated the Winoe Report rendering test to assert the real visible UI
-- Updated the print-proof test to validate the actual appendix code block content
-- Updated polling and interaction tests to match the current product surface
-- Added/updated unit coverage for score formatting and normalization
-
-# Commands Run
-
-- `npm run lint` - pass
-- `npm run typecheck` - pass
-- `npm test -- --runInBand` - pass
-- `npm run build` - pass
-- `npx jest tests/integration/talent-partner/trials/candidates/WinoeReportPage.printProof.test.tsx --runInBand` - pass
-- `npx jest tests/integration/talent-partner/trials/candidates/WinoeReportPage.rendering.test.tsx --runInBand` - pass
-- `npx jest tests/integration/talent-partner/trials/candidates/WinoeReportPage.interactions.test.tsx --runInBand` - pass
-- `npx jest tests/integration/talent-partner/trials/candidates/WinoeReportPage.pollingGenerate.test.tsx --runInBand` - pass
-
-# Remaining Limitations
-
-- Compare still routes to the trial detail benchmarks anchor; there is no standalone benchmarks page in this app shell yet
-- Secure team sharing remains unavailable, so the share modal intentionally points users to PDF download
-- Evidence appendix print fidelity is limited by the browser’s PDF rendering, as with any CSS print export
-- Cohort benchmarks remain optional when the backend does not return comparison data
-
-# Files Changed
-
-- `winoe-ai-frontend/src/features/talent-partner/winoe-report/WinoeReportPage.tsx`
-- `winoe-ai-frontend/src/features/talent-partner/winoe-report/WinoeReportView.tsx`
-- `winoe-ai-frontend/src/features/talent-partner/winoe-report/winoeReport.normalize.base.ts`
-- `winoe-ai-frontend/src/features/talent-partner/winoe-report/winoeReport.normalizePayload.ts`
-- `winoe-ai-frontend/src/features/talent-partner/winoe-report/winoeReport.viewModel.ts`
-- `winoe-ai-frontend/src/features/talent-partner/winoe-report/winoeReportFormatting.ts`
-- `winoe-ai-frontend/src/features/talent-partner/winoe-report/components/`
-- `winoe-ai-frontend/src/features/talent-partner/winoe-report/utils/`
-- `winoe-ai-frontend/src/features/talent-partner/trial-management/detail/components/CandidateCompareSection.tsx`
-- `winoe-ai-frontend/src/styles/print.css`
-- `winoe-ai-frontend/tests/integration/talent-partner/trials/candidates/WinoeReportPage.rendering.test.tsx`
-- `winoe-ai-frontend/tests/integration/talent-partner/trials/candidates/WinoeReportPage.printProof.test.tsx`
-- `winoe-ai-frontend/tests/integration/talent-partner/trials/candidates/WinoeReportPage.interactions.test.tsx`
-- `winoe-ai-frontend/tests/integration/talent-partner/trials/candidates/WinoeReportPage.pollingGenerate.test.tsx`
-- `winoe-ai-frontend/tests/unit/features/talent-partner/winoe-report/reportFormatting.test.ts`
-- `winoe-ai-frontend/tests/unit/features/talent-partner/winoe-report/winoeReport.normalizeReport.test.ts`
-
-# Task 6 Manual QA — Winoe Report Page + Print-to-PDF
-
-## Environment
+# Task 5 (Iteration 2): Trial Preview, Approval, Detail, and Candidate Invite
 
-- Backend command: `DEV_AUTH_BYPASS=1 WINOE_DEV_AUTH_BYPASS=1 ./runBackend.sh up`
-- Frontend command: `npm run dev`
-- Backend URL: `http://localhost:8000`
-- Frontend URL: `http://localhost:3000`
-- Auth mode: local dev QA login route with Talent Partner seed account
-- Browser: Playwright-driven Chromium
-- Date/time: 2026-05-14 America/New_York
+## Summary
 
-## Report Under Test
-
-- Trial: `YC Demo Backend Engineer Trial`
-- Candidate: `Avery Chen`
-- Report URL: `http://localhost:3000/dashboard/trials/1/candidates/1/winoe-report`
-- Data source: seeded completed Trial
+- **Trial Preview** at `/talent-partner/trials/{id}/preview`: Project Brief from **`readProjectBrief` / `detail.projectBrief`** (canonical markdown), not the scenario label; honest fallback when only storyline-like content exists. Rubric table, cadence, sticky actions (approve, regenerate, discard, print).
+- **Trial Detail** tabs: **Brief** uses **`selectedScenarioVersion.projectBriefMd`** (version snapshot), not `scenarioLabel`. **MarkdownRenderer** uses design-token-friendly defaults where adjusted (e.g. `pre` surface).
+- **Batch invite** modal: token-oriented styling, **`fieldset` / `legend`**, row-scoped labels (**`Full name (row n)`**, **`Email (row n)`**), duplicate validation, **`aria-live`** summary, success UI lists **sent** and **failed** rows with per-row errors; invite URLs copyable with accessible controls.
+- **BFF**: Next routes under `src/app/api/trials/[id]/approve` and `invite-candidates` forward to the backend; clients use **`requestTalentPartnerBff`** with **`/trials/{id}/approve`** and **`/trials/{id}/invite-candidates`** (same convention as other trial BFF calls — not `/backend/trials/...`).
 
-## QA Result
+## Preview / Detail data sources
 
-FAIL
+| Surface            | Project Brief source                                                                                  |
+| ------------------ | ----------------------------------------------------------------------------------------------------- |
+| Preview            | `detail.projectBrief` from normalized trial detail / `readProjectBrief()`; not scenario display label |
+| Detail → Brief tab | Active / selected scenario snapshot **`projectBriefMd`**                                              |
 
-## Screenshots
+Scenario label / version string is **not** used as a stand-in for the Project Brief.
 
-- Score headline: `winoe-ai-frontend/test-results/task-6-winoe-report-qa/screenshots/03-score-headline.png`
-- Dimensional breakdown: `winoe-ai-frontend/test-results/task-6-winoe-report-qa/screenshots/04-dimensional-breakdown.png`
-- Evidence drawer: `winoe-ai-frontend/test-results/task-6-winoe-report-qa/screenshots/05-evidence-drawer.png`
-- Artifact modal: `winoe-ai-frontend/test-results/task-6-winoe-report-qa/screenshots/06-artifact-modal-or-preview.png`
-- Narrative Assessment: `winoe-ai-frontend/test-results/task-6-winoe-report-qa/screenshots/07-narrative-assessment.png`
-- Candidate's Work: `winoe-ai-frontend/test-results/task-6-winoe-report-qa/screenshots/09-candidates-work-expanded.png`
-- Share modal: `winoe-ai-frontend/test-results/task-6-winoe-report-qa/screenshots/10-share-modal.png`
-- Print preview: `winoe-ai-frontend/test-results/task-6-winoe-report-qa/screenshots/12-print-preview.png`
-- Dark mode: `winoe-ai-frontend/test-results/task-6-winoe-report-qa/screenshots/13-dark-mode-report.png`
+## BFF / API route paths
 
-## PDF Artifact
+- **`approveTrialForInviting`**: `POST` **`/trials/{id}/approve`** via `requestTalentPartnerBff`.
+- **`inviteCandidatesBatch`**: `POST` **`/trials/{id}/invite-candidates`** via `requestTalentPartnerBff`.
+- Unit tests assert these URL paths (see `trialLifecycle.test.ts`, `invitesBatchApi.test.ts`).
 
-- Saved PDF path: `winoe-ai-frontend/test-results/task-6-winoe-report-qa/pdf/winoe-report-task-6-qa.pdf`
+## Invite modal behavior
 
-## Checklist
+- Duplicate emails in the form: user-visible errors; row-specific **`id` / `htmlFor`** wiring for multiple rows.
+- API partial success: **`status: 'failed'`** rows show **`errorCode` / `errorMessage`**; **`useInviteBatchCandidateFlow`** (and related copy) treats mixed sent/failed outcomes explicitly.
 
-- [x] Identity Bar
-- [x] Score Headline
-- [x] Dimensional Breakdown
-- [ ] Evidence Trail Drawer
-- [x] Narrative Assessment
-- [x] Candidate's Work
-- [x] Footer Actions
-- [x] Share Modal
-- [x] Compare Action
-- [x] Print-to-PDF
-- [ ] Evidence Appendix
-- [x] Dark Mode
-- [x] Accessibility
-- [x] Terminology Guard
-- [x] Console/Network Cleanliness
+## Regenerate / discard
 
-## Command Results
+- **Regenerate**: on success, navigates to **`/talent-partner/trials/{id}`** with **`router.refresh`** so the Talent Partner lands on the **Task 4-style trial detail / generation** experience instead of a stale preview-only reload.
+- **Discard draft**: calls **`terminateTrial`**; modal copy describes **termination** (draft ends in **terminated** state), not a misleading “hard delete” promise if the backend archives/terminates rather than destroying rows.
 
-- `npm run lint`: pass
-- `npm run typecheck`: pass
-- `npm test -- --runInBand`: pass
-- `npm run build`: pass
-- backend `./precommit.sh`: pass
+## Components / files (non-exhaustive)
 
-## Issues Found
+- `src/shared/ui/MarkdownRenderer.tsx`
+- `src/features/talent-partner/trial-management/preview/TrialPreviewContent.tsx`
+- `src/features/talent-partner/trial-management/detail/components/TrialDetailTabs.tsx`
+- `src/features/talent-partner/trial-management/invitations/InviteCandidatesBatchModal.tsx`, `InviteInputField.tsx`
+- `src/features/talent-partner/api/trialLifecycle.actions.approveApi.ts`, `invitesBatchApi.ts`
+- `src/app/api/trials/[id]/approve/route.ts`, `invite-candidates/route.ts`
 
-- severity: blocker
-- surface: Winoe Report evidence trail / report generation
-- expected: a generated report with citation cards grouped by artifact/day type, and an Evidence Trail drawer that opens populated citations for the selected dimension
-- actual: the drawer contained no citations for any dimension in the seeded runtime, and `POST /api/candidate_sessions/1/winoe_report/generate` returned `500 Internal Server Error`
-- screenshot/log: `winoe-ai-frontend/test-results/task-6-winoe-report-qa/logs/drawer-state.txt`, `winoe-ai-frontend/test-results/task-6-winoe-report-qa/logs/browser-console.log`
-- recommended fix: repair report generation for the seeded trial/candidate data path and ensure at least one dimension has linked artifacts so the drawer and appendix are not empty
+## Tests run
 
-## Final Recommendation
+```bash
+npm run lint
+npm run typecheck
+npm test -- --runInBand
+```
 
-- `QA FAIL — requires implementation fixes`
+**Pass** (Iteration 2): **517** test suites, **1640** tests; Prettier + ESLint clean.
 
-# Task 6 Evidence Fix Verification
+## Iteration 5 — Manual QA blocker fixes (May 2026)
 
-## Result
+- **Trial Detail (active inviting)**: **Regenerate** moved into the **overflow menu** (with Edit details / Terminate); primary header actions stay **Invite candidates** + **More**. **Scenario workbench** is tucked under **“Advanced — scenario workbench”** `<details>` so tabs + Candidates stay the default surface.
+- **Lock copy**: Scenario lock messaging no longer claims “invites exist” by default; it states the version is locked because the **Trial is approved for inviting**.
+- **Preview approve UX**: **`SCENARIO_APPROVAL_PENDING`** surfaces as a **warning**-tone notification (not a generic error-only toast).
+- **Action error sanitization**: `mapActionError` strips UI-facing strings that include **`api.github.com`** or **`GitHub API error`** before falling back to a safe message.
+- **Print brief as PDF**: Existing unit test continues to assert **`window.print`** via the **Print brief as PDF** button; print CSS still hides **`.tp-no-print`** chrome.
 
-PASS
+### Manual QA rerun (this iteration)
 
-## What changed
+- **Not claimed as pass**: Full browser manual QA was **not** re-run end-to-end in this agent session after these changes.
+- **`./precommit.sh`** remains the automated gate for this branch.
 
-- Seeded demo trials now persist keyed Winoe rubric snapshots and citation rows for the ready report path.
-- Evidence citations now carry dimension metadata so the frontend can map them into the Evidence Trail drawer and print appendix.
-- The seeded report includes grouped evidence for Day 1, Day 2/3, Day 4, and Day 5 where available.
+## Known limitations
 
-## Backend generation result
+- If the backend regeneration endpoint does not fully mirror Task 4’s streaming/progress contract, the UI still relies on **detail refresh + trial route** for progress; any gap is owned by backend/Task 4 alignment.
+- **Activity** tab has no dedicated audit API yet; it summarizes **scenario approval/lock** and **invite-related candidate row signals** (invite URL / sent timestamp) from existing detail data.
+- No browser QA or screenshots in this pass.
 
-- `POST /api/candidate_sessions/1/winoe_report/generate` no longer returned the previous unexplained 500 during local seeded QA.
-- The backend precommit suite passed after the seed and report-path fixes.
+## Iteration 7 (May 2026)
 
-## Evidence drawer result
+- **Prettier**: `InviteCandidatesBatchModal` + batch modal tests formatted; `./precommit.sh` green.
+- **Activity tab**: `TrialDetailTabs` shows short bullets when the scenario is **approved/locked** or **ready for review**, and when candidates have **invite URLs** or **invite email sent** timestamps; otherwise the previous empty-state copy remains.
+- **Tests**: `TrialDetailTabs.brief.test.tsx` extended with Activity coverage.
+- **Manual QA**: Full invite/GitHub tree pass **not re-run** in this session; follow backend `pr.md` Iteration 7 for log/tree verification steps.
 
-- The seeded Winoe Report drawer rendered populated citations for linked dimensions.
-- Citations grouped under artifact/day headings instead of appearing as ungrouped raw refs.
+## Iteration 9 (May 2026)
 
-## Evidence appendix result
+- **No frontend code changes** for this iteration; behavior depends on backend fixes in **`winoe-ai-backend` `pr.md` → Iteration 9** (Anthropic scenario generation request ordering + richer error classification; invite email persistence uses **`flush`** so batch + Codespace finalization share one coherent transaction boundary per row).
+- **Manual QA**: Full two-candidate + real LLM path **not re-run** in this agent session (no provider keys in the environment). Re-run the supervisor checklist once backend is deployed with keys.
 
-- The print-only appendix rendered the same grouped citation structure.
-- Code citations rendered as code blocks, and prose/transcript citations rendered in their appropriate modes.
+## Iteration 11 (May 2026) — Stabilization (precommit, BFF, seed, generation UI)
 
-## Commands run
-
-- `cd winoe-ai-backend && poetry run pytest tests/demo/services/test_demo_yc_seed_service.py tests/shared/http/routes/test_shared_http_routes_winoe_report_and_jobs_routes.py -q` - pass
-- `cd winoe-ai-backend && ./precommit.sh` - pass
-- `cd winoe-ai-frontend && npm run lint` - pass
-- `cd winoe-ai-frontend && npm run typecheck` - pass
-- `cd winoe-ai-frontend && npm test -- --runInBand` - pass
-- `cd winoe-ai-frontend && npm run build` - pass
-
-## Remaining risks
-
-- Print fidelity still depends on browser PDF rendering, so minor pagination differences can occur between environments.
-- The generation endpoint still depends on the seeded local runtime and the local auth bypass path for QA verification.
-
-# Task 6 Re-QA After Live Surface Fix
-
-## Result
-
-PASS
-
-## Environment
-
-- Backend command: `QA_E2E_TALENT_PARTNER_EMAIL=talent.partner.demo@winoe.ai DEV_AUTH_BYPASS=1 WINOE_DEV_AUTH_BYPASS=1 ./runBackend.sh up`
-- Frontend command: `QA_E2E_TALENT_PARTNER_EMAIL=talent.partner.demo@winoe.ai npm run dev`
-- Seed command: `poetry run python -m scripts.seed_demo --github-provider fake --reset-db`
-- Backend URL: `http://localhost:8000`
-- Frontend URL: `http://localhost:3000`
-- Browser: Playwright-driven Chromium
-- Auth mode: local dev QA login route with seeded talent partner email
-- Date/time: `2026-05-14 America/New_York`
-
-## Report Under Test
-
-- Trial: `YC Demo Backend Engineer Trial`
-- Candidate: `Avery Chen`
-- Report URL: `http://localhost:3000/dashboard/trials/1/candidates/1/winoe-report`
-- Confirmed component path: `src/features/talent-partner/winoe-report/WinoeReportPage.tsx` -> `src/features/talent-partner/winoe-report/WinoeReportView.tsx`
-- Data source: refreshed seeded demo runtime
-
-## Route / Component Verification
-
-- `document.body.innerText` contained `Narrative Assessment`
-- `document.body.innerText` contained `Persona note: Winoe's tone is evidence-first and measured. Disagree? Send feedback →`
-- `document.body.innerText` contained `View evidence`
-- `document.querySelectorAll('.dimension-row').length` returned `9`
-- `View evidence` buttons were visible and keyboard reachable
-- Route authorized without `401` / `403` churn after QA login for `talent.partner.demo@winoe.ai`
-
-## Generation Endpoint Verification
-
-- Endpoint: `POST /api/candidate_sessions/1/winoe_report/generate`
-- Status: `202 Accepted`
-- Response summary: `{"jobId":"c8395f88-6985-4b87-baa6-8b1b2e7e671c","status":"queued"}`
-- Auth identity: `talent.partner.demo@winoe.ai`
-- Company binding: `company_id=1`
-- Trial ID: `1`
-- Candidate Session ID: `1`
-
-## Evidence Payload Verification
-
-- Network response path: `GET /api/candidate_sessions/1/winoe_report`
-- Citation count: populated across multiple dimensions
-- Dimensions with citations: at least 4
-- Artifact groups observed: Day 1, Day 2/3, Day 4, Day 5
-- Artifact refs observed: `day1-design-doc.md:L12-L31`, `day2-tests.txt:L1-L4`, `handoff-demo-transcript.txt:02:14-02:48`, `day5-reflection.md:L8-L22`, `day5-reflection.md:L23-L34`
-
-## Evidence Drawer Verification
-
-- Dimensions checked: `project_scaffolding_quality`, `communication_handoff_demo`
-- Drawer opened: yes
-- Citation groups observed: artifact/day grouping rendered in the drawer
-- Code citation rendering: yes, including `1c2b66873099f4f3884c5ec852ad104b86526f69:README.md:L1-L24`
-- Demo citation rendering: yes, including `handoff-demo-transcript.txt:02:14-02:48`
-- Screenshot path: `winoe-ai-frontend/test-results/task-6-winoe-report-qa/screenshots/05-evidence-drawer-after-fix.png`
-
-## Evidence Appendix / PDF Verification
-
-- PDF path: `winoe-ai-frontend/test-results/task-6-winoe-report-qa/pdf/winoe-report-task-6-qa-after-evidence-fix.pdf`
-- Appendix populated: yes
-- Citation groups observed: grouped by dimension and artifact/day group
-- Code blocks present: yes
-- Screenshot path: `winoe-ai-frontend/test-results/task-6-winoe-report-qa/screenshots/12-print-preview-after-fix.png`
-
-## Updated Screenshots
-
-- Evidence drawer: `winoe-ai-frontend/test-results/task-6-winoe-report-qa/screenshots/05-evidence-drawer-after-fix.png`
-- Artifact modal: `winoe-ai-frontend/test-results/task-6-winoe-report-qa/screenshots/06-artifact-modal-after-fix.png`
-- Print preview: `winoe-ai-frontend/test-results/task-6-winoe-report-qa/screenshots/12-print-preview-after-fix.png`
-- PDF path: `winoe-ai-frontend/test-results/task-6-winoe-report-qa/pdf/winoe-report-task-6-qa-after-evidence-fix.pdf`
-
-## Regression Sweep
-
-- [x] Identity Bar
-- [x] Score Headline
-- [x] Dimensional Breakdown
-- [x] Evidence Trail Drawer populated
-- [x] Narrative Assessment
-- [x] Persona note
-- [x] Candidate's Work
-- [x] Footer Actions
-- [x] Share Modal
-- [x] Compare Action
-- [x] Print-to-PDF
-- [x] Evidence Appendix populated
-- [x] Dark Mode
-- [x] Accessibility / keyboard sanity
-- [x] Terminology Guard
-- [x] Console/Network Cleanliness
-
-## Command Results
-
-- backend focused pytest: `FAIL` only because the narrow test subset hit the global coverage gate; the targeted tests passed but total coverage was `48.58%`
-- backend precommit: `PASS`
-- frontend lint: `PASS`
-- frontend typecheck: `PASS`
-- frontend tests: `PASS`
-- frontend build: `PASS`
-
-## Issues Found
-
-- none
-
-## Final Recommendation
-
-- `QA PASS — ready for finish approval`
+### Root causes fixed
+
+- **Backend coverage gate**: Total coverage was fractionally under **96%** while rounding to `96.00%`. Added **approve lifecycle unit tests**, **Anthropic `call_anthropic_json` contract tests**, and **batch invite / provisioning** tests so the gate clears without lowering `cov-fail-under`.
+- **Next BFF 500 on `/api/trials`**: `forwardJson` always called **`getSessionNormalized()`** after BFF auth succeeded; in local/dev that call can **throw** (Auth0/session edge cases), turning good upstream calls into **500**. Session lookup is now **best-effort** inside a `try`/`catch`; **`x-dev-user-email`** is omitted when lookup fails instead of failing the proxy.
+- **Scenario generation model / env drift**: Repo **`.env`** still pinned **`WINOE_SCENARIO_GENERATION_MODEL=claude-opus-4-7`** while defaults moved to **`claude-3-5-sonnet-20241022`** (Anthropic Messages API–friendly). **`.env`**, **`runBackend.sh` default**, and **`SettingsFields`** are aligned so local runs and tests resolve the same model.
+- **`scenario_generation_llm_failed` grepability**: Added a second plain-text log line **`scenario_generation_llm_failed_message errorSummary=…`** after the structured warning so aggregators that drop `extra=` still surface **`errorSummary=`** for classification.
+- **Local QA seed**: **`scripts/local_qa_backend.sh`** now runs **`poetry run python scripts/seed_local_talent_partners.py`** after migrations (idempotent; **`WINOE_LOCAL_QA_SKIP_SEED=1`** to skip). Shell test documents **`WINOE_LOCAL_QA_SKIP_SEED`** alongside the alembic skip guard.
+- **Generation wizard stuck on “Drafting”**: While SSE remains primary, the wizard now **polls `GET /api/trials/{id}`** for **`generationStatus === 'failed'`** (and **`ready_for_review`**) so a missed **`failed`** SSE frame does not leave the UI spinning forever. Failed state adds **Back to Trials** next to **Edit context** / **Try again**.
+
+### Files changed (representative)
+
+- `src/platform/server/bff/forward.ts` — resilient Auth0 session read for dev email header.
+- `src/features/talent-partner/trial-management/create/NewTrialWizard.tsx` — detail polling + return control.
+- `tests/trials/services/test_trials_lifecycle_approve_service_unit.py`, `tests/ai/test_ai_provider_clients_call_anthropic_json_contract.py`, `tests/trials/services/test_trials_invite_batch_service.py`, `tests/scripts/test_local_qa_backend_shell.py` — coverage and script guards.
+
+### Commands run (this session)
+
+- **`cd winoe-ai-backend && ./precommit.sh`**: **PASS** (after fixes).
+- **`cd winoe-ai-frontend && ./precommit.sh`**: **PASS**.
+
+### Anthropic / job `aba0f408-d6ea-4f7c-89f6-295a90001482`
+
+- **No server log artifact** was present in this workspace for that job id; classification from stored logs was **not possible** here. With the new **`scenario_generation_llm_failed_message errorSummary=`** line and aligned model default, re-run generation and grep worker output for **`anthropic_request_failed:`** + **`tool_attempt=`** / **`json_prompt_attempt=`** to classify (**invalid model** vs **payload/schema** vs **account/entitlement** vs **429**/outage).
+
+### Known limitations
+
+- **Full narrow live smoke** (backend + Next + curl BFF) was **not** executed in this session (no long-running servers started). **Recommendation**: run the supervisor’s narrow smoke checklist on a dev machine with DB + keys before full Task 5 manual QA.
+- **Not CODE READY** note **superseded** by **Final Task 5 QA Signoff — CODE READY** (post–Iteration 12) below.
+
+## Final Task 5 QA Signoff — CODE READY
+
+### Status
+
+**CODE READY — proceed to final handoff / PR packaging.**
+
+The frontend passed the Task 5 Talent Partner flow in live manual QA after Iteration 12. **Task 5 is CODE READY despite the Anthropic billing caveat** below — the UI path was fully verified in demo mode after real generation failed only for provider account/credits, not for frontend implementation defects.
+
+### Final verification summary
+
+- Frontend `./precommit.sh`: PASS
+- Backend `./precommit.sh`: PASS
+- `/api/dev/qa-login`: PASS
+- BFF `GET /api/trials`: PASS
+- BFF `POST /api/v1/trials`: PASS
+- BFF `GET /api/trials/{id}`: PASS
+- Trial Preview rendered correctly: PASS
+- Approve through UI: PASS
+- Active Trial Detail rendered correctly: PASS
+- Two-candidate invite modal: PASS
+- Invite URLs visible/copyable: PASS
+- Candidate rows refreshed: PASS
+- Repo tree proof passed for both candidates: PASS
+- README proof passed for both candidates: PASS
+- Termination UI: PASS
+- No raw provider errors in the final successful Talent Partner UI path: PASS
+
+### Preview / approval
+
+Verified on Trial ID `3`.
+
+The Preview page showed:
+
+- Tags row
+- Actual Project Brief
+- Rubric table
+- Daily cadence pills
+- Sticky decision panel
+- Print path
+- Approval flow
+
+Approval worked through the Talent Partner UI and moved the Trial to active detail.
+
+### Active Trial Detail
+
+Verified:
+
+- Hero/title
+- Role context
+- Active badge
+- Invite candidates button
+- Overflow menu
+- Tabs: Candidates / Brief / Rubric / Activity
+- Scenario workbench behind Advanced
+- Brief tab showing approved Project Brief
+- Rubric tab showing approved rubric
+
+### Candidate invite UI
+
+Verified candidate emails:
+
+```txt
+task5-final-a+1778782430@example.com
+task5-final-b+1778782430@example.com
+```
+
+Both invites returned as sent with visible/copyable invite URLs.
+
+The UI correctly represented workspace setup as needing attention because Codespace provisioning failed externally, while repo bootstrap succeeded.
+
+No raw provider errors were visible in the final successful Talent Partner UI path.
+
+### Termination UI
+
+Verified:
+
+- Neutral termination copy.
+- Checkbox confirmation.
+- Trial terminated state.
+- Invite/resend/copy actions disabled.
+- Cleanup-in-progress messaging with job id.
+- No raw provider errors.
+
+### Real LLM caveat
+
+Real LLM generation was attempted before demo-mode QA. Anthropic returned a billing/credit error:
+
+```txt
+credit balance too low
+```
+
+Classification:
+
+```txt
+quota / billing / insufficient Anthropic credits
+```
+
+The full Task 5 UI/invite/repo/termination QA was completed using demo mode after this provider-account failure. This is acceptable for Task 5 signoff because the frontend flow itself passed and the real-generation failure is not a frontend implementation blocker.
+
+### Operational note
+
+During QA, local DB Alembic drift caused invite failures before the schema was corrected. After the DB was brought to the true repo head and migration `202605120001` was actually applied, the invite flow passed.
+
+Optional follow-up:
+
+- Ensure local QA setup detects schema drift before the Talent Partner invite flow.
+- Continue sanitizing backend-originated ORM/SQL failures defensively, even though the correct fix is migration hygiene.

--- a/src/app/(talent-partner)/dashboard/trials/[id]/preview/page.tsx
+++ b/src/app/(talent-partner)/dashboard/trials/[id]/preview/page.tsx
@@ -1,0 +1,4 @@
+export {
+  default,
+  metadata,
+} from '../../../../talent-partner/trials/[id]/preview/page';

--- a/src/app/(talent-partner)/talent-partner/trials/[id]/page.tsx
+++ b/src/app/(talent-partner)/talent-partner/trials/[id]/page.tsx
@@ -1,0 +1,1 @@
+export { default, metadata } from '../../../dashboard/trials/[id]/page';

--- a/src/app/(talent-partner)/talent-partner/trials/[id]/preview/page.tsx
+++ b/src/app/(talent-partner)/talent-partner/trials/[id]/preview/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
+import { TrialPreviewContent } from '@/features/talent-partner/trial-management/preview/TrialPreviewContent';
 import { BRAND_NAME } from '@/platform/config/brand';
 
 type Props = { params: Promise<{ id: string }> };
@@ -7,34 +7,10 @@ type Props = { params: Promise<{ id: string }> };
 export const metadata: Metadata = {
   title: `Trial preview | ${BRAND_NAME}`,
   description:
-    'Review the generated Project Brief and rubric before inviting candidates.',
+    'Review the generated Project Brief and Evaluation Rubric before inviting candidates.',
 };
 
-export default async function TrialPreviewPlaceholderPage({ params }: Props) {
+export default async function TrialPreviewPage({ params }: Props) {
   const { id } = await params;
-  const safe = encodeURIComponent(id);
-  return (
-    <main className="mx-auto max-w-[720px] space-y-6 py-10">
-      <h1 className="text-2xl font-semibold text-primary">Trial preview</h1>
-      <p className="text-sm text-secondary">
-        Full preview and approval flows are next up. For now, open this Trial on
-        the dashboard to review the Project Brief, rubric, and lifecycle
-        actions.
-      </p>
-      <div className="flex flex-wrap gap-3">
-        <Link
-          href={`/dashboard/trials/${safe}`}
-          className="inline-flex rounded-md bg-wheat-500 px-4 py-2 text-sm font-medium text-on-accent hover:bg-wheat-700"
-        >
-          Open Trial on dashboard
-        </Link>
-        <Link
-          href="/dashboard/trials"
-          className="inline-flex rounded-md border border-strong px-4 py-2 text-sm font-medium text-primary hover:bg-secondary"
-        >
-          Back to Trials
-        </Link>
-      </div>
-    </main>
-  );
+  return <TrialPreviewContent trialId={id} />;
 }

--- a/src/app/api/trials/[id]/approve/route.ts
+++ b/src/app/api/trials/[id]/approve/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest } from 'next/server';
+import { forwardJson } from '@/platform/server/bff';
+import { withTalentPartnerAuth } from '@/app/api/bffRouteHelpers';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
+
+export async function POST(
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  const body = await req.json().catch(() => null);
+
+  return withTalentPartnerAuth(
+    req,
+    { tag: 'approve-trial', requirePermission: 'talent_partner:access' },
+    async (auth) =>
+      forwardJson({
+        path: `/api/trials/${encodeURIComponent(id)}/approve`,
+        method: 'POST',
+        cache: 'no-store',
+        ...(body === null ? {} : { body }),
+        accessToken: auth.accessToken,
+        requestId: auth.requestId,
+      }),
+  );
+}

--- a/src/app/api/trials/[id]/invite-candidates/route.ts
+++ b/src/app/api/trials/[id]/invite-candidates/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from 'next/server';
+import { forwardJson } from '@/platform/server/bff';
+import { withTalentPartnerAuth } from '@/app/api/bffRouteHelpers';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
+
+const INVITE_BATCH_TIMEOUT_MS = 120_000;
+
+export async function POST(
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+
+  return withTalentPartnerAuth(
+    req,
+    {
+      tag: 'invite-candidates-batch',
+      requirePermission: 'talent_partner:access',
+    },
+    async (auth) => {
+      const payload: unknown = await req.json().catch(() => undefined);
+      return forwardJson({
+        path: `/api/trials/${encodeURIComponent(id)}/invite-candidates`,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: payload ?? {},
+        accessToken: auth.accessToken,
+        requestId: auth.requestId,
+        timeoutMs: INVITE_BATCH_TIMEOUT_MS,
+      });
+    },
+  );
+}

--- a/src/features/talent-partner/api/index.ts
+++ b/src/features/talent-partner/api/index.ts
@@ -6,5 +6,6 @@ export * from './trialsUpdateApi';
 export * from './companyAiConfigApi';
 export * from './candidatesApi';
 export * from './invitesApi';
+export * from './invitesBatchApi';
 export * from './resendCandidateInviteApi';
 export * from './trialLifecycleApi';

--- a/src/features/talent-partner/api/invitesBatchApi.ts
+++ b/src/features/talent-partner/api/invitesBatchApi.ts
@@ -1,0 +1,76 @@
+import { requestTalentPartnerBff } from './requestTalentPartnerBffApi';
+import { safeId } from './trialUtilsApi';
+import { throwMappedApiError } from '@/platform/api-client/errors/errorMapping';
+
+export type InviteCandidateRowInput = { name: string; email: string };
+
+export type TrialInviteResultItem = {
+  candidateSessionId: string;
+  name: string;
+  email: string;
+  inviteUrl: string;
+  status: 'sent' | 'resent' | 'failed';
+  errorCode?: string | null;
+  errorMessage?: string | null;
+  workspaceProvisioningStatus?: string | null;
+  workspaceProvisioningNotice?: string | null;
+};
+
+export async function inviteCandidatesBatch(
+  trialId: string,
+  candidates: InviteCandidateRowInput[],
+): Promise<{ invites: TrialInviteResultItem[] }> {
+  const id = safeId(trialId);
+  if (!id) {
+    throw new Error('Trial ID is required.');
+  }
+  try {
+    const { data } = await requestTalentPartnerBff<{
+      invites?: Array<{
+        candidateSessionId?: number | null;
+        name?: string;
+        email?: string;
+        inviteUrl?: string;
+        status?: string;
+        errorCode?: string | null;
+        errorMessage?: string | null;
+      }>;
+    }>(`/trials/${encodeURIComponent(id)}/invite-candidates`, {
+      method: 'POST',
+      body: {
+        candidates: candidates.map((c) => ({
+          name: c.name.trim(),
+          email: c.email.trim().toLowerCase(),
+        })),
+      },
+    });
+    const raw = Array.isArray(data?.invites) ? data.invites : [];
+    const invites: TrialInviteResultItem[] = raw.map((row) => ({
+      candidateSessionId: String(row.candidateSessionId ?? ''),
+      name: String(row.name ?? ''),
+      email: String(row.email ?? ''),
+      inviteUrl: String(row.inviteUrl ?? ''),
+      status:
+        row.status === 'resent'
+          ? 'resent'
+          : row.status === 'failed'
+            ? 'failed'
+            : 'sent',
+      errorCode: row.errorCode ?? null,
+      errorMessage: row.errorMessage ?? null,
+      workspaceProvisioningStatus:
+        (row as { workspaceProvisioningStatus?: string | null })
+          .workspaceProvisioningStatus ?? null,
+      workspaceProvisioningNotice:
+        (row as { workspaceProvisioningNotice?: string | null })
+          .workspaceProvisioningNotice ?? null,
+    }));
+    return { invites };
+  } catch (error) {
+    throwMappedApiError(
+      error,
+      'Unable to send invites. Check Trial status and try again.',
+      'talent_partner',
+    );
+  }
+}

--- a/src/features/talent-partner/api/trialLifecycle.actions.approveApi.ts
+++ b/src/features/talent-partner/api/trialLifecycle.actions.approveApi.ts
@@ -1,0 +1,34 @@
+import { requestTalentPartnerBff } from './requestTalentPartnerBffApi';
+import { safeId } from './trialUtilsApi';
+import { mapActionError } from './trialLifecycle.errorsApi';
+import type { TrialActionResult } from './trialLifecycle.typesApi';
+
+export async function approveTrialForInviting(
+  trialId: string | number,
+): Promise<TrialActionResult> {
+  try {
+    const id = safeId(trialId);
+    if (!id) {
+      return {
+        ok: false,
+        statusCode: 400,
+        message: 'Trial ID is required.',
+      };
+    }
+
+    const { data } = await requestTalentPartnerBff<unknown>(
+      `/trials/${encodeURIComponent(id)}/approve`,
+      { method: 'POST', body: { confirm: true } },
+    );
+    return {
+      ok: true,
+      statusCode: 200,
+      message: null,
+      errorCode: null,
+      details: null,
+      data,
+    };
+  } catch (error) {
+    return mapActionError(error, 'Unable to approve Trial.');
+  }
+}

--- a/src/features/talent-partner/api/trialLifecycle.actionsApi.ts
+++ b/src/features/talent-partner/api/trialLifecycle.actionsApi.ts
@@ -1,4 +1,5 @@
 export { activateTrialInviting } from './trialLifecycle.actions.activateApi';
+export { approveTrialForInviting } from './trialLifecycle.actions.approveApi';
 export {
   approveScenarioVersion,
   patchScenarioVersion,

--- a/src/features/talent-partner/api/trialLifecycle.errorsApi.ts
+++ b/src/features/talent-partner/api/trialLifecycle.errorsApi.ts
@@ -36,6 +36,17 @@ function extractActionErrorCode(error: unknown): string | null {
   return nestedErrorCode;
 }
 
+function sanitizeTalentPartnerActionMessage(
+  message: string | null | undefined,
+  fallback: string,
+): string {
+  const raw =
+    typeof message === 'string' && message.trim() ? message.trim() : fallback;
+  if (/\bapi\.github\.com\b/i.test(raw)) return fallback;
+  if (/GitHub API error/i.test(raw)) return fallback;
+  return raw;
+}
+
 export function mapActionError(
   error: unknown,
   fallback: string,
@@ -79,12 +90,26 @@ export function mapActionError(
       };
     }
 
+    if (errorCode === 'SCENARIO_APPROVAL_PENDING') {
+      return {
+        ok: false,
+        statusCode,
+        errorCode,
+        details,
+        message:
+          'A regenerated Project Brief is waiting for your approval. Open this Trial, select the pending scenario version, approve that brief, then return here to approve the Trial for inviting.',
+      };
+    }
+
     return {
       ok: false,
       statusCode,
       errorCode,
       details,
-      message: toUserMessage(error, fallback, { includeDetail: false }),
+      message: sanitizeTalentPartnerActionMessage(
+        toUserMessage(error, fallback, { includeDetail: false }),
+        fallback,
+      ),
     };
   } catch {
     return {

--- a/src/features/talent-partner/api/trialLifecycleApi.ts
+++ b/src/features/talent-partner/api/trialLifecycleApi.ts
@@ -9,6 +9,7 @@ export type {
 
 export {
   activateTrialInviting,
+  approveTrialForInviting,
   approveScenarioVersion,
   patchScenarioVersion,
   regenerateTrialScenario,

--- a/src/features/talent-partner/dashboard/hooks/useInviteBatchCandidateFlow.ts
+++ b/src/features/talent-partner/dashboard/hooks/useInviteBatchCandidateFlow.ts
@@ -1,0 +1,69 @@
+import { useCallback, useState } from 'react';
+import { inviteCandidatesBatch } from '@/features/talent-partner/api/invitesBatchApi';
+import { formatTalentPartnerError } from '../../utils/formattersUtils';
+import { friendlyInviteError, toSafeString } from '../utils/inviteHelpersUtils';
+import type { InviteModalState } from '@/features/talent-partner/types';
+import type {
+  InviteBatchUiState,
+  InviteCandidateRow,
+} from '@/features/talent-partner/trial-management/invitations/InviteBatchCandidateTypes';
+
+export function useInviteBatchCandidateFlow(trial: InviteModalState | null) {
+  const [state, setState] = useState<InviteBatchUiState>({ status: 'idle' });
+
+  const submit = useCallback(
+    async (rows: InviteCandidateRow[]): Promise<boolean> => {
+      const safeTrialId = toSafeString(trial?.trialId).trim();
+      if (!safeTrialId) return false;
+      const cleaned = rows
+        .map((r) => ({
+          name: toSafeString(r.name).trim(),
+          email: toSafeString(r.email).trim().toLowerCase(),
+        }))
+        .filter((r) => r.name && r.email);
+      if (!cleaned.length) {
+        setState({
+          status: 'error',
+          message: 'Add at least one candidate with name and email.',
+        });
+        return false;
+      }
+      setState({ status: 'loading' });
+      try {
+        const { invites } = await inviteCandidatesBatch(safeTrialId, cleaned);
+        const ok = invites.filter((i) => i.status !== 'failed');
+        const failed = invites.filter((i) => i.status === 'failed');
+        const nOk = ok.length;
+        const nFail = failed.length;
+        let message: string;
+        if (nFail === 0) {
+          message = `${nOk} invite${nOk === 1 ? '' : 's'} sent. Each candidate received a unique link. You can also copy the links below.`;
+        } else if (nOk === 0) {
+          message = `No invites were sent (${nFail} failed). Review the errors below.`;
+        } else {
+          message = `${nOk} invite${nOk === 1 ? '' : 's'} sent; ${nFail} failed. Review errors below.`;
+        }
+        setState({
+          status: 'success',
+          message,
+          invites,
+        });
+        return true;
+      } catch (e: unknown) {
+        const friendlyMessage = friendlyInviteError(e);
+        setState({
+          status: 'error',
+          message:
+            friendlyMessage ??
+            formatTalentPartnerError(e, 'Failed to send invites.'),
+        });
+        return false;
+      }
+    },
+    [trial],
+  );
+
+  const reset = useCallback(() => setState({ status: 'idle' }), []);
+
+  return { state, submit, reset, setState };
+}

--- a/src/features/talent-partner/trial-management/create/NewTrialWizard.tsx
+++ b/src/features/talent-partner/trial-management/create/NewTrialWizard.tsx
@@ -267,6 +267,60 @@ export default function NewTrialWizard() {
   }, [scheduleRedirect, sseRetryKey, trialId, wizardStep]);
 
   useEffect(() => {
+    if (wizardStep !== 3 || !trialId) return undefined;
+    let cancelled = false;
+    let polls = 0;
+    const maxPolls = 200;
+
+    const pollDetail = async () => {
+      if (cancelled || backendCompleteRef.current || polls >= maxPolls) return;
+      polls += 1;
+      try {
+        const res = await fetch(`/api/trials/${encodeURIComponent(trialId)}`, {
+          credentials: 'same-origin',
+          cache: 'no-store',
+        });
+        if (!res.ok || cancelled || backendCompleteRef.current) return;
+        const data: unknown = await res.json();
+        if (!data || typeof data !== 'object') return;
+        const rec = data as Record<string, unknown>;
+        const gs =
+          typeof rec.generationStatus === 'string'
+            ? rec.generationStatus
+            : typeof rec.generation_status === 'string'
+              ? rec.generation_status
+              : null;
+        if (gs === 'failed') {
+          const gf = rec.generationFailure ?? rec.generation_failure;
+          let msg: string | undefined;
+          if (gf && typeof gf === 'object') {
+            const er = (gf as Record<string, unknown>).error;
+            if (typeof er === 'string' && er.trim()) msg = er.trim();
+          }
+          setSseFailedMessage(
+            msg ??
+              'Scenario generation failed. Edit your context and try again, or return to Trials if you want to stop here.',
+          );
+          backendCompleteRef.current = true;
+          setStreamOverlay('generation_failed');
+          return;
+        }
+        if (gs === 'ready_for_review') {
+          backendCompleteRef.current = true;
+          scheduleRedirect(trialId);
+        }
+      } catch {}
+    };
+
+    void pollDetail();
+    const id = window.setInterval(() => void pollDetail(), 2800);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [scheduleRedirect, trialId, wizardStep]);
+
+  useEffect(() => {
     if (wizardStep !== 3 || !loadStartedAt.current) return undefined;
     const tick = () => {
       const start = loadStartedAt.current;
@@ -653,6 +707,13 @@ export default function NewTrialWizard() {
                       }}
                     >
                       Edit context
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={() => router.push('/dashboard/trials')}
+                    >
+                      Back to Trials
                     </Button>
                     <Button
                       type="button"

--- a/src/features/talent-partner/trial-management/detail/components/CandidatesEmptyState.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/CandidatesEmptyState.tsx
@@ -16,8 +16,8 @@ export function CandidatesEmptyState({
 }: Props) {
   return (
     <EmptyState
-      title="No candidates yet"
-      description="Invite candidates to this trial to track their progress and submissions."
+      title="No candidates invited yet."
+      description="Invite candidates to start collecting real-work evidence for this Trial."
       action={
         <Button
           variant="secondary"
@@ -27,8 +27,9 @@ export function CandidatesEmptyState({
           title={
             inviteEnabled ? undefined : (inviteDisabledReason ?? undefined)
           }
+          data-testid="invite-candidates-empty-cta"
         >
-          Invite your first candidate
+          Invite candidates
         </Button>
       }
     />

--- a/src/features/talent-partner/trial-management/detail/components/TerminateTrialModal.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/TerminateTrialModal.tsx
@@ -36,8 +36,8 @@ export function TerminateTrialModal({
           Terminate trial
         </h2>
         <p className="mt-2 text-sm text-gray-700">
-          Terminating this trial is destructive. Invites are disabled
-          immediately, and cleanup jobs run asynchronously in the background.
+          Terminate this Trial? Candidate access will be revoked and workspace
+          cleanup will start in the background.
         </p>
         <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-gray-700">
           <li>Invite and resend actions are blocked immediately.</li>

--- a/src/features/talent-partner/trial-management/detail/components/TrialDetailHeader.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/TrialDetailHeader.tsx
@@ -13,6 +13,8 @@ type Props = Pick<
   | 'scenarioLocked'
   | 'scenarioLockedAt'
   | 'titleLabel'
+  | 'roleLabel'
+  | 'preferredLanguageFrameworkLabel'
   | 'inviteEnabled'
   | 'inviteDisabledReason'
   | 'canApprove'
@@ -27,7 +29,12 @@ type Props = Pick<
   | 'regenerateDisabled'
   | 'onRegenerate'
   | 'terminatePending'
-> & { onInvite: () => void; onOpenTerminateModal: () => void };
+> & {
+  commandCenterActive: boolean;
+  onRevealScenarioWorkbench: () => void;
+  onInvite: () => void;
+  onOpenTerminateModal: () => void;
+};
 
 export function TrialDetailHeader({
   trialId,
@@ -38,6 +45,10 @@ export function TrialDetailHeader({
   scenarioLocked,
   scenarioLockedAt,
   titleLabel,
+  roleLabel,
+  preferredLanguageFrameworkLabel,
+  commandCenterActive,
+  onRevealScenarioWorkbench,
   inviteEnabled,
   inviteDisabledReason,
   canApprove,
@@ -65,6 +76,10 @@ export function TrialDetailHeader({
       scenarioLocked={scenarioLocked}
       scenarioLockedAt={scenarioLockedAt}
       title={titleLabel}
+      roleLabel={roleLabel}
+      preferredLanguageFrameworkLabel={preferredLanguageFrameworkLabel}
+      commandCenterActive={commandCenterActive}
+      onRevealScenarioWorkbench={onRevealScenarioWorkbench}
       inviteEnabled={inviteEnabled}
       inviteDisabledReason={inviteDisabledReason}
       canApprove={canApprove}

--- a/src/features/talent-partner/trial-management/detail/components/TrialDetailHeaderActions.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/TrialDetailHeaderActions.tsx
@@ -3,8 +3,11 @@
 import Link from 'next/link';
 import Button from '@/shared/ui/Button';
 import { RegenerateScenarioButton } from '../scenario';
+import { TrialDetailOverflowMenu } from './TrialDetailOverflowMenu';
 
 type Props = {
+  commandCenterActive: boolean;
+  onRevealScenarioWorkbench: () => void;
   canApprove: boolean;
   approveButtonLabel: string;
   approveLoading: boolean;
@@ -26,6 +29,8 @@ type Props = {
 };
 
 export function TrialDetailHeaderActions({
+  commandCenterActive,
+  onRevealScenarioWorkbench,
   canApprove,
   approveButtonLabel,
   approveLoading,
@@ -45,6 +50,45 @@ export function TrialDetailHeaderActions({
   terminatePending,
   onOpenTerminateModal,
 }: Props) {
+  if (commandCenterActive) {
+    return (
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <Button
+          onClick={onInvite}
+          size="sm"
+          disabled={!inviteEnabled}
+          title={
+            inviteEnabled ? undefined : (inviteDisabledReason ?? undefined)
+          }
+          data-testid="invite-candidates-header"
+        >
+          Invite candidates
+        </Button>
+        <TrialDetailOverflowMenu
+          onEditDetails={onRevealScenarioWorkbench}
+          onTerminate={onOpenTerminateModal}
+          terminatePending={terminatePending}
+          trialTerminated={trialStatus === 'terminated'}
+          midMenuSlot={
+            <RegenerateScenarioButton
+              appearance="menu"
+              loading={regenerateLoading}
+              disabled={regenerateDisabled}
+              currentVersionLabel={scenarioVersionLabel}
+              onConfirm={onRegenerate}
+            />
+          }
+        />
+        <Link
+          className="tp-no-print text-sm text-wheat-700 hover:text-wheat-900 hover:underline"
+          href="/dashboard"
+        >
+          ← Back to dashboard
+        </Link>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-wrap items-center justify-end gap-2">
       {canApprove ? (
@@ -78,8 +122,9 @@ export function TrialDetailHeaderActions({
         size="sm"
         disabled={!inviteEnabled}
         title={inviteEnabled ? undefined : (inviteDisabledReason ?? undefined)}
+        data-testid="invite-candidates-header"
       >
-        Invite candidate
+        Invite candidates
       </Button>
       <Button
         type="button"
@@ -93,7 +138,7 @@ export function TrialDetailHeaderActions({
         {trialStatus === 'terminated' ? 'Trial terminated' : 'Terminate trial'}
       </Button>
       <Link
-        className="text-sm text-wheat-700 hover:text-wheat-900 hover:underline"
+        className="tp-no-print text-sm text-wheat-700 hover:text-wheat-900 hover:underline"
         href="/dashboard"
       >
         ← Back to dashboard

--- a/src/features/talent-partner/trial-management/detail/components/TrialDetailHeaderCore.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/TrialDetailHeaderCore.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { InlineBadge } from '@/shared/ui/InlineBadge';
 import PageHeader from '@/shared/ui/PageHeader';
 import { StatusPill } from '@/shared/ui/StatusPill';
@@ -14,6 +15,10 @@ type Props = {
   scenarioLocked: boolean;
   scenarioLockedAt: string | null;
   title: string;
+  roleLabel: string;
+  preferredLanguageFrameworkLabel: string | null;
+  commandCenterActive: boolean;
+  onRevealScenarioWorkbench: () => void;
   inviteEnabled: boolean;
   inviteDisabledReason: string | null;
   canApprove: boolean;
@@ -41,6 +46,10 @@ export function TrialDetailHeaderCore({
   scenarioLocked,
   scenarioLockedAt,
   title,
+  roleLabel,
+  preferredLanguageFrameworkLabel,
+  commandCenterActive,
+  onRevealScenarioWorkbench,
   inviteEnabled,
   inviteDisabledReason,
   canApprove,
@@ -62,12 +71,20 @@ export function TrialDetailHeaderCore({
     selectedScenarioStatusForDisplay ?? trialStatus ?? 'draft',
     'Unknown',
   );
+  const stack =
+    preferredLanguageFrameworkLabel &&
+    preferredLanguageFrameworkLabel.trim().length > 0
+      ? preferredLanguageFrameworkLabel.trim()
+      : 'Any stack';
+  const heroSubtitle = `${roleLabel} · ${stack} · Trial ID: ${trialId}`;
 
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-wrap items-start justify-between gap-4">
-        <PageHeader title={title} subtitle={`Trial ID: ${trialId}`} />
+        <PageHeader title={title} subtitle={heroSubtitle} />
         <TrialDetailHeaderActions
+          commandCenterActive={commandCenterActive}
+          onRevealScenarioWorkbench={onRevealScenarioWorkbench}
           canApprove={canApprove}
           approveButtonLabel={approveButtonLabel}
           approveLoading={approveLoading}
@@ -89,6 +106,11 @@ export function TrialDetailHeaderCore({
         />
       </div>
       <div className="flex flex-wrap items-center gap-2">
+        {trialStatus === 'active_inviting' ? (
+          <span data-testid="trial-active-badge">
+            <InlineBadge label="Active" tone="success" />
+          </span>
+        ) : null}
         <StatusPill label={status.label} tone={status.tone} />
         <InlineBadge label={`Scenario ${scenarioVersionLabel}`} tone="info" />
         {scenarioIdLabel ? (

--- a/src/features/talent-partner/trial-management/detail/components/TrialDetailHeaderSection.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/TrialDetailHeaderSection.tsx
@@ -4,12 +4,19 @@ import type { TrialDetailViewProps } from './types';
 type TrialDetailHeaderSectionProps = {
   props: TrialDetailViewProps;
   onInvite: () => void;
+  onRevealScenarioWorkbench: () => void;
 };
 
 export function TrialDetailHeaderSection({
   props,
   onInvite,
+  onRevealScenarioWorkbench,
 }: TrialDetailHeaderSectionProps) {
+  const commandCenterActive =
+    props.trialStatus === 'active_inviting' &&
+    !props.generating &&
+    !props.jobFailureMessage;
+
   return (
     <TrialDetailHeader
       trialId={props.trialId}
@@ -20,6 +27,10 @@ export function TrialDetailHeaderSection({
       scenarioLocked={props.scenarioLocked}
       scenarioLockedAt={props.scenarioLockedAt}
       titleLabel={props.titleLabel}
+      roleLabel={props.roleLabel}
+      preferredLanguageFrameworkLabel={props.preferredLanguageFrameworkLabel}
+      commandCenterActive={commandCenterActive}
+      onRevealScenarioWorkbench={onRevealScenarioWorkbench}
       inviteEnabled={props.inviteEnabled}
       inviteDisabledReason={props.inviteDisabledReason}
       canApprove={props.canApprove}

--- a/src/features/talent-partner/trial-management/detail/components/TrialDetailModals.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/TrialDetailModals.tsx
@@ -1,21 +1,7 @@
 'use client';
-import dynamic from 'next/dynamic';
 import { TerminateTrialModal } from './TerminateTrialModal';
+import { TrialInviteModal } from './TrialInviteModal';
 import type { TrialDetailViewProps } from './types';
-
-const TrialInviteModal = dynamic(
-  () => import('./TrialInviteModal').then((mod) => mod.TrialInviteModal),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/30">
-        <div className="rounded bg-white px-4 py-3 text-sm text-gray-700 shadow">
-          Loading invite form…
-        </div>
-      </div>
-    ),
-  },
-);
 
 type TrialDetailModalsProps = {
   props: TrialDetailViewProps;

--- a/src/features/talent-partner/trial-management/detail/components/TrialDetailOverflowMenu.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/TrialDetailOverflowMenu.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
+
+type Props = {
+  onEditDetails: () => void;
+  onTerminate: () => void;
+  terminatePending: boolean;
+  trialTerminated: boolean;
+  midMenuSlot?: ReactNode;
+};
+
+export function TrialDetailOverflowMenu({
+  onEditDetails,
+  onTerminate,
+  terminatePending,
+  trialTerminated,
+  midMenuSlot,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const menuId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      const root = rootRef.current;
+      if (!root?.contains(event.target as Node)) setOpen(false);
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    return () => document.removeEventListener('pointerdown', onPointerDown);
+  }, [open]);
+
+  const close = () => setOpen(false);
+
+  return (
+    <div
+      className="relative"
+      ref={rootRef}
+      data-testid="trial-detail-overflow-menu"
+    >
+      <button
+        type="button"
+        className="tp-no-print cursor-pointer rounded-md border border-subtle bg-elevated px-3 py-1.5 text-sm font-medium text-primary hover:bg-muted/40"
+        aria-label="Trial actions menu"
+        aria-expanded={open}
+        aria-controls={menuId}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="inline-flex items-center gap-1">
+          More
+          <span aria-hidden className="text-xs text-secondary">
+            ▾
+          </span>
+        </span>
+      </button>
+      {open ? (
+        <div
+          id={menuId}
+          className="absolute right-0 z-20 mt-1 min-w-[200px] rounded-md border border-subtle bg-elevated py-1 shadow-lg"
+        >
+          <button
+            type="button"
+            className="block w-full px-3 py-2 text-left text-sm text-primary hover:bg-muted/30"
+            onClick={() => {
+              onEditDetails();
+              close();
+            }}
+          >
+            Edit details
+          </button>
+          {midMenuSlot ? (
+            <div className="border-t border-subtle">{midMenuSlot}</div>
+          ) : null}
+          <button
+            type="button"
+            className="block w-full px-3 py-2 text-left text-sm text-red-800 hover:bg-red-50"
+            disabled={trialTerminated || terminatePending}
+            onClick={() => {
+              onTerminate();
+              close();
+            }}
+          >
+            Terminate Trial
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/talent-partner/trial-management/detail/components/TrialDetailTabs.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/TrialDetailTabs.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState } from 'react';
+import { MarkdownRenderer } from '@/shared/ui/MarkdownRenderer';
+import { mapRubricJsonToRows } from '@/features/talent-partner/trial-management/preview/rubricMapper';
+import { EvaluationRubricTable } from '@/features/talent-partner/trial-management/preview/EvaluationRubricTable';
+import { TrialDetailCandidatesPanel } from './TrialDetailCandidatesPanel';
+import type { TrialDetailViewProps } from './types';
+
+type TabId = 'candidates' | 'brief' | 'rubric' | 'activity';
+
+type Props = {
+  props: TrialDetailViewProps;
+  onInvite: () => void;
+};
+
+function trialActivitySummaryLines(props: TrialDetailViewProps): string[] {
+  const lines: string[] = [];
+  const sv = props.selectedScenarioVersion;
+  if (sv?.uiStatus === 'approved' || sv?.uiStatus === 'locked') {
+    const label =
+      sv.versionIndex != null ? `v${sv.versionIndex}` : 'current version';
+    lines.push(
+      `Scenario ${label} is ${sv.uiStatus === 'locked' ? 'locked' : 'approved'} and is the invite baseline.`,
+    );
+  } else if (sv?.uiStatus === 'ready_for_review') {
+    lines.push(
+      'Scenario is ready for review — approve it to unlock candidate invites.',
+    );
+  }
+  const invited = props.candidates.filter(
+    (c) => Boolean(c.inviteEmailSentAt?.trim()) || Boolean(c.inviteUrl?.trim()),
+  );
+  if (invited.length > 0) {
+    lines.push(
+      `${invited.length} candidate invite link(s) are available (see the Candidates tab for URLs and email delivery).`,
+    );
+  }
+  return lines;
+}
+
+export function TrialDetailTabs({ props, onInvite }: Props) {
+  const [tab, setTab] = useState<TabId>('candidates');
+  const rubricRows = mapRubricJsonToRows(
+    props.selectedScenarioVersion?.rubric ?? null,
+  );
+
+  return (
+    <div className="w-full">
+      <div className="border-b border-subtle">
+        <nav
+          className="-mb-px flex flex-wrap gap-6"
+          aria-label="Trial sections"
+        >
+          {(
+            [
+              ['candidates', 'Candidates'],
+              ['brief', 'Brief'],
+              ['rubric', 'Rubric'],
+              ['activity', 'Activity'],
+            ] as const
+          ).map(([id, label]) => (
+            <button
+              key={id}
+              type="button"
+              className={`border-b-2 pb-3 text-sm font-medium transition-colors ${
+                tab === id
+                  ? 'border-wheat-500 text-primary'
+                  : 'border-transparent text-secondary hover:text-primary'
+              }`}
+              onClick={() => setTab(id)}
+            >
+              {label}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      <div className="mt-6">
+        {tab === 'candidates' ? (
+          <TrialDetailCandidatesPanel props={props} onInvite={onInvite} />
+        ) : null}
+        {tab === 'brief' ? (
+          <div className="max-w-[720px] space-y-3">
+            <h3 className="text-sm font-semibold text-primary">
+              Project Brief
+            </h3>
+            <MarkdownRenderer
+              content={
+                props.selectedScenarioVersion?.projectBriefMd?.trim() ?? ''
+              }
+              variant="reading"
+              emptyPlaceholder="No Project Brief has been generated or approved for this version yet."
+            />
+          </div>
+        ) : null}
+        {tab === 'rubric' ? (
+          <div className="space-y-3">
+            <p className="text-sm text-secondary">
+              Winoe will evaluate candidates against these dimensions, using the
+              same rubric for everyone invited to this Trial.
+            </p>
+            <EvaluationRubricTable rows={rubricRows} />
+          </div>
+        ) : null}
+        {tab === 'activity' ? (
+          <div className="max-w-[720px] space-y-3 text-sm text-secondary">
+            {(() => {
+              const lines = trialActivitySummaryLines(props);
+              if (lines.length === 0) {
+                return (
+                  <p>
+                    No Trial activity recorded yet. Events such as approvals and
+                    invites will appear here when available.
+                  </p>
+                );
+              }
+              return (
+                <ul className="list-disc space-y-2 pl-5">
+                  {lines.map((line, idx) => (
+                    <li key={idx}>{line}</li>
+                  ))}
+                </ul>
+              );
+            })()}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/features/talent-partner/trial-management/detail/components/TrialDetailView.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/TrialDetailView.tsx
@@ -2,10 +2,10 @@
 import { useInviteModalActions } from './InviteModalActions';
 import { CleanupInProgressPanel } from './CleanupInProgressPanel';
 import { TrialAiOverridesPanel } from './TrialAiOverridesPanel';
-import { TrialDetailCandidatesPanel } from './TrialDetailCandidatesPanel';
 import { TrialDetailHeaderSection } from './TrialDetailHeaderSection';
 import { TrialDetailModals } from './TrialDetailModals';
 import { TrialDetailPlanPanel } from './TrialDetailPlanPanel';
+import { TrialDetailTabs } from './TrialDetailTabs';
 import { TrialDetailScenarioControls } from './TrialDetailScenarioControls';
 import type { TrialDetailViewProps } from './types';
 import { useDeferredScenarioControls } from './useDeferredScenarioControls';
@@ -18,14 +18,78 @@ export function TrialDetailView(props: TrialDetailViewProps) {
   });
   const showScenarioControls = useDeferredScenarioControls();
 
+  const commandSurfaceFirst =
+    props.trialStatus === 'active_inviting' &&
+    !props.generating &&
+    !props.jobFailureMessage;
+
+  const scenarioBlockInner = (
+    <TrialDetailScenarioControls
+      props={props}
+      showScenarioControls={showScenarioControls}
+    />
+  );
+
+  const scenarioBlock = commandSurfaceFirst ? (
+    <details
+      id="trial-scenario-workbench"
+      className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm open:ring-1 open:ring-subtle"
+      data-testid="trial-scenario-workbench-details"
+    >
+      <summary className="cursor-pointer text-sm font-medium text-primary">
+        Advanced — scenario workbench
+      </summary>
+      <div className="mt-4">{scenarioBlockInner}</div>
+    </details>
+  ) : (
+    <div id="trial-scenario-workbench">{scenarioBlockInner}</div>
+  );
+
+  const tabsBlock =
+    !props.generating && !props.jobFailureMessage ? (
+      <TrialDetailTabs props={props} onInvite={openInviteModal} />
+    ) : null;
+
   return (
     <div className="flex flex-col gap-4 py-8">
-      <TrialDetailHeaderSection props={props} onInvite={openInviteModal} />
-      <CleanupInProgressPanel cleanupJobIds={props.cleanupJobIds} />
-      <TrialDetailScenarioControls
+      <TrialDetailHeaderSection
         props={props}
-        showScenarioControls={showScenarioControls}
+        onInvite={openInviteModal}
+        onRevealScenarioWorkbench={() => {
+          const anchor = document.getElementById('trial-scenario-workbench');
+          anchor?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }}
       />
+      {props.planError && !props.generating ? (
+        <div
+          role="alert"
+          className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800"
+        >
+          {props.planError}
+        </div>
+      ) : null}
+      {props.actionError ? (
+        <div
+          role="alert"
+          className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900"
+        >
+          {props.actionError}
+        </div>
+      ) : null}
+      <CleanupInProgressPanel cleanupJobIds={props.cleanupJobIds} />
+      {props.generating || props.jobFailureMessage ? (
+        <TrialDetailPlanPanel props={props} />
+      ) : commandSurfaceFirst ? (
+        <>
+          {tabsBlock}
+          {scenarioBlock}
+        </>
+      ) : (
+        <>
+          {scenarioBlock}
+          {tabsBlock}
+        </>
+      )}
       {props.aiConfig ? (
         <TrialAiOverridesPanel
           trialId={props.trialId}
@@ -33,8 +97,6 @@ export function TrialDetailView(props: TrialDetailViewProps) {
           onSaved={props.reloadPlan}
         />
       ) : null}
-      <TrialDetailPlanPanel props={props} />
-      <TrialDetailCandidatesPanel props={props} onInvite={openInviteModal} />
       <TrialDetailModals props={props} closeInviteModal={closeInviteModal} />
     </div>
   );

--- a/src/features/talent-partner/trial-management/detail/components/TrialInviteModal.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/TrialInviteModal.tsx
@@ -1,12 +1,13 @@
-import { InviteCandidateModal } from '@/features/talent-partner/trial-management/invitations/InviteCandidateModal';
-import type { InviteUiState } from '@/features/talent-partner/trial-management/invitations/InviteCandidateTypes';
+import { InviteCandidatesBatchModal } from '@/features/talent-partner/trial-management/invitations/InviteCandidatesBatchModal';
+import type { InviteBatchUiState } from '@/features/talent-partner/trial-management/invitations/InviteBatchCandidateTypes';
+import type { InviteCandidateRow } from '@/features/talent-partner/trial-management/invitations/InviteBatchCandidateTypes';
 
 type Props = {
   trialId: string;
   open: boolean;
-  inviteFlowState: InviteUiState;
+  inviteFlowState: InviteBatchUiState;
   onClose: () => void;
-  onSubmit: (name: string, email: string) => Promise<void>;
+  onSubmit: (rows: InviteCandidateRow[]) => Promise<void>;
 };
 
 export function TrialInviteModal({
@@ -16,17 +17,15 @@ export function TrialInviteModal({
   onClose,
   onSubmit,
 }: Props) {
-  const state: InviteUiState = inviteFlowState;
-
   return (
-    <InviteCandidateModal
+    <InviteCandidatesBatchModal
       open={open}
       title={`Trial ${trialId}`}
-      state={state}
+      state={inviteFlowState}
       onClose={onClose}
-      onSubmit={onSubmit}
-      initialName=""
-      initialEmail=""
+      onSubmit={(rows) => {
+        void onSubmit(rows);
+      }}
     />
   );
 }

--- a/src/features/talent-partner/trial-management/detail/components/types.ts
+++ b/src/features/talent-partner/trial-management/detail/components/types.ts
@@ -1,7 +1,8 @@
 import type { ScenarioPatchPayload } from '@/features/talent-partner/api/trialLifecycleApi';
 import type { TrialAiConfig } from '@/features/talent-partner/api';
 import type { CandidateSession } from '@/features/talent-partner/types';
-import type { InviteUiState } from '@/features/talent-partner/trial-management/invitations/InviteCandidateTypes';
+import type { InviteBatchUiState } from '@/features/talent-partner/trial-management/invitations/InviteBatchCandidateTypes';
+import type { InviteCandidateRow } from '@/features/talent-partner/trial-management/invitations/InviteBatchCandidateTypes';
 import type { RowState } from '../hooks/useTypes';
 import type { ScenarioEditorDraft } from '../scenario';
 import type { ScenarioVersionItem } from '../scenario/types';
@@ -97,7 +98,7 @@ export type TrialDetailViewProps = {
   cooldownNow: number;
   inviteModalOpen: boolean;
   setInviteModalOpen: (open: boolean) => void;
-  inviteFlowState: InviteUiState;
-  submitInvite: (name: string, email: string) => Promise<void>;
+  inviteFlowState: InviteBatchUiState;
+  submitInvite: (rows: InviteCandidateRow[]) => Promise<void>;
   resetInviteFlow: () => void;
 };

--- a/src/features/talent-partner/trial-management/detail/container/actions/regenerateScenarioAction.ts
+++ b/src/features/talent-partner/trial-management/detail/container/actions/regenerateScenarioAction.ts
@@ -95,6 +95,7 @@ export async function regenerateScenarioAction({
           lockedAt: null,
           contentAvailability: 'local_only',
           storylineMd: null,
+          projectBriefMd: null,
           taskPrompts: null,
           rubric: null,
         },

--- a/src/features/talent-partner/trial-management/detail/container/actions/saveScenarioEdits.ts
+++ b/src/features/talent-partner/trial-management/detail/container/actions/saveScenarioEdits.ts
@@ -56,7 +56,7 @@ export async function saveScenarioEdits({
     if (!result.ok) {
       if (result.statusCode === 409 && result.errorCode === 'SCENARIO_LOCKED') {
         setScenarioLockBannerMessage(
-          'This version is locked because invites exist.',
+          'This version is locked for editing because the Trial is approved for inviting.',
         );
         setScenarioVersionSnapshots((prev) => {
           const current = prev[selectedScenarioVersionId];

--- a/src/features/talent-partner/trial-management/detail/container/actions/submitInviteAction.ts
+++ b/src/features/talent-partner/trial-management/detail/container/actions/submitInviteAction.ts
@@ -1,23 +1,22 @@
 import type { Dispatch, SetStateAction } from 'react';
 import type { ToastInput } from '@/shared/notifications/types';
+import type { InviteCandidateRow } from '@/features/talent-partner/trial-management/invitations/InviteBatchCandidateTypes';
 
 type NotifyFn = (payload: ToastInput) => void;
 
 type SubmitInviteArgs = {
-  candidateName: string;
-  inviteEmail: string;
+  rows: InviteCandidateRow[];
   isTerminated: boolean;
   inviteDisabledReason: string | null;
   trialId: string;
   setActionError: Dispatch<SetStateAction<string | null>>;
   closeInviteModal: () => void;
   notify: NotifyFn;
-  submitInvite: (candidateName: string, inviteEmail: string) => Promise<void>;
+  submitInvite: (rows: InviteCandidateRow[]) => Promise<void>;
 };
 
 export async function submitInviteAction({
-  candidateName,
-  inviteEmail,
+  rows,
   isTerminated,
   inviteDisabledReason,
   trialId,
@@ -29,7 +28,7 @@ export async function submitInviteAction({
   if (isTerminated) {
     const message =
       inviteDisabledReason ??
-      'This trial has been terminated. Invites are disabled immediately.';
+      'This Trial has been terminated. Invites are disabled immediately.';
     setActionError(message);
     notify({
       id: `invite-disabled-${trialId}`,
@@ -40,5 +39,5 @@ export async function submitInviteAction({
     closeInviteModal();
     return;
   }
-  await submitInvite(candidateName, inviteEmail);
+  await submitInvite(rows);
 }

--- a/src/features/talent-partner/trial-management/detail/container/buildTrialDetailCandidateProps.ts
+++ b/src/features/talent-partner/trial-management/detail/container/buildTrialDetailCandidateProps.ts
@@ -1,3 +1,4 @@
+import type { InviteCandidateRow } from '@/features/talent-partner/trial-management/invitations/InviteBatchCandidateTypes';
 import type { useTrialDetailCandidates } from './hooks/useTrialDetailCandidates';
 
 type BuildCandidatePropsArgs = {
@@ -6,7 +7,7 @@ type BuildCandidatePropsArgs = {
   inviteResendEnabled: boolean;
   inviteResendDisabledReason: string | null;
   candidatesModel: ReturnType<typeof useTrialDetailCandidates>;
-  onSubmitInvite: (name: string, email: string) => Promise<void>;
+  onSubmitInvite: (rows: InviteCandidateRow[]) => Promise<void>;
 };
 
 export function buildTrialDetailCandidateProps({

--- a/src/features/talent-partner/trial-management/detail/container/buildTrialDetailViewProps.ts
+++ b/src/features/talent-partner/trial-management/detail/container/buildTrialDetailViewProps.ts
@@ -1,4 +1,5 @@
 import type { TrialAiConfig } from '@/features/talent-partner/api';
+import type { InviteCandidateRow } from '@/features/talent-partner/trial-management/invitations/InviteBatchCandidateTypes';
 import type { TrialDetailViewProps } from '../components/types';
 import type { useTrialLabels } from '../hooks/useTrialLabels';
 import type { useTrialDetailCandidates } from './hooks/useTrialDetailCandidates';
@@ -34,7 +35,7 @@ type BuildTrialDetailViewPropsArgs = {
   activateLoading: boolean;
   onActivate: () => Promise<void>;
   candidatesModel: ReturnType<typeof useTrialDetailCandidates>;
-  onSubmitInvite: (name: string, email: string) => Promise<void>;
+  onSubmitInvite: (rows: InviteCandidateRow[]) => Promise<void>;
 };
 
 export function buildTrialDetailViewProps({

--- a/src/features/talent-partner/trial-management/detail/container/hooks/useDeriveScenarioVersionViewFields.ts
+++ b/src/features/talent-partner/trial-management/detail/container/hooks/useDeriveScenarioVersionViewFields.ts
@@ -109,7 +109,9 @@ export function deriveScenarioVersionViewFields({
     effectiveLockBannerMessage:
       scenarioLockBannerMessage ??
       (selectedScenarioVersion?.isLocked
-        ? 'This version is locked because invites exist.'
+        ? trialStatus === 'active_inviting'
+          ? 'This scenario version is frozen while this Trial is active for inviting.'
+          : 'This scenario version is locked.'
         : null),
   };
 }

--- a/src/features/talent-partner/trial-management/detail/container/hooks/useScenarioVersionDerived.ts
+++ b/src/features/talent-partner/trial-management/detail/container/hooks/useScenarioVersionDerived.ts
@@ -39,7 +39,7 @@ export function scenarioEditorDisabledReason(
     return 'This version cannot be edited because canonical scenario content is unavailable.';
   }
   if (selectedScenarioVersion.isLocked) {
-    return 'This version is locked because invites exist.';
+    return 'This scenario version is locked for editing in the current trial state.';
   }
   if (trialStatus !== 'ready_for_review' && trialStatus !== 'active_inviting') {
     return 'Scenario editing is unavailable in the current trial status.';

--- a/src/features/talent-partner/trial-management/detail/container/hooks/useSubmitInviteCallback.ts
+++ b/src/features/talent-partner/trial-management/detail/container/hooks/useSubmitInviteCallback.ts
@@ -1,5 +1,6 @@
 import { useCallback, type Dispatch, type SetStateAction } from 'react';
 import type { ToastInput } from '@/shared/notifications/types';
+import type { InviteCandidateRow } from '@/features/talent-partner/trial-management/invitations/InviteBatchCandidateTypes';
 import { submitInviteAction } from '../actions/submitInviteAction';
 
 type NotifyFn = (payload: ToastInput) => void;
@@ -9,7 +10,7 @@ type UseSubmitInviteCallbackArgs = {
   isTerminated: boolean;
   inviteDisabledReason: string | null;
   closeInviteModal: () => void;
-  submitInvite: (candidateName: string, inviteEmail: string) => Promise<void>;
+  submitInvite: (rows: InviteCandidateRow[]) => Promise<void>;
   notify: NotifyFn;
   setActionError: Dispatch<SetStateAction<string | null>>;
 };
@@ -24,10 +25,9 @@ export function useSubmitInviteCallback({
   setActionError,
 }: UseSubmitInviteCallbackArgs) {
   return useCallback(
-    async (candidateName: string, inviteEmail: string) => {
+    async (rows: InviteCandidateRow[]) => {
       await submitInviteAction({
-        candidateName,
-        inviteEmail,
+        rows,
         isTerminated,
         inviteDisabledReason,
         trialId,

--- a/src/features/talent-partner/trial-management/detail/container/hooks/useSyncScenarioVersionSnapshots.ts
+++ b/src/features/talent-partner/trial-management/detail/container/hooks/useSyncScenarioVersionSnapshots.ts
@@ -35,6 +35,7 @@ export function syncScenarioVersionSnapshots({
       lockedAt: version.lockedAt,
       contentAvailability: version.contentAvailability,
       storylineMd: current?.storylineMd ?? null,
+      projectBriefMd: current?.projectBriefMd ?? null,
       taskPrompts: current?.taskPrompts ?? null,
       rubric: current?.rubric ?? null,
     });
@@ -75,6 +76,7 @@ export function syncScenarioVersionSnapshots({
         ? 'local_only'
         : 'unavailable',
     storylineMd: next[pendingId]?.storylineMd ?? null,
+    projectBriefMd: next[pendingId]?.projectBriefMd ?? null,
     taskPrompts: next[pendingId]?.taskPrompts ?? null,
     rubric: next[pendingId]?.rubric ?? null,
   });

--- a/src/features/talent-partner/trial-management/detail/container/hooks/useTrialDetailCallbacks.ts
+++ b/src/features/talent-partner/trial-management/detail/container/hooks/useTrialDetailCallbacks.ts
@@ -1,5 +1,6 @@
 import { useState, type Dispatch, type SetStateAction } from 'react';
 import type { ToastInput } from '@/shared/notifications/types';
+import type { InviteCandidateRow } from '@/features/talent-partner/trial-management/invitations/InviteBatchCandidateTypes';
 import { logTrialDetailEvent } from '../../utils/eventsUtils';
 import { activateTrialAction } from '../actions/activateTrialAction';
 import { useSubmitInviteCallback } from './useSubmitInviteCallback';
@@ -20,7 +21,7 @@ type UseTrialDetailCallbacksArgs = {
   isTerminated: boolean;
   inviteDisabledReason: string | null;
   closeInviteModal: () => void;
-  submitInvite: (candidateName: string, inviteEmail: string) => Promise<void>;
+  submitInvite: (rows: InviteCandidateRow[]) => Promise<void>;
   notify: NotifyFn;
   setActionError: Dispatch<SetStateAction<string | null>>;
   setTerminatePending: Dispatch<SetStateAction<boolean>>;
@@ -55,7 +56,7 @@ export function useTrialDetailCallbacks({
   const approveButtonLabel = hasSelectedScenarioVersion
     ? `Approve ${selectedScenarioVersionText}`
     : 'Approve';
-  const activateButtonLabel = 'Activate trial';
+  const activateButtonLabel = 'Approve & Invite Candidates';
   const [activateLoading, setActivateLoading] = useState(false);
 
   const onSubmitInvite = useSubmitInviteCallback({

--- a/src/features/talent-partner/trial-management/detail/container/hooks/useTrialDetailState.ts
+++ b/src/features/talent-partner/trial-management/detail/container/hooks/useTrialDetailState.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 type UseTrialDetailStateArgs = {
   trialId: string;
@@ -25,8 +25,13 @@ export function useTrialDetailState({
   >(null);
   const [statusOverride, setStatusOverride] = useState<string | null>(null);
   const [cleanupJobIds, setCleanupJobIds] = useState<string[]>([]);
+  const skipInitialResetRef = useRef(true);
 
   useEffect(() => {
+    if (skipInitialResetRef.current) {
+      skipInitialResetRef.current = false;
+      return;
+    }
     const timerId = window.setTimeout(() => {
       setActionError(null);
       setTerminatePending(false);

--- a/src/features/talent-partner/trial-management/detail/container/scenarioSnapshotData.ts
+++ b/src/features/talent-partner/trial-management/detail/container/scenarioSnapshotData.ts
@@ -55,6 +55,7 @@ export function toScenarioSnapshotFromDetail({
     lockedAt: detail.scenarioVersion.lockedAt,
     contentAvailability: detail.scenarioVersion.contentAvailability,
     storylineMd: detail.storyline,
+    projectBriefMd: detail.projectBrief,
     taskPrompts:
       normalizeTaskPrompts(detail.taskPromptsJson) ?? fallbackTaskPrompts,
     rubric: normalizeRubricObject(detail.rubricJson),

--- a/src/features/talent-partner/trial-management/detail/container/scenarioSnapshotVersion.ts
+++ b/src/features/talent-partner/trial-management/detail/container/scenarioSnapshotVersion.ts
@@ -28,6 +28,7 @@ export function mergeScenarioSnapshot(
       incoming.contentAvailability,
     ),
     storylineMd: incoming.storylineMd ?? current.storylineMd,
+    projectBriefMd: incoming.projectBriefMd ?? current.projectBriefMd,
     taskPrompts: incoming.taskPrompts ?? current.taskPrompts,
     rubric: incoming.rubric ?? current.rubric,
   };

--- a/src/features/talent-partner/trial-management/detail/container/types.ts
+++ b/src/features/talent-partner/trial-management/detail/container/types.ts
@@ -12,6 +12,7 @@ export type ScenarioVersionSnapshot = {
   lockedAt: string | null;
   contentAvailability: ScenarioContentAvailability;
   storylineMd: string | null;
+  projectBriefMd: string | null;
   taskPrompts: Array<Record<string, unknown>> | null;
   rubric: Record<string, unknown> | null;
 };

--- a/src/features/talent-partner/trial-management/detail/hooks/useInviteSubmit.ts
+++ b/src/features/talent-partner/trial-management/detail/hooks/useInviteSubmit.ts
@@ -1,47 +1,25 @@
 import { useCallback, type Dispatch, type SetStateAction } from 'react';
-import { useInviteToasts } from '@/features/talent-partner/trial-management/invitations/useInviteToasts';
-import type {
-  CandidateSession,
-  InviteSuccess,
-} from '@/features/talent-partner/types';
-import type { InviteUiState } from '@/features/talent-partner/trial-management/invitations/InviteCandidateTypes';
-import {
-  buildInviteModalState,
-  findInvitedCandidate,
-} from './inviteCandidateReconciliation';
+import type { CandidateSession } from '@/features/talent-partner/types';
+import type { InviteBatchUiState } from '@/features/talent-partner/trial-management/invitations/InviteBatchCandidateTypes';
+import type { InviteCandidateRow } from '@/features/talent-partner/trial-management/invitations/InviteBatchCandidateTypes';
 
 type InviteFlow = {
-  submit: (name: string, email: string) => Promise<InviteSuccess | null>;
-  setState: Dispatch<SetStateAction<InviteUiState>>;
+  submit: (rows: InviteCandidateRow[]) => Promise<boolean>;
+  setState: Dispatch<SetStateAction<InviteBatchUiState>>;
 };
 
 type Params = {
-  trialId: string;
   inviteFlow: InviteFlow;
   reload: () => Promise<CandidateSession[]>;
 };
 
-export function useInviteSubmit({ trialId, inviteFlow, reload }: Params) {
-  const { showInviteToast } = useInviteToasts();
-
+export function useInviteSubmit({ inviteFlow, reload }: Params) {
   return useCallback(
-    async (candidateName: string, inviteEmail: string) => {
-      const res = await inviteFlow.submit(candidateName, inviteEmail);
-      if (!res) return;
-      inviteFlow.setState({ status: 'loading' });
-      const candidates = await reload().catch(() => [] as CandidateSession[]);
-      const candidate = findInvitedCandidate(candidates, res);
-      const finalState = buildInviteModalState({ invite: res, candidate });
-      inviteFlow.setState(finalState);
-      if (finalState.status === 'success') {
-        showInviteToast({
-          ...res,
-          trialId,
-          candidateName,
-          candidateEmail: inviteEmail,
-        });
-      }
+    async (rows: InviteCandidateRow[]) => {
+      const ok = await inviteFlow.submit(rows);
+      if (!ok) return;
+      await reload().catch(() => [] as CandidateSession[]);
     },
-    [inviteFlow, reload, showInviteToast, trialId],
+    [inviteFlow, reload],
   );
 }

--- a/src/features/talent-partner/trial-management/detail/hooks/useTrialInviteModal.ts
+++ b/src/features/talent-partner/trial-management/detail/hooks/useTrialInviteModal.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { useInviteCandidateFlow } from '@/features/talent-partner/dashboard/hooks/useInviteCandidateFlow';
+import { useInviteBatchCandidateFlow } from '@/features/talent-partner/dashboard/hooks/useInviteBatchCandidateFlow';
 import { useInviteSubmit } from './useInviteSubmit';
 import type { CandidateSession } from '@/features/talent-partner/types';
 
@@ -11,7 +11,7 @@ type Params = {
 export function useTrialInviteModal({ trialId, reloadCandidates }: Params) {
   const [open, setOpen] = useState(false);
 
-  const inviteFlow = useInviteCandidateFlow(
+  const inviteFlow = useInviteBatchCandidateFlow(
     open
       ? {
           open: true,
@@ -27,7 +27,6 @@ export function useTrialInviteModal({ trialId, reloadCandidates }: Params) {
   }, [inviteFlow]);
 
   const submitInvite = useInviteSubmit({
-    trialId,
     inviteFlow,
     reload: reloadCandidates,
   });

--- a/src/features/talent-partner/trial-management/detail/scenario/RegenerateScenarioButton.tsx
+++ b/src/features/talent-partner/trial-management/detail/scenario/RegenerateScenarioButton.tsx
@@ -8,6 +8,7 @@ type Props = {
   disabled?: boolean;
   currentVersionLabel: string;
   onConfirm: () => void;
+  appearance?: 'toolbar' | 'menu';
 };
 
 export function RegenerateScenarioButton({
@@ -15,6 +16,7 @@ export function RegenerateScenarioButton({
   disabled,
   currentVersionLabel,
   onConfirm,
+  appearance = 'toolbar',
 }: Props) {
   const [open, setOpen] = useState(false);
 
@@ -36,11 +38,17 @@ export function RegenerateScenarioButton({
   return (
     <>
       <Button
+        data-testid="regenerate-scenario-trigger"
         onClick={openModal}
         size="sm"
         variant="secondary"
         loading={loading}
         disabled={disabled}
+        className={
+          appearance === 'menu'
+            ? 'block w-full rounded-none border-0 bg-transparent px-3 py-2 text-left text-sm font-normal text-primary shadow-none hover:bg-muted/30'
+            : undefined
+        }
       >
         Regenerate scenario
       </Button>

--- a/src/features/talent-partner/trial-management/detail/scenario/ScenarioLockBanner.tsx
+++ b/src/features/talent-partner/trial-management/detail/scenario/ScenarioLockBanner.tsx
@@ -5,7 +5,7 @@ type Props = {
 };
 
 export function ScenarioLockBanner({
-  message = 'This version is locked because invites exist.',
+  message = 'This version is locked for editing because the Trial is approved for inviting.',
 }: Props) {
   return (
     <div className="rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">

--- a/src/features/talent-partner/trial-management/detail/scenario/types.ts
+++ b/src/features/talent-partner/trial-management/detail/scenario/types.ts
@@ -17,6 +17,7 @@ export type ScenarioVersionItem = {
   isPending: boolean;
   contentAvailability: ScenarioContentAvailability;
   storylineMd: string | null;
+  projectBriefMd: string | null;
   taskPrompts: Array<Record<string, unknown>> | null;
   rubric: Record<string, unknown> | null;
 };

--- a/src/features/talent-partner/trial-management/detail/utils/detail/contentUtils.ts
+++ b/src/features/talent-partner/trial-management/detail/utils/detail/contentUtils.ts
@@ -28,6 +28,28 @@ export function readCompanyContext(value: unknown): string | null {
   return bits.length ? bits.join(' · ') : null;
 }
 
+export function readProjectBrief(
+  raw: Record<string, unknown>,
+  scenario: Record<string, unknown> | null,
+): string | null {
+  const top = toStringOrNull(
+    raw.projectBrief ??
+      raw.projectBriefMd ??
+      raw.project_brief_md ??
+      raw.projectBriefMarkdown ??
+      raw.project_brief_markdown,
+  );
+  if (top) return top;
+  if (!scenario) return null;
+  return toStringOrNull(
+    scenario.projectBrief ??
+      scenario.projectBriefMd ??
+      scenario.project_brief_md ??
+      scenario.projectBriefMarkdown ??
+      scenario.project_brief_markdown,
+  );
+}
+
 export function readStoryline(
   raw: Record<string, unknown>,
   scenario: Record<string, unknown> | null,

--- a/src/features/talent-partner/trial-management/detail/utils/detail/normalizePreviewUtils.ts
+++ b/src/features/talent-partner/trial-management/detail/utils/detail/normalizePreviewUtils.ts
@@ -5,6 +5,7 @@ import { normalizeTrialPlan } from '../plan';
 import {
   readCompanyContext,
   readNotes,
+  readProjectBrief,
   readRubricJson,
   readRubricSummary,
   readStoryline,
@@ -86,6 +87,7 @@ export function normalizeTrialDetailPreview(raw: unknown): TrialDetailPreview {
     scenarioVersions: versions,
     scenarioVersion,
     storyline: readStoryline(record, scenario, plan),
+    projectBrief: readProjectBrief(record, scenario),
     taskPromptsJson: readTaskPromptsJson(record, scenario),
     rubricJson: readRubricJson(record, scenario),
     notes: readNotes(record, scenario),

--- a/src/features/talent-partner/trial-management/detail/utils/detail/parsersUtils.ts
+++ b/src/features/talent-partner/trial-management/detail/utils/detail/parsersUtils.ts
@@ -60,6 +60,8 @@ export function hasCanonicalScenarioContent(
 ): boolean {
   if (!record) return false;
   return (
+    Object.prototype.hasOwnProperty.call(record, 'projectBriefMd') ||
+    Object.prototype.hasOwnProperty.call(record, 'project_brief_md') ||
     Object.prototype.hasOwnProperty.call(record, 'storylineMd') ||
     Object.prototype.hasOwnProperty.call(record, 'storyline_md') ||
     Object.prototype.hasOwnProperty.call(record, 'storyline') ||

--- a/src/features/talent-partner/trial-management/detail/utils/detail/previewStateUtils.ts
+++ b/src/features/talent-partner/trial-management/detail/utils/detail/previewStateUtils.ts
@@ -21,7 +21,8 @@ export function isPreviewGenerating(
 export function isPreviewEmpty(detail: TrialDetailPreview | null): boolean {
   if (!detail) return true;
   const hasStoryline = Boolean(detail.storyline?.trim());
+  const hasProjectBrief = Boolean(detail.projectBrief?.trim());
   const hasRubricSummary = Boolean(detail.rubricSummary?.trim());
   const hasTasks = Boolean(detail.plan?.days?.length);
-  return !hasStoryline && !hasRubricSummary && !hasTasks;
+  return !hasStoryline && !hasProjectBrief && !hasRubricSummary && !hasTasks;
 }

--- a/src/features/talent-partner/trial-management/detail/utils/detail/typesUtils.ts
+++ b/src/features/talent-partner/trial-management/detail/utils/detail/typesUtils.ts
@@ -41,6 +41,7 @@ export type TrialDetailPreview = {
   scenarioVersions: TrialScenarioVersion[];
   scenarioVersion: TrialScenarioVersion;
   storyline: string | null;
+  projectBrief: string | null;
   taskPromptsJson: unknown;
   rubricJson: unknown;
   notes: string | null;

--- a/src/features/talent-partner/trial-management/invitations/InviteBatchCandidateTypes.ts
+++ b/src/features/talent-partner/trial-management/invitations/InviteBatchCandidateTypes.ts
@@ -1,0 +1,13 @@
+import type { TrialInviteResultItem } from '@/features/talent-partner/api/invitesBatchApi';
+
+export type InviteCandidateRow = { name: string; email: string };
+
+export type InviteBatchUiState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | {
+      status: 'success';
+      message: string;
+      invites: TrialInviteResultItem[];
+    };

--- a/src/features/talent-partner/trial-management/invitations/InviteCandidateModal.tsx
+++ b/src/features/talent-partner/trial-management/invitations/InviteCandidateModal.tsx
@@ -39,7 +39,7 @@ export function InviteCandidateModal({
       <div className="relative w-full max-w-lg rounded-lg bg-white p-6 shadow-lg">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h3 className="text-lg font-semibold">Invite candidate</h3>
+            <h3 className="text-lg font-semibold">Invite candidates</h3>
             <p className="mt-1 text-sm text-gray-600">{title}</p>
           </div>
           <button

--- a/src/features/talent-partner/trial-management/invitations/InviteCandidatesBatchModal.tsx
+++ b/src/features/talent-partner/trial-management/invitations/InviteCandidatesBatchModal.tsx
@@ -1,0 +1,331 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Button from '@/shared/ui/Button';
+import { InviteInputField } from './InviteInputField';
+import type { InviteBatchUiState } from './InviteBatchCandidateTypes';
+import type { InviteCandidateRow } from './InviteBatchCandidateTypes';
+import { copyInviteLink } from '@/features/talent-partner/utils/formattersUtils';
+
+export function formatInviteBatchFailureMessage(raw: string): string {
+  const m = raw.trim();
+  if (!m) return m;
+  if (/api\.github\.com/i.test(m) || /GitHub API error/i.test(m)) {
+    return 'We could not finish preparing this candidate workspace. The invite was not sent. Please try again, or check the GitHub workspace configuration.';
+  }
+  if (
+    /sqlalchemy|asyncpg|ProgrammingError|UndefinedColumn|UndefinedTable/i.test(
+      m,
+    ) ||
+    /\[SQL:/i.test(m)
+  ) {
+    return 'Something went wrong on our side while preparing this invite. Please try again in a moment. If this keeps happening, contact support.';
+  }
+  return m;
+}
+
+type Props = {
+  open: boolean;
+  title: string;
+  state: InviteBatchUiState;
+  onClose: () => void;
+  onSubmit: (rows: InviteCandidateRow[]) => void;
+};
+
+export function InviteCandidatesBatchModal({
+  open,
+  title,
+  state,
+  onClose,
+  onSubmit,
+}: Props) {
+  const [rows, setRows] = useState<InviteCandidateRow[]>([
+    { name: '', email: '' },
+  ]);
+
+  const validation = useMemo(() => {
+    const errors: Record<number, { name?: string; email?: string }> = {};
+    const emails = new Set<string>();
+    rows.forEach((row, idx) => {
+      const name = row.name.trim();
+      const email = row.email.trim().toLowerCase();
+      if (!name)
+        errors[idx] = { ...errors[idx], name: 'Full name is required.' };
+      if (!email) {
+        errors[idx] = { ...errors[idx], email: 'Email is required.' };
+      } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+        errors[idx] = { ...errors[idx], email: 'Enter a valid email address.' };
+      } else if (emails.has(email)) {
+        errors[idx] = {
+          ...errors[idx],
+          email: 'Duplicate email in this list.',
+        };
+      } else {
+        emails.add(email);
+      }
+    });
+    return { errors, ok: Object.keys(errors).length === 0 };
+  }, [rows]);
+
+  if (!open) return null;
+
+  const disabled = state.status === 'loading';
+  const submitDisabled =
+    disabled ||
+    !validation.ok ||
+    rows.every((r) => !r.name.trim() && !r.email.trim());
+
+  const addRow = () => setRows((prev) => [...prev, { name: '', email: '' }]);
+
+  const updateRow = (index: number, patch: Partial<InviteCandidateRow>) => {
+    setRows((prev) =>
+      prev.map((row, i) => (i === index ? { ...row, ...patch } : row)),
+    );
+  };
+
+  if (state.status === 'success') {
+    const sent = state.invites.filter((i) => i.status !== 'failed');
+    const failed = state.invites.filter((i) => i.status === 'failed');
+    return (
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center"
+        role="dialog"
+        aria-modal="true"
+        data-testid="invite-batch-success"
+        aria-labelledby="invite-batch-success-title"
+      >
+        <div
+          className="absolute inset-0 bg-black/30"
+          onClick={onClose}
+          aria-hidden="true"
+        />
+        <div
+          className="relative max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-lg border border-subtle bg-elevated p-6 shadow-lg"
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h3
+                id="invite-batch-success-title"
+                className="text-lg font-semibold text-primary"
+              >
+                Invite results
+              </h3>
+              <p className="mt-1 text-sm text-secondary">{title}</p>
+            </div>
+            <button
+              type="button"
+              className="rounded p-2 text-secondary hover:bg-secondary"
+              onClick={onClose}
+              aria-label="Close invite results"
+            >
+              ✕
+            </button>
+          </div>
+          <p className="mt-4 text-sm text-secondary" aria-live="polite">
+            {state.message}
+          </p>
+          {sent.length ? (
+            <ul className="mt-4 space-y-3" aria-label="Successful invites">
+              {sent.map((inv, idx) => (
+                <li
+                  key={`${inv.email}-ok-${idx}`}
+                  className="rounded border border-subtle p-3 text-sm"
+                >
+                  <div className="font-medium text-primary">{inv.name}</div>
+                  <div className="text-secondary">{inv.email}</div>
+                  {inv.workspaceProvisioningNotice ? (
+                    <p
+                      className="mt-2 text-xs text-amber-900"
+                      data-testid="invite-workspace-provisioning-notice"
+                    >
+                      {inv.workspaceProvisioningNotice}
+                    </p>
+                  ) : null}
+                  <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
+                    <input
+                      className="min-w-0 flex-1 rounded border border-subtle bg-secondary px-2 py-1 font-mono text-xs text-primary"
+                      readOnly
+                      value={inv.inviteUrl}
+                      aria-label={`Invite URL for ${inv.email}`}
+                      onFocus={(e) => e.currentTarget.select()}
+                    />
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => void copyInviteLink(inv.inviteUrl)}
+                    >
+                      Copy
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          {failed.length ? (
+            <div className="mt-6" role="region" aria-label="Failed invites">
+              <h4 className="text-sm font-semibold text-primary">
+                Could not send ({failed.length})
+              </h4>
+              <ul className="mt-2 space-y-2">
+                {failed.map((inv, idx) => (
+                  <li
+                    key={`${inv.email}-fail-${idx}`}
+                    className="rounded border border-subtle bg-secondary p-3 text-sm"
+                  >
+                    <div className="font-medium text-primary">{inv.name}</div>
+                    <div className="text-secondary">{inv.email}</div>
+                    {inv.errorMessage ? (
+                      <p
+                        className="mt-2 text-xs text-secondary"
+                        id={`invite-fail-msg-${idx}`}
+                      >
+                        {formatInviteBatchFailureMessage(inv.errorMessage)}
+                      </p>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+          <div className="mt-6 flex justify-end">
+            <Button type="button" onClick={onClose}>
+              Done
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="invite-batch-form-title"
+    >
+      <div
+        className="absolute inset-0 bg-black/30"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        className="relative max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-lg border border-subtle bg-elevated p-6 shadow-lg"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3
+              id="invite-batch-form-title"
+              className="text-lg font-semibold text-primary"
+            >
+              Invite candidates
+            </h3>
+            <p className="mt-1 text-sm text-secondary">{title}</p>
+          </div>
+          <button
+            type="button"
+            className="rounded p-2 text-secondary hover:bg-secondary"
+            onClick={onClose}
+            aria-label="Close invite form"
+          >
+            ✕
+          </button>
+        </div>
+
+        <form
+          className="mt-4 space-y-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (!submitDisabled) onSubmit(rows);
+          }}
+        >
+          {rows.map((row, idx) => (
+            <fieldset
+              key={idx}
+              className="grid gap-3 border-b border-subtle pb-4 sm:grid-cols-2"
+              aria-labelledby={`invite-row-legend-${idx}`}
+            >
+              <legend
+                id={`invite-row-legend-${idx}`}
+                className="sr-only sm:col-span-2"
+              >
+                Candidate row {idx + 1}
+              </legend>
+              <InviteInputField
+                id={`invite-name-${idx}`}
+                label={`Full name (row ${idx + 1})`}
+                value={row.name}
+                onChange={(v) => updateRow(idx, { name: v })}
+                placeholder="Jordan Smith"
+                disabled={disabled}
+              />
+              <InviteInputField
+                id={`invite-email-${idx}`}
+                label={`Email (row ${idx + 1})`}
+                value={row.email}
+                onChange={(v) => updateRow(idx, { email: v })}
+                placeholder="jordan@example.com"
+                disabled={disabled}
+              />
+              {validation.errors[idx]?.name ? (
+                <p
+                  className="text-xs text-secondary sm:col-span-2"
+                  role="alert"
+                  id={`invite-name-err-${idx}`}
+                >
+                  {validation.errors[idx]?.name}
+                </p>
+              ) : null}
+              {validation.errors[idx]?.email ? (
+                <p
+                  className="text-xs text-secondary sm:col-span-2"
+                  role="alert"
+                  id={`invite-email-err-${idx}`}
+                >
+                  {validation.errors[idx]?.email}
+                </p>
+              ) : null}
+            </fieldset>
+          ))}
+
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={addRow}
+            disabled={disabled}
+          >
+            + Add another candidate
+          </Button>
+
+          {state.status === 'error' ? (
+            <div
+              className="rounded border border-subtle bg-secondary p-3 text-sm text-secondary"
+              role="alert"
+            >
+              {state.message}
+            </div>
+          ) : null}
+
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={onClose}
+              disabled={disabled}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" loading={disabled} disabled={submitDisabled}>
+              {rows.filter((r) => r.name.trim() && r.email.trim()).length > 1
+                ? `Send ${rows.filter((r) => r.name.trim() && r.email.trim()).length} invites`
+                : 'Send invite'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/features/talent-partner/trial-management/invitations/InviteInputField.tsx
+++ b/src/features/talent-partner/trial-management/invitations/InviteInputField.tsx
@@ -18,11 +18,11 @@ export function InviteInputField({
   onChange,
 }: Props) {
   return (
-    <label className="block text-xs font-medium uppercase tracking-wide text-gray-500">
+    <label className="block text-xs font-medium uppercase tracking-wide text-secondary">
       {label}
       <input
         id={id}
-        className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+        className="mt-1 w-full rounded border border-subtle bg-secondary px-3 py-2 text-sm text-primary placeholder:text-secondary"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}

--- a/src/features/talent-partner/trial-management/list/TrialListRow.tsx
+++ b/src/features/talent-partner/trial-management/list/TrialListRow.tsx
@@ -49,7 +49,7 @@ export function TrialListRow({ trial, onInvite, onPrefetch }: Props) {
         </div>
 
         <div className="col-span-2 flex justify-end">
-          <Button onClick={() => onInvite(trial)}>Invite candidate</Button>
+          <Button onClick={() => onInvite(trial)}>Invite candidates</Button>
         </div>
       </div>
     </div>

--- a/src/features/talent-partner/trial-management/preview/EvaluationRubricTable.tsx
+++ b/src/features/talent-partner/trial-management/preview/EvaluationRubricTable.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import type { RubricRow } from './rubricMapper';
+
+type Props = {
+  rows: RubricRow[];
+};
+
+export function EvaluationRubricTable({ rows }: Props) {
+  if (!rows.length) {
+    return (
+      <p className="text-sm text-secondary">
+        No rubric dimensions were returned for this Trial yet.
+      </p>
+    );
+  }
+  return (
+    <div className="overflow-x-auto rounded-lg border border-subtle">
+      <table className="min-w-full divide-y divide-subtle text-sm">
+        <thead className="bg-secondary">
+          <tr>
+            <th className="px-4 py-3 text-left font-semibold text-primary">
+              Dimension
+            </th>
+            <th className="px-4 py-3 text-left font-semibold text-primary">
+              What Winoe will look for
+            </th>
+            <th className="px-4 py-3 text-left font-semibold text-primary">
+              Weight
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-subtle bg-elevated">
+          {rows.map((row, i) => (
+            <tr key={`${row.dimension}-${i}`}>
+              <td className="px-4 py-3 font-medium text-primary">
+                {row.dimension}
+              </td>
+              <td className="px-4 py-3 text-secondary">
+                {row.whatWinoeWillLookFor}
+              </td>
+              <td className="px-4 py-3 text-secondary">
+                {row.weightLabel ?? '—'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/features/talent-partner/trial-management/preview/TrialPreviewContent.tsx
+++ b/src/features/talent-partner/trial-management/preview/TrialPreviewContent.tsx
@@ -1,0 +1,438 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useCallback, useMemo, useState } from 'react';
+import {
+  approveTrialForInviting,
+  regenerateTrialScenario,
+  terminateTrial,
+} from '@/features/talent-partner/api/trialLifecycleApi';
+import { useTrialPlan } from '@/features/talent-partner/trial-management/detail/hooks/useTrialPlan';
+import {
+  isPreviewGenerating,
+  isPreviewEmpty,
+} from '@/features/talent-partner/trial-management/detail/utils/detailUtils';
+import { mapRubricJsonToRows } from '@/features/talent-partner/trial-management/preview/rubricMapper';
+import { EvaluationRubricTable } from '@/features/talent-partner/trial-management/preview/EvaluationRubricTable';
+import { useNotifications } from '@/shared/notifications';
+import Button from '@/shared/ui/Button';
+import { MarkdownRenderer } from '@/shared/ui/MarkdownRenderer';
+
+const DEFAULT_CADENCE: { day: number; title: string; fallback: string }[] = [
+  { day: 1, title: 'Day 1 — Design Doc', fallback: 'Design Doc' },
+  {
+    day: 2,
+    title: 'Day 2 — Implementation Kickoff',
+    fallback: 'Implementation Kickoff',
+  },
+  {
+    day: 3,
+    title: 'Day 3 — Implementation Wrap-Up',
+    fallback: 'Implementation Wrap-Up',
+  },
+  { day: 4, title: 'Day 4 — Handoff + Demo', fallback: 'Handoff + Demo' },
+  { day: 5, title: 'Day 5 — Reflection Essay', fallback: 'Reflection Essay' },
+];
+
+function DiscardDraftModal({
+  open,
+  pending,
+  onClose,
+  onConfirm,
+}: {
+  open: boolean;
+  pending: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      data-testid="discard-draft-modal"
+    >
+      <div className="w-full max-w-lg rounded-lg border border-subtle bg-elevated p-6 shadow-lg">
+        <h2 className="text-lg font-semibold text-primary">Discard draft</h2>
+        <p className="mt-2 text-sm text-secondary">
+          This ends the Trial as terminated. It will no longer appear in your
+          active Trial list and candidates cannot be invited. This action cannot
+          be undone.
+        </p>
+        <div className="mt-6 flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={onClose}
+            disabled={pending}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            className="border-red-700 bg-red-600 text-white hover:bg-red-700"
+            onClick={onConfirm}
+            loading={pending}
+            disabled={pending}
+          >
+            Discard
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type Props = { trialId: string };
+
+export function TrialPreviewContent({ trialId }: Props) {
+  const router = useRouter();
+  const { notify } = useNotifications();
+  const { detail, plan, loading, error, statusCode, isGenerating, reload } =
+    useTrialPlan({ trialId });
+  const [approvePending, setApprovePending] = useState(false);
+  const [regenPending, setRegenPending] = useState(false);
+  const [discardOpen, setDiscardOpen] = useState(false);
+  const [discardPending, setDiscardPending] = useState(false);
+
+  const generating = isGenerating || isPreviewGenerating(detail);
+  const empty = isPreviewEmpty(detail);
+  const projectBriefMd =
+    (detail?.projectBrief ?? '').trim() || (detail?.storyline ?? '').trim();
+  const briefMissing =
+    !(detail?.projectBrief ?? '').trim() && Boolean(detail?.storyline ?? '');
+  const rubricRows = useMemo(
+    () => mapRubricJsonToRows(detail?.rubricJson),
+    [detail?.rubricJson],
+  );
+  const role = plan?.role?.trim() || 'Role';
+  const stackRaw = plan?.preferredLanguageFramework?.trim();
+  const stackLabel = stackRaw && stackRaw.length > 0 ? stackRaw : 'Any stack';
+  const seniority = detail?.level?.trim() || '—';
+  const pendingScenarioVersionId = detail?.pendingScenarioVersionId ?? null;
+  const approveBlocked = Boolean(pendingScenarioVersionId);
+
+  const handleApprove = useCallback(async () => {
+    setApprovePending(true);
+    try {
+      const res = await approveTrialForInviting(trialId);
+      if (!res.ok) {
+        const isScenarioPending = res.errorCode === 'SCENARIO_APPROVAL_PENDING';
+        notify({
+          id: `approve-${trialId}`,
+          tone: isScenarioPending ? 'warning' : 'error',
+          title: isScenarioPending
+            ? 'Approve the regenerated brief first'
+            : 'Approval failed',
+          description:
+            res.message ??
+            (isScenarioPending
+              ? 'Approve the pending scenario version on the Trial before approving the Trial for inviting.'
+              : 'Unable to approve Trial.'),
+        });
+        return;
+      }
+      notify({
+        id: `approve-ok-${trialId}`,
+        tone: 'success',
+        title: 'Trial approved',
+        description: 'You can now invite candidates.',
+      });
+      router.push(`/talent-partner/trials/${encodeURIComponent(trialId)}`);
+      router.refresh();
+    } finally {
+      setApprovePending(false);
+    }
+  }, [notify, router, trialId]);
+
+  const handleRegenerate = useCallback(async () => {
+    setRegenPending(true);
+    try {
+      const res = await regenerateTrialScenario(trialId);
+      if (!res.ok) {
+        notify({
+          id: `regen-${trialId}`,
+          tone: 'error',
+          title: 'Regeneration unavailable',
+          description:
+            res.message ??
+            'The server could not start regeneration for this Trial.',
+        });
+        return;
+      }
+      router.push(`/talent-partner/trials/${encodeURIComponent(trialId)}`);
+      router.refresh();
+    } finally {
+      setRegenPending(false);
+    }
+  }, [notify, router, trialId]);
+
+  const handleDiscard = useCallback(async () => {
+    setDiscardPending(true);
+    try {
+      const res = await terminateTrial(trialId);
+      if (!res.ok) {
+        notify({
+          id: `discard-${trialId}`,
+          tone: 'error',
+          title: 'Unable to discard',
+          description: res.message ?? 'Termination failed.',
+        });
+        return;
+      }
+      setDiscardOpen(false);
+      router.push('/talent-partner/trials');
+      router.refresh();
+    } finally {
+      setDiscardPending(false);
+    }
+  }, [notify, router, trialId]);
+
+  const handlePrint = () => {
+    if (typeof window !== 'undefined') window.print();
+  };
+
+  if (loading && !detail) {
+    return (
+      <div className="py-16 text-center text-sm text-secondary">
+        Loading Trial…
+      </div>
+    );
+  }
+
+  if (statusCode === 403 || statusCode === 404) {
+    return (
+      <div className="py-16 text-center text-sm text-secondary">
+        This Trial is not available ({statusCode}).
+      </div>
+    );
+  }
+
+  if (error && !detail) {
+    return (
+      <div className="py-16 text-center text-sm text-red-700">
+        {error || 'Unable to load Trial.'}
+      </div>
+    );
+  }
+
+  if (generating || empty) {
+    return (
+      <div className="mx-auto max-w-xl space-y-4 py-16 text-center">
+        <p className="text-sm text-secondary">
+          {generating
+            ? 'Generation in progress. This page will update when the Project Brief and rubric are ready.'
+            : 'Trial content is not ready yet.'}
+        </p>
+        <Button type="button" variant="secondary" onClick={() => reload()}>
+          Refresh
+        </Button>
+        <div>
+          <Link
+            href="/talent-partner/trials"
+            className="text-sm text-wheat-700 underline"
+          >
+            Back to Trials
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `
+          @media print {
+            body * { visibility: hidden !important; }
+            .tp-trial-print-root, .tp-trial-print-root * { visibility: visible !important; }
+            .tp-trial-print-root { position: absolute; left: 0; top: 0; width: 100%; }
+            .tp-no-print { display: none !important; }
+          }
+        `,
+        }}
+      />
+      <div className="tp-trial-print-root mx-auto max-w-6xl px-4 pb-16 pt-8 lg:px-6">
+        <div className="lg:grid lg:grid-cols-5 lg:gap-10">
+          <div className="lg:col-span-3">
+            <div className="tp-no-print mb-6 flex flex-wrap gap-2">
+              <span className="rounded-full border border-subtle bg-elevated px-3 py-1 text-xs font-medium text-primary">
+                {role}
+              </span>
+              <span className="rounded-full border border-subtle bg-elevated px-3 py-1 text-xs font-medium text-primary">
+                {stackLabel}
+              </span>
+              <span className="rounded-full border border-subtle bg-elevated px-3 py-1 text-xs font-medium text-primary">
+                5-day Trial
+              </span>
+            </div>
+
+            <section className="space-y-3">
+              <h2 className="text-lg font-semibold text-primary">
+                Project Brief
+              </h2>
+              {briefMissing ? (
+                <p className="text-sm text-secondary">
+                  No separate Project Brief field was returned for this Trial;
+                  showing storyline text only. Regenerate or save edits if the
+                  brief looks wrong.
+                </p>
+              ) : null}
+              <MarkdownRenderer
+                content={projectBriefMd}
+                variant="reading"
+                emptyPlaceholder="Project Brief is not available yet."
+              />
+            </section>
+
+            <section className="mt-10 space-y-3">
+              <h2 className="text-lg font-semibold text-primary">
+                Evaluation Rubric
+              </h2>
+              <p className="text-sm text-secondary">
+                Winoe will evaluate candidates against these dimensions, using
+                the same rubric for everyone invited to this Trial.
+              </p>
+              <EvaluationRubricTable rows={rubricRows} />
+            </section>
+
+            <section className="mt-10 space-y-3">
+              <h2 className="text-lg font-semibold text-primary">
+                Suggested Daily Cadence
+              </h2>
+              <div className="flex gap-2 overflow-x-auto pb-1">
+                {DEFAULT_CADENCE.map((slot) => {
+                  const dayPlan = plan?.days?.find(
+                    (d) => d.dayIndex === slot.day,
+                  );
+                  const desc =
+                    (dayPlan?.prompt && dayPlan.prompt.trim().slice(0, 120)) ||
+                    slot.fallback;
+                  return (
+                    <div
+                      key={slot.day}
+                      className="min-w-[200px] shrink-0 rounded-lg border border-subtle bg-elevated p-3 text-left"
+                    >
+                      <div className="text-xs font-semibold text-primary">
+                        {slot.title}
+                      </div>
+                      <p className="mt-1 text-xs text-secondary">{desc}</p>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          </div>
+
+          <aside className="tp-no-print mt-10 lg:sticky lg:top-24 lg:col-span-2 lg:mt-0">
+            <div className="rounded-xl border border-subtle bg-elevated p-6 shadow-sm">
+              <h2 className="text-base font-semibold text-primary">
+                Approve this Trial?
+              </h2>
+              <p className="mt-2 text-sm text-secondary">
+                Review the Project Brief carefully. Once approved, candidates
+                will see this exact text.
+              </p>
+              {approveBlocked ? (
+                <div
+                  role="status"
+                  className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950"
+                  data-testid="preview-pending-scenario-callout"
+                >
+                  <p className="font-medium text-amber-950">
+                    A regenerated Project Brief is waiting for your approval.
+                  </p>
+                  <p className="mt-1 text-amber-900">
+                    {
+                      'Open the Trial detail page, select the pending scenario version, and approve that brief before using "Approve & Invite Candidates" here.'
+                    }
+                  </p>
+                  <Link
+                    className="mt-2 inline-block text-sm font-medium text-wheat-800 underline"
+                    href={`/talent-partner/trials/${encodeURIComponent(trialId)}`}
+                  >
+                    Go to Trial to approve pending brief
+                  </Link>
+                </div>
+              ) : null}
+              <dl className="mt-4 space-y-2 text-sm">
+                <div className="flex justify-between gap-4">
+                  <dt className="text-secondary">Role</dt>
+                  <dd className="text-right font-medium text-primary">
+                    {role}
+                  </dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-secondary">
+                    Preferred language/framework
+                  </dt>
+                  <dd className="text-right font-medium text-primary">
+                    {stackLabel}
+                  </dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-secondary">Seniority</dt>
+                  <dd className="text-right font-medium text-primary">
+                    {seniority}
+                  </dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-secondary">Trial length</dt>
+                  <dd className="text-right font-medium text-primary">
+                    5 days
+                  </dd>
+                </div>
+              </dl>
+              <div className="mt-6 flex flex-col gap-2">
+                <Button
+                  type="button"
+                  onClick={handleApprove}
+                  loading={approvePending}
+                  disabled={approvePending || generating || approveBlocked}
+                >
+                  Approve & Invite Candidates
+                </Button>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={handleRegenerate}
+                  loading={regenPending}
+                  disabled={regenPending || generating}
+                >
+                  Regenerate
+                </Button>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="border-red-300 text-red-800 hover:bg-red-50"
+                  onClick={() => setDiscardOpen(true)}
+                  disabled={discardPending}
+                >
+                  Discard draft
+                </Button>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={handlePrint}
+                  data-testid="print-trial-brief"
+                >
+                  Print brief as PDF
+                </Button>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+
+      <DiscardDraftModal
+        open={discardOpen}
+        pending={discardPending}
+        onClose={() => setDiscardOpen(false)}
+        onConfirm={handleDiscard}
+      />
+    </>
+  );
+}

--- a/src/features/talent-partner/trial-management/preview/rubricMapper.ts
+++ b/src/features/talent-partner/trial-management/preview/rubricMapper.ts
@@ -1,0 +1,61 @@
+export type RubricRow = {
+  dimension: string;
+  whatWinoeWillLookFor: string;
+  weightLabel: string | null;
+};
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return v && typeof v === 'object' && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : null;
+}
+
+function pickString(...vals: unknown[]): string {
+  for (const v of vals) {
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  return '';
+}
+
+export function mapRubricJsonToRows(rubricJson: unknown): RubricRow[] {
+  if (Array.isArray(rubricJson)) {
+    return rubricJson.map((item, idx) => {
+      const rec = asRecord(item) ?? {};
+      const dimension =
+        pickString(
+          rec.dimension,
+          rec.name,
+          rec.title,
+          rec.criterion,
+          `Dimension ${idx + 1}`,
+        ) || `Dimension ${idx + 1}`;
+      const what = pickString(
+        rec.whatWinoeWillLookFor,
+        rec.description,
+        rec.criteria,
+        rec.prompt,
+        rec.summary,
+        rec.details,
+      );
+      const weightRaw = rec.weight ?? rec.points ?? rec.score;
+      let weightLabel: string | null = null;
+      if (typeof weightRaw === 'number' && Number.isFinite(weightRaw)) {
+        weightLabel = String(weightRaw);
+      } else if (typeof weightRaw === 'string' && weightRaw.trim()) {
+        weightLabel = weightRaw.trim();
+      }
+      return {
+        dimension,
+        whatWinoeWillLookFor: what || '—',
+        weightLabel,
+      };
+    });
+  }
+  const root = asRecord(rubricJson);
+  if (!root) return [];
+  const dims = root.dimensions ?? root.criteria ?? root.rows;
+  if (Array.isArray(dims)) {
+    return mapRubricJsonToRows(dims);
+  }
+  return [];
+}

--- a/src/platform/server/bff/forward.ts
+++ b/src/platform/server/bff/forward.ts
@@ -36,13 +36,17 @@ export async function forwardJson(options: ForwardOptions) {
     Authorization: `Bearer ${accessToken}`,
     ...headers,
   };
-  const session = devUserEmail
-    ? null
-    : await import('@/platform/auth0').then((mod) =>
-        mod.getSessionNormalized(),
-      );
-  const effectiveDevUserEmail =
-    devUserEmail ?? (session?.user?.email as string | undefined);
+  let sessionEmail: string | undefined;
+  if (!devUserEmail) {
+    try {
+      const mod = await import('@/platform/auth0');
+      const session = await mod.getSessionNormalized();
+      sessionEmail = session?.user?.email as string | undefined;
+    } catch {
+      sessionEmail = undefined;
+    }
+  }
+  const effectiveDevUserEmail = devUserEmail ?? sessionEmail;
   if (effectiveDevUserEmail) {
     outgoingHeaders['x-dev-user-email'] = effectiveDevUserEmail;
   }

--- a/src/shared/ui/CommandPalette.tsx
+++ b/src/shared/ui/CommandPalette.tsx
@@ -85,7 +85,7 @@ export function CommandPalette({ trials = [] }: CommandPaletteProps) {
       },
       {
         id: 'qa-2',
-        label: 'Invite candidate',
+        label: 'Invite candidates',
         section: 'Quick Actions',
         shortcut: 'I',
         onSelect: () => {

--- a/src/shared/ui/MarkdownRenderer.tsx
+++ b/src/shared/ui/MarkdownRenderer.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
+import { cn } from './classnames';
+import { sanitizeMarkdownUrl } from './Markdown';
+
+export type MarkdownRendererProps = {
+  content: string | null | undefined;
+  className?: string;
+  emptyPlaceholder?: ReactNode;
+  variant?: 'default' | 'reading';
+};
+
+const readingClassName =
+  'markdown-reading max-w-[720px] font-sans text-base leading-[1.6] text-primary ' +
+  '[&_h1]:mb-4 [&_h1]:mt-0 [&_h1]:text-2xl [&_h1]:font-semibold [&_h1]:tracking-tight ' +
+  '[&_h2]:mt-8 [&_h2]:mb-3 [&_h2]:text-xl [&_h2]:font-semibold [&_h3]:mt-6 [&_h3]:mb-2 ' +
+  '[&_h3]:text-lg [&_h3]:font-semibold [&_p]:my-4 [&_ul]:my-3 [&_ul]:list-disc [&_ul]:pl-6 ' +
+  '[&_ol]:my-3 [&_ol]:list-decimal [&_ol]:pl-6 [&_li]:my-1.5 ' +
+  '[&_code]:rounded-md [&_code]:bg-elevated [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono ' +
+  '[&_code]:text-[0.9em] [&_pre]:my-4 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:border ' +
+  '[&_pre]:border-subtle [&_pre]:bg-elevated [&_pre]:p-4 [&_pre]:font-mono [&_pre]:text-sm ' +
+  '[&_table]:my-4 [&_table]:w-full [&_table]:border-collapse [&_table]:text-sm ' +
+  '[&_th]:border [&_th]:border-subtle [&_th]:bg-secondary [&_th]:px-3 [&_th]:py-2 [&_th]:text-left ' +
+  '[&_td]:border [&_td]:border-subtle [&_td]:px-3 [&_td]:py-2 [&_blockquote]:my-4 ' +
+  '[&_blockquote]:border-l-4 [&_blockquote]:border-wheat-500/40 [&_blockquote]:pl-4 ' +
+  '[&_blockquote]:text-secondary [&_a]:text-wheat-700 [&_a]:underline';
+
+const defaultClassName =
+  'markdown-content text-sm leading-6 text-primary [&_h1]:mb-3 [&_h1]:mt-0 [&_h1]:text-xl ' +
+  '[&_h1]:font-semibold [&_h2]:mt-4 [&_h2]:mb-2 [&_h2]:text-lg [&_h2]:font-semibold ' +
+  '[&_h3]:mt-3 [&_h3]:mb-2 [&_h3]:text-base [&_h3]:font-semibold [&_p]:my-2 [&_ul]:my-2 ' +
+  '[&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-2 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:my-1 ' +
+  '[&_code]:rounded [&_code]:bg-secondary [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono ' +
+  '[&_pre]:overflow-auto [&_pre]:rounded [&_pre]:bg-elevated [&_pre]:p-3 [&_pre]:font-mono ' +
+  '[&_pre]:text-sm [&_blockquote]:border-l-4 [&_blockquote]:border-subtle ' +
+  '[&_blockquote]:pl-3 [&_a]:text-wheat-700 [&_a]:underline';
+
+export function MarkdownRenderer({
+  content,
+  className,
+  emptyPlaceholder,
+  variant = 'default',
+}: MarkdownRendererProps) {
+  const safeContent = typeof content === 'string' ? content : '';
+
+  if (!safeContent.trim()) {
+    return (
+      <div className={cn('text-sm text-secondary', className)}>
+        {emptyPlaceholder ?? 'Nothing to show yet.'}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        variant === 'reading' ? readingClassName : defaultClassName,
+        className,
+      )}
+    >
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkBreaks]}
+        skipHtml
+        urlTransform={sanitizeMarkdownUrl}
+      >
+        {safeContent}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/tests/e2e/flow-qa/talent-partner-trial-detail.actions.spec.ts
+++ b/tests/e2e/flow-qa/talent-partner-trial-detail.actions.spec.ts
@@ -52,10 +52,8 @@ test.describe('TalentPartner Trial Detail Actions', () => {
       page.getByRole('heading', { name: /invite candidate/i }),
     ).toHaveCount(0);
 
-    await page
-      .getByRole('button', { name: /terminate trial/i })
-      .first()
-      .click();
+    await page.getByRole('button', { name: /trial actions menu/i }).click();
+    await page.getByRole('button', { name: /^terminate trial$/i }).click();
     await expect(page.getByTestId('terminate-trial-modal')).toBeVisible();
     await expect(
       page.getByRole('button', { name: /terminate trial/i }).last(),

--- a/tests/integration/talent-partner/TalentPartnerDashboardContent.profileStates.test.tsx
+++ b/tests/integration/talent-partner/TalentPartnerDashboardContent.profileStates.test.tsx
@@ -118,7 +118,9 @@ describe('TalentPartnerDashboardPage profile/list states', () => {
     );
 
     await user.keyboard('{Control>}k{/Control}');
-    await user.click(screen.getByRole('option', { name: /Invite candidate/i }));
+    await user.click(
+      screen.getByRole('option', { name: /Invite candidates/i }),
+    );
     expect(routerMock.push).toHaveBeenCalledWith('/dashboard/trials');
   });
 

--- a/tests/integration/talent-partner/TrialDetailPageClient.candidateRowsAndGates.test.tsx
+++ b/tests/integration/talent-partner/TrialDetailPageClient.candidateRowsAndGates.test.tsx
@@ -11,6 +11,7 @@ import {
 
 describe('TalentPartnerTrialDetailPage - candidate rows and gating', () => {
   it('renders candidate rows with status badges', async () => {
+    const user = userEvent.setup();
     mockFetchHandlers({
       '/api/trials': jsonResponse([
         {
@@ -48,17 +49,11 @@ describe('TalentPartnerTrialDetailPage - candidate rows and gating', () => {
     renderPage();
 
     expect(await screen.findByText(/Trial ID: trial-1/i)).toBeInTheDocument();
-    expect(
-      await screen.findByText(/Project brief narrative/i),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText(/Preferred language\/framework/i),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText(/Node\.js \+ Postgres/i),
-    ).toBeInTheDocument();
     expect(await screen.findByText('Alex')).toBeInTheDocument();
     expect(await screen.findByText('Blake')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Brief' }));
+    expect(await screen.findByText(/SAAS_BRIEF_EXTRA/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Candidates' }));
     expect(await screen.findByText(/In progress/i)).toBeInTheDocument();
     expect(await screen.findByText('Pending')).toBeInTheDocument();
     expect(await screen.findByText('Rate limited')).toBeInTheDocument();
@@ -132,13 +127,11 @@ describe('TalentPartnerTrialDetailPage - candidate rows and gating', () => {
     const approveBtn = await screen.findByRole('button', {
       name: /Approve v1/i,
     });
-    const inviteBtn = await screen.findByRole('button', {
-      name: /Invite candidate/i,
-    });
+    const inviteBtn = await screen.findByTestId('invite-candidates-header');
     expect(approveBtn).toBeEnabled();
     expect(inviteBtn).toBeDisabled();
     expect(
-      screen.queryByRole('button', { name: /Activate trial/i }),
+      screen.queryByRole('button', { name: /Approve & Invite Candidates/i }),
     ).not.toBeInTheDocument();
 
     await user.click(approveBtn);
@@ -156,16 +149,14 @@ describe('TalentPartnerTrialDetailPage - candidate rows and gating', () => {
     });
     await waitFor(() =>
       expect(
-        screen.getByRole('button', { name: /Activate trial/i }),
+        screen.getByRole('button', { name: /Approve & Invite Candidates/i }),
       ).toBeInTheDocument(),
     );
     const activateBtn = await screen.findByRole('button', {
-      name: /Activate trial/i,
+      name: /Approve & Invite Candidates/i,
     });
     expect(activateBtn).toBeEnabled();
-    expect(
-      screen.getByRole('button', { name: /Invite candidate/i }),
-    ).toBeDisabled();
+    expect(screen.getByTestId('invite-candidates-header')).toBeDisabled();
     await user.click(activateBtn);
     await waitFor(() => {
       const activateCalls = fetchMock.mock.calls.filter(
@@ -173,8 +164,6 @@ describe('TalentPartnerTrialDetailPage - candidate rows and gating', () => {
       );
       expect(activateCalls.length).toBe(1);
     });
-    expect(
-      screen.getByRole('button', { name: /Invite candidate/i }),
-    ).toBeEnabled();
+    expect(screen.getByTestId('invite-candidates-header')).toBeEnabled();
   });
 });

--- a/tests/integration/talent-partner/TrialDetailPageClient.inviteCreateModal.test.tsx
+++ b/tests/integration/talent-partner/TrialDetailPageClient.inviteCreateModal.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/react';
 import {
   fetchMock,
   getUrl,
@@ -7,10 +8,11 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
 } from './TrialDetailPageClient.testlib';
 
 describe('TalentPartnerTrialDetailPage - invite create modal', () => {
-  it('creates an invite and refreshes the list', async () => {
+  it('sends a batch invite and shows copyable links', async () => {
     const user = userEvent.setup();
     const candidateResponses = [
       jsonResponse([]),
@@ -39,35 +41,47 @@ describe('TalentPartnerTrialDetailPage - invite create modal', () => {
       ]),
       '/api/trials/trial-1/candidates': () =>
         candidateResponses.shift() ?? jsonResponse([]),
-      '/api/trials/trial-1/invite': jsonResponse({
-        candidateSessionId: '99',
-        token: 'invite-token',
-        inviteUrl: 'https://example.com/candidate/session/invite-token',
-        outcome: 'created',
+      '/api/trials/trial-1/invite-candidates': jsonResponse({
+        invites: [
+          {
+            candidateSessionId: '99',
+            name: 'New Person',
+            email: 'new@example.com',
+            inviteUrl: 'https://example.com/candidate/session/invite-token',
+            status: 'sent',
+          },
+        ],
       }),
     });
 
     renderPage();
-    await screen.findByText(/No candidates yet/i);
-    await user.click(screen.getByRole('button', { name: /Invite candidate/i }));
-    await user.type(screen.getByLabelText(/Candidate name/i), 'New Person');
+    await screen.findByText(/No candidates invited yet/i);
+    await waitFor(() =>
+      expect(screen.getByTestId('invite-candidates-header')).not.toBeDisabled(),
+    );
+    fireEvent.click(screen.getByTestId('invite-candidates-header'));
+    await screen.findByLabelText(/Full name \(row 1\)/i);
     await user.type(
-      screen.getByLabelText(/Candidate email/i),
+      screen.getByLabelText(/Full name \(row 1\)/i),
+      'New Person',
+    );
+    await user.type(
+      screen.getByLabelText(/Email \(row 1\)/i),
       'new@example.com',
     );
     await user.click(screen.getByRole('button', { name: /Send invite/i }));
-    expect(await screen.findByTestId('invite-success')).toBeInTheDocument();
-    expect(await screen.findByLabelText(/Invite URL/i)).toHaveValue(
-      'https://example.com/candidate/session/invite-token',
-    );
     expect(
-      await screen.findByRole('button', { name: /Copy invite URL/i }),
+      await screen.findByTestId('invite-batch-success'),
     ).toBeInTheDocument();
-    expect(await screen.findByText('New Person')).toBeInTheDocument();
-    expect(await screen.findByText(/Email sent/i)).toBeInTheDocument();
+    expect(
+      await screen.findByLabelText(/Invite URL for new@example.com/i),
+    ).toHaveValue('https://example.com/candidate/session/invite-token');
+    const success = await screen.findByTestId('invite-batch-success');
+    expect(within(success).getByText('New Person')).toBeInTheDocument();
+    expect(await screen.findByText(/1 invite sent/i)).toBeInTheDocument();
   });
 
-  it('shows a truthful warning when refreshed invite delivery is degraded', async () => {
+  it('reopens the modal to a clean idle form after success', async () => {
     const user = userEvent.setup();
     const candidateResponses = [
       jsonResponse([]),
@@ -77,70 +91,7 @@ describe('TalentPartnerTrialDetailPage - invite create modal', () => {
           inviteEmail: 'new@example.com',
           candidateName: 'New Person',
           status: 'not_started',
-          inviteEmailStatus: 'rate_limited',
-          inviteEmailSentAt: null,
-          startedAt: null,
-          completedAt: null,
-          hasReport: false,
-          inviteUrl: 'https://example.com/candidate/session/invite-token',
-        },
-      ]),
-    ];
-
-    mockFetchHandlers({
-      '/api/trials': jsonResponse([
-        {
-          id: 'trial-1',
-          title: 'Trial trial-1',
-          templateKey: 'python-fastapi',
-        },
-      ]),
-      '/api/trials/trial-1/candidates': () =>
-        candidateResponses.shift() ?? jsonResponse([]),
-      '/api/trials/trial-1/invite': jsonResponse({
-        candidateSessionId: '99',
-        token: 'invite-token',
-        inviteUrl: 'https://example.com/candidate/session/invite-token',
-        outcome: 'created',
-      }),
-    });
-
-    renderPage();
-    await screen.findByText(/No candidates yet/i);
-    await user.click(screen.getByRole('button', { name: /Invite candidate/i }));
-    await user.type(screen.getByLabelText(/Candidate name/i), 'New Person');
-    await user.type(
-      screen.getByLabelText(/Candidate email/i),
-      'new@example.com',
-    );
-    await user.click(screen.getByRole('button', { name: /Send invite/i }));
-
-    expect(await screen.findByTestId('invite-success')).toBeInTheDocument();
-    expect(screen.queryByText(/^Invite sent$/i)).not.toBeInTheDocument();
-    expect(
-      await screen.findByText(
-        /Invite link created, but email delivery was rate limited/i,
-      ),
-    ).toBeInTheDocument();
-    expect(await screen.findByLabelText(/Invite URL/i)).toHaveValue(
-      'https://example.com/candidate/session/invite-token',
-    );
-    expect(
-      await screen.findByRole('button', { name: /Copy invite URL/i }),
-    ).toBeInTheDocument();
-  });
-
-  it('reopens the modal to a clean idle form after a degraded invite state', async () => {
-    const user = userEvent.setup();
-    const candidateResponses = [
-      jsonResponse([]),
-      jsonResponse([
-        {
-          candidateSessionId: 99,
-          inviteEmail: 'new@example.com',
-          candidateName: 'New Person',
-          status: 'not_started',
-          inviteEmailStatus: 'rate_limited',
+          inviteEmailStatus: 'sent',
           inviteEmailSentAt: null,
           startedAt: null,
           completedAt: null,
@@ -159,35 +110,51 @@ describe('TalentPartnerTrialDetailPage - invite create modal', () => {
       ]),
       '/api/trials/trial-1/candidates': () =>
         candidateResponses.shift() ?? jsonResponse([]),
-      '/api/trials/trial-1/invite': jsonResponse({
-        candidateSessionId: '99',
-        token: 'invite-token',
-        inviteUrl: 'https://example.com/candidate/session/invite-token',
-        outcome: 'created',
+      '/api/trials/trial-1/invite-candidates': jsonResponse({
+        invites: [
+          {
+            candidateSessionId: '99',
+            name: 'New Person',
+            email: 'new@example.com',
+            inviteUrl: 'https://example.com/candidate/session/invite-token',
+            status: 'sent',
+          },
+        ],
       }),
     });
 
     renderPage();
-    await screen.findByText(/No candidates yet/i);
-    await user.click(screen.getByRole('button', { name: /Invite candidate/i }));
-    await user.type(screen.getByLabelText(/Candidate name/i), 'New Person');
+    await screen.findByText(/No candidates invited yet/i);
+    await waitFor(() =>
+      expect(screen.getByTestId('invite-candidates-header')).not.toBeDisabled(),
+    );
+    fireEvent.click(screen.getByTestId('invite-candidates-header'));
+    await screen.findByLabelText(/Full name \(row 1\)/i);
     await user.type(
-      screen.getByLabelText(/Candidate email/i),
+      screen.getByLabelText(/Full name \(row 1\)/i),
+      'New Person',
+    );
+    await user.type(
+      screen.getByLabelText(/Email \(row 1\)/i),
       'new@example.com',
     );
     await user.click(screen.getByRole('button', { name: /Send invite/i }));
 
     expect(
-      await screen.findByText(
-        /Invite link created, but email delivery was rate limited/i,
-      ),
+      await screen.findByTestId('invite-batch-success'),
     ).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /Done/i }));
 
-    await user.click(screen.getByRole('button', { name: /Invite candidate/i }));
-    expect(screen.getByLabelText(/Candidate name/i)).toHaveValue('');
-    expect(screen.getByLabelText(/Candidate email/i)).toHaveValue('');
-    expect(screen.queryByText(/Invite link created/i)).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByTestId('invite-candidates-header')).not.toBeDisabled(),
+    );
+    fireEvent.click(screen.getByTestId('invite-candidates-header'));
+    await screen.findByLabelText(/Full name \(row 1\)/i);
+    expect(screen.getByLabelText(/Full name \(row 1\)/i)).toHaveValue('');
+    expect(screen.getByLabelText(/Email \(row 1\)/i)).toHaveValue('');
+    expect(
+      screen.queryByTestId('invite-batch-success'),
+    ).not.toBeInTheDocument();
   });
 
   it('does not pre-check candidates when opening the invite modal', async () => {
@@ -202,23 +169,32 @@ describe('TalentPartnerTrialDetailPage - invite create modal', () => {
         },
       ]),
       '/api/trials/trial-1/candidates': jsonResponse([]),
-      '/api/trials/trial-1/invite': jsonResponse({
-        candidateSessionId: '99',
-        token: 'invite-token',
-        inviteUrl: 'https://example.com/candidate/session/invite-token',
-        outcome: 'created',
+      '/api/trials/trial-1/invite-candidates': jsonResponse({
+        invites: [
+          {
+            candidateSessionId: '99',
+            name: 'New Person',
+            email: 'new@example.com',
+            inviteUrl: 'https://example.com/candidate/session/invite-token',
+            status: 'sent',
+          },
+        ],
       }),
     });
 
     renderPage();
-    await screen.findByText(/No candidates yet/i);
+    await screen.findByText(/No candidates invited yet/i);
 
     const candidatesUrl = '/api/trials/trial-1/candidates';
     const candidateCallsBefore = fetchMock.mock.calls.filter(
       (call) => getUrl(call[0]) === candidatesUrl,
     ).length;
 
-    await user.click(screen.getByRole('button', { name: /Invite candidate/i }));
+    await waitFor(() =>
+      expect(screen.getByTestId('invite-candidates-header')).not.toBeDisabled(),
+    );
+    fireEvent.click(screen.getByTestId('invite-candidates-header'));
+    await screen.findByLabelText(/Full name \(row 1\)/i);
     await waitFor(() => {
       const candidateCallsAfterOpen = fetchMock.mock.calls.filter(
         (call) => getUrl(call[0]) === candidatesUrl,
@@ -228,16 +204,19 @@ describe('TalentPartnerTrialDetailPage - invite create modal', () => {
       );
     });
 
-    await user.type(screen.getByLabelText(/Candidate name/i), 'New Person');
     await user.type(
-      screen.getByLabelText(/Candidate email/i),
+      screen.getByLabelText(/Full name \(row 1\)/i),
+      'New Person',
+    );
+    await user.type(
+      screen.getByLabelText(/Email \(row 1\)/i),
       'new@example.com',
     );
     await user.click(screen.getByRole('button', { name: /Send invite/i }));
 
     await waitFor(() => {
       const inviteCalls = fetchMock.mock.calls.filter(
-        (call) => getUrl(call[0]) === '/api/trials/trial-1/invite',
+        (call) => getUrl(call[0]) === '/api/trials/trial-1/invite-candidates',
       ).length;
       expect(inviteCalls).toBe(1);
     });

--- a/tests/integration/talent-partner/TrialDetailPageClient.inviteErrors.test.tsx
+++ b/tests/integration/talent-partner/TrialDetailPageClient.inviteErrors.test.tsx
@@ -1,9 +1,11 @@
+import { fireEvent } from '@testing-library/react';
 import {
   jsonResponse,
   mockFetchHandlers,
   renderPage,
   screen,
   userEvent,
+  waitFor,
 } from './TrialDetailPageClient.testlib';
 
 describe('TalentPartnerTrialDetailPage - invite error handling', () => {
@@ -20,7 +22,7 @@ describe('TalentPartnerTrialDetailPage - invite error handling', () => {
         },
       ]),
       '/api/trials/trial-1/candidates': jsonResponse([]),
-      '/api/trials/trial-1/invite': () => {
+      '/api/trials/trial-1/invite-candidates': () => {
         inviteStep += 1;
         if (inviteStep === 1)
           return jsonResponse(
@@ -41,10 +43,15 @@ describe('TalentPartnerTrialDetailPage - invite error handling', () => {
 
     renderPage();
 
-    await user.click(screen.getByRole('button', { name: /Invite candidate/i }));
-    await user.type(screen.getByLabelText(/Candidate name/i), 'Alex');
+    await screen.findByText(/No candidates invited yet/i);
+    await waitFor(() =>
+      expect(screen.getByTestId('invite-candidates-header')).not.toBeDisabled(),
+    );
+    fireEvent.click(screen.getByTestId('invite-candidates-header'));
+    await screen.findByLabelText(/Full name \(row 1\)/i);
+    await user.type(screen.getByLabelText(/Full name \(row 1\)/i), 'Alex');
     await user.type(
-      screen.getByLabelText(/Candidate email/i),
+      screen.getByLabelText(/Email \(row 1\)/i),
       'alex@example.com',
     );
     await user.click(screen.getByRole('button', { name: /Send invite/i }));

--- a/tests/integration/talent-partner/TrialDetailPageClient.pageStates.test.tsx
+++ b/tests/integration/talent-partner/TrialDetailPageClient.pageStates.test.tsx
@@ -24,7 +24,10 @@ describe('TalentPartnerTrialDetailPage - page states', () => {
 
     expect(await screen.findByText(/Trial not found/i)).toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: /Invite candidate/i }),
+      screen.queryByTestId('invite-candidates-header'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('invite-candidates-empty-cta'),
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: /Approve v\d+/i }),
@@ -52,7 +55,10 @@ describe('TalentPartnerTrialDetailPage - page states', () => {
       await screen.findByText(/You don't have access to this trial/i),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: /Invite candidate/i }),
+      screen.queryByTestId('invite-candidates-header'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('invite-candidates-empty-cta'),
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: /Approve v\d+/i }),

--- a/tests/integration/talent-partner/TrialDetailPageClient.scenarioActions.test.tsx
+++ b/tests/integration/talent-partner/TrialDetailPageClient.scenarioActions.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/react';
 import {
   fetchMock,
   getUrl,
@@ -51,14 +52,17 @@ describe('TalentPartnerTrialDetailPage - scenario actions', () => {
 
     renderPage();
 
-    const regenerateBtn = await screen.findByRole('button', {
-      name: /Regenerate scenario/i,
-    });
-    await user.click(regenerateBtn);
+    await user.click(
+      await screen.findByRole('button', { name: /Trial actions menu/i }),
+    );
+    const regenerateBtn = await screen.findByTestId(
+      'regenerate-scenario-trigger',
+    );
+    expect(regenerateBtn).not.toBeDisabled();
+    fireEvent.click(regenerateBtn);
     const dialog = await screen.findByRole('dialog', {
       name: /Confirm scenario regenerate/i,
     });
-    expect(dialog).toBeInTheDocument();
     expect(
       fetchMock.mock.calls.filter(
         (call) => getUrl(call[0]) === '/api/trials/trial-1/scenario/regenerate',
@@ -66,7 +70,10 @@ describe('TalentPartnerTrialDetailPage - scenario actions', () => {
     ).toBe(0);
 
     await user.click(within(dialog).getByRole('button', { name: /Cancel/i }));
-    await user.click(regenerateBtn);
+    const regenerateBtnAgain = screen.getByTestId(
+      'regenerate-scenario-trigger',
+    );
+    fireEvent.click(regenerateBtnAgain);
     const confirmDialog = await screen.findByRole('dialog', {
       name: /Confirm scenario regenerate/i,
     });
@@ -82,7 +89,7 @@ describe('TalentPartnerTrialDetailPage - scenario actions', () => {
     });
   });
 
-  it('shows action error when approve request fails', async () => {
+  it('calls approve endpoint when Approve is used', async () => {
     const user = userEvent.setup();
 
     mockFetchHandlers({
@@ -98,7 +105,7 @@ describe('TalentPartnerTrialDetailPage - scenario actions', () => {
         status: 'ready_for_review',
         title: 'Trial trial-1',
         templateKey: 'python-fastapi',
-        scenario: { id: 10, versionIndex: 1, status: 'ready' },
+        scenario: { id: '10', versionIndex: 1, status: 'ready' },
         tasks: [
           {
             dayIndex: 1,
@@ -108,8 +115,10 @@ describe('TalentPartnerTrialDetailPage - scenario actions', () => {
         ],
       }),
       '/api/trials/trial-1/candidates': jsonResponse([]),
-      '/api/trials/trial-1/scenario/10/approve': () =>
-        Promise.reject('approve failed'),
+      '/api/trials/trial-1/scenario/10/approve': jsonResponse(
+        { message: 'Approve failed' },
+        500,
+      ),
     });
 
     renderPage();
@@ -118,6 +127,11 @@ describe('TalentPartnerTrialDetailPage - scenario actions', () => {
         name: /Approve v1/i,
       }),
     );
-    expect(await screen.findByText(/Request failed/i)).toBeInTheDocument();
+    await waitFor(() => {
+      const approveCalls = fetchMock.mock.calls.filter(
+        (call) => getUrl(call[0]) === '/api/trials/trial-1/scenario/10/approve',
+      );
+      expect(approveCalls.length).toBe(1);
+    });
   });
 });

--- a/tests/integration/talent-partner/TrialDetailPageClient.testlib.tsx
+++ b/tests/integration/talent-partner/TrialDetailPageClient.testlib.tsx
@@ -22,7 +22,19 @@ const trialDetailResponse = () =>
     techStack: 'Node.js + Postgres',
     preferredLanguageFramework: 'Node.js + Postgres',
     focus: 'Payments',
-    scenario: 'Design a billing service for a SaaS platform.',
+    activeScenarioVersionId: '200',
+    scenario: {
+      id: '200',
+      versionIndex: 1,
+      status: 'ready',
+      storylineMd: 'Storyline for editor textarea',
+      projectBriefMd:
+        'Design a billing service for a SaaS platform.\n\nSAAS_BRIEF_EXTRA.',
+      rubricJson: {},
+      taskPromptsJson: [],
+    },
+    projectBriefMd:
+      'Design a billing service for a SaaS platform.\n\nSAAS_BRIEF_EXTRA.',
     rubricSummary: 'Judge correctness, clarity, and resilience.',
     tasks: [
       {

--- a/tests/integration/talent-partner/TrialDetailScenarioVersions.draftsAndSave.test.tsx
+++ b/tests/integration/talent-partner/TrialDetailScenarioVersions.draftsAndSave.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/react';
 import {
   buildDetail,
   fetchMock,
@@ -73,7 +74,11 @@ describe('TrialDetail scenario versions - drafts and save', () => {
     await user.click(
       screen.getByRole('button', { name: /Select scenario v2/i }),
     );
-    await screen.findByText(/Version v2/i);
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /Select scenario v2/i }),
+      ).toHaveAttribute('aria-pressed', 'true'),
+    );
     await user.click(
       screen.getByRole('button', { name: /Select scenario v1/i }),
     );
@@ -100,6 +105,23 @@ describe('TrialDetail scenario versions - drafts and save', () => {
               ],
             }),
           );
+        if (detailCalls === 2)
+          return jsonResponse(
+            buildDetail({
+              status: 'ready_for_review',
+              activeScenarioVersionId: 10,
+              pendingScenarioVersionId: 12,
+              scenarioVersions: [
+                { id: 10, versionIndex: 1, status: 'ready', lockedAt: null },
+                {
+                  id: 12,
+                  versionIndex: 2,
+                  status: 'generating',
+                  lockedAt: null,
+                },
+              ],
+            }),
+          );
         return jsonResponse(
           buildDetail({
             status: 'ready_for_review',
@@ -107,7 +129,7 @@ describe('TrialDetail scenario versions - drafts and save', () => {
             pendingScenarioVersionId: 12,
             scenarioVersions: [
               { id: 10, versionIndex: 1, status: 'ready', lockedAt: null },
-              { id: 12, versionIndex: 2, status: 'generating', lockedAt: null },
+              { id: 12, versionIndex: 2, status: 'ready', lockedAt: null },
             ],
           }),
         );
@@ -117,9 +139,9 @@ describe('TrialDetail scenario versions - drafts and save', () => {
         jobId: 'job-regen-draft',
         status: 'generating',
       }),
-      '/api/backend/jobs/job-regen-draft': jsonResponse({
+      '/api/jobs/job-regen-draft': jsonResponse({
         jobId: 'job-regen-draft',
-        status: 'running',
+        status: 'succeeded',
       }),
     });
     renderPage();
@@ -129,19 +151,24 @@ describe('TrialDetail scenario versions - drafts and save', () => {
     await user.clear(storylineArea);
     await user.type(storylineArea, 'Draft survives regenerate');
     expect(storylineArea.value).toBe('Draft survives regenerate');
-    await user.click(
-      screen.getByRole('button', { name: /Regenerate scenario/i }),
-    );
+    fireEvent.click(screen.getByTestId('regenerate-scenario-trigger'));
     const dialog = await screen.findByRole('dialog', {
       name: /Confirm scenario regenerate/i,
     });
     await user.click(
       within(dialog).getByRole('button', { name: /^Regenerate$/i }),
     );
-    await screen.findByText(/Generating v2\.\.\./i);
+    await screen.findByText(/Project brief generation is in progress/i);
     expect(
       screen.queryByRole('button', { name: /Approve v\d+/i }),
     ).not.toBeInTheDocument();
+    await waitFor(
+      () =>
+        expect(
+          screen.queryByText(/Project brief generation is in progress/i),
+        ).not.toBeInTheDocument(),
+      { timeout: 12000 },
+    );
     await user.click(
       await screen.findByRole('button', { name: /Select scenario v1/i }),
     );

--- a/tests/integration/talent-partner/TrialDetailScenarioVersions.lockedAndApprove.test.tsx
+++ b/tests/integration/talent-partner/TrialDetailScenarioVersions.lockedAndApprove.test.tsx
@@ -31,7 +31,7 @@ describe('TrialDetail scenario versions - lock banner and approve', () => {
     expect(
       (
         await screen.findAllByText(
-          /This version is locked because invites exist\./i,
+          /This version is locked for editing because the Trial is approved for inviting\./i,
         )
       ).length,
     ).toBeGreaterThan(0);
@@ -163,7 +163,7 @@ describe('TrialDetail scenario versions - lock banner and approve', () => {
       expect(approveCalls.length).toBe(1);
     });
     const activateButton = await screen.findByRole('button', {
-      name: /Activate trial/i,
+      name: /Approve & Invite Candidates/i,
     });
     expect(activateButton).toBeEnabled();
     await user.click(activateButton);
@@ -174,10 +174,8 @@ describe('TrialDetail scenario versions - lock banner and approve', () => {
       expect(activateCalls.length).toBe(1);
     });
     expect(
-      screen.queryByRole('button', { name: /Activate trial/i }),
+      screen.queryByRole('button', { name: /Approve & Invite Candidates/i }),
     ).toBeNull();
-    expect(
-      screen.getByRole('button', { name: /Invite candidate/i }),
-    ).toBeEnabled();
+    expect(screen.getByTestId('invite-candidates-header')).toBeEnabled();
   });
 });

--- a/tests/integration/talent-partner/TrialDetailScenarioVersions.regenerateLifecycle.test.tsx
+++ b/tests/integration/talent-partner/TrialDetailScenarioVersions.regenerateLifecycle.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/react';
 import {
   act,
   buildDetail,
@@ -65,22 +66,22 @@ describe('TrialDetail scenario versions - regenerate lifecycle', () => {
       }),
     });
     renderPage();
-    await user.click(
-      await screen.findByRole('button', { name: /Regenerate scenario/i }),
-    );
+    fireEvent.click(await screen.findByTestId('regenerate-scenario-trigger'));
     const dialog = await screen.findByRole('dialog', {
       name: /Confirm scenario regenerate/i,
     });
     await user.click(
       within(dialog).getByRole('button', { name: /^Regenerate$/i }),
     );
-    expect(await screen.findByText(/Generating v2\.\.\./i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Project brief generation is in progress/i),
+    ).toBeInTheDocument();
     await act(async () => {
       jest.advanceTimersByTime(2200);
     });
     await waitFor(() =>
       expect(
-        screen.queryByText(/Generating v2\.\.\./i),
+        screen.queryByText(/Project brief generation is in progress/i),
       ).not.toBeInTheDocument(),
     );
     expect(
@@ -130,16 +131,16 @@ describe('TrialDetail scenario versions - regenerate lifecycle', () => {
       }),
     });
     renderPage();
-    await user.click(
-      await screen.findByRole('button', { name: /Regenerate scenario/i }),
-    );
+    fireEvent.click(await screen.findByTestId('regenerate-scenario-trigger'));
     const dialog = await screen.findByRole('dialog', {
       name: /Confirm scenario regenerate/i,
     });
     await user.click(
       within(dialog).getByRole('button', { name: /^Regenerate$/i }),
     );
-    expect(await screen.findByText(/Generating v2\.\.\./i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Project brief generation is in progress/i),
+    ).toBeInTheDocument();
     await act(async () => {
       jest.advanceTimersByTime(2200);
     });
@@ -152,7 +153,7 @@ describe('TrialDetail scenario versions - regenerate lifecycle', () => {
     );
     await waitFor(() =>
       expect(
-        screen.queryByText(/Generating v2\.\.\./i),
+        screen.queryByText(/Project brief generation is in progress/i),
       ).not.toBeInTheDocument(),
     );
     expect(
@@ -165,9 +166,7 @@ describe('TrialDetail scenario versions - regenerate lifecycle', () => {
     expect(
       screen.queryByRole('button', { name: /Approve v\d+/i }),
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: /Invite candidate/i }),
-    ).toBeDisabled();
+    expect(screen.getByTestId('invite-candidates-header')).toBeDisabled();
     expect(
       screen.getByText(
         /Invites stay disabled until the trial is active inviting\./i,

--- a/tests/integration/talent-partner/TrialDetailScenarioVersions.unavailableAndBadge.test.tsx
+++ b/tests/integration/talent-partner/TrialDetailScenarioVersions.unavailableAndBadge.test.tsx
@@ -5,6 +5,7 @@ import {
   renderPage,
   screen,
   userEvent,
+  waitFor,
 } from './TrialDetailScenarioVersions.testlib';
 
 describe('TrialDetail scenario versions - unavailable and badges', () => {
@@ -33,7 +34,11 @@ describe('TrialDetail scenario versions - unavailable and badges', () => {
       }),
     ).toBeInTheDocument();
     await user.click(selectV2);
-    expect(await screen.findByText(/Version v2/i)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /Select scenario v2/i }),
+      ).toHaveAttribute('aria-pressed', 'true'),
+    );
     expect(
       await screen.findAllByText(/content is unavailable from the backend/i),
     ).not.toHaveLength(0);
@@ -44,9 +49,7 @@ describe('TrialDetail scenario versions - unavailable and badges', () => {
     expect(
       screen.queryByRole('button', { name: /Approve v1/i }),
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: /Invite candidate/i }),
-    ).toBeDisabled();
+    expect(screen.getByTestId('invite-candidates-header')).toBeDisabled();
     expect(screen.getByRole('button', { name: /Save edits/i })).toBeDisabled();
   });
 
@@ -65,7 +68,9 @@ describe('TrialDetail scenario versions - unavailable and badges', () => {
       ),
     });
     renderPage();
-    expect(await screen.findByText(/Generating v2\.\.\./i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Project brief generation is in progress/i),
+    ).toBeInTheDocument();
     expect(screen.queryByText(/^Ready for review$/i)).not.toBeInTheDocument();
     expect(screen.getAllByText(/^Generating$/i).length).toBeGreaterThanOrEqual(
       2,

--- a/tests/integration/talent-partner/trials/tests/TrialDetailContent.candidateErrors.test.tsx
+++ b/tests/integration/talent-partner/trials/tests/TrialDetailContent.candidateErrors.test.tsx
@@ -8,6 +8,7 @@ import {
   trialDetailResponse,
   textResponse,
   waitFor,
+  userEvent,
 } from './TrialDetailContent.testlib';
 
 describe('TalentPartnerTrialDetailPage - candidate error handling', () => {
@@ -80,6 +81,8 @@ describe('TalentPartnerTrialDetailPage - candidate error handling', () => {
     expect(
       await screen.findByText('You are not authorized to view candidates.'),
     ).toBeInTheDocument();
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Brief' }));
     expect(
       await screen.findByRole('heading', { name: 'Project Brief' }),
     ).toBeInTheDocument();

--- a/tests/integration/talent-partner/trials/tests/TrialDetailContent.candidateStates.test.tsx
+++ b/tests/integration/talent-partner/trials/tests/TrialDetailContent.candidateStates.test.tsx
@@ -25,10 +25,12 @@ describe('TalentPartnerTrialDetailPage - candidate state rendering', () => {
 
     render(<TalentPartnerTrialDetailPage />);
     await waitFor(() =>
-      expect(screen.getByText(/No candidates yet/i)).toBeInTheDocument(),
+      expect(
+        screen.getByText(/No candidates invited yet/i),
+      ).toBeInTheDocument(),
     );
     expect(
-      screen.getByRole('button', { name: /Invite candidate/i }),
+      screen.getByTestId('invite-candidates-empty-cta'),
     ).toBeInTheDocument();
   });
 

--- a/tests/integration/talent-partner/trials/tests/TrialDetailContent.planRendering.test.tsx
+++ b/tests/integration/talent-partner/trials/tests/TrialDetailContent.planRendering.test.tsx
@@ -8,65 +8,37 @@ import {
   trialDetailResponse,
   trialListResponse,
   textResponse,
+  userEvent,
 } from './TrialDetailContent.testlib';
 
 describe('TalentPartnerTrialDetailPage - plan rendering', () => {
-  it('renders the generated trial plan with tasks and repo status', async () => {
+  it('renders tabbed Trial detail with Brief and Rubric content', async () => {
+    const user = userEvent.setup();
     render(<TalentPartnerTrialDetailPage />);
+
+    expect(await screen.findByText('Jane Doe')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Brief' }));
     expect(
-      await screen.findByRole('heading', { name: 'Project Brief' }),
-    ).toBeInTheDocument();
-    expect(await screen.findByText('Backend Engineer')).toBeInTheDocument();
-    expect(
-      await screen.findByText(/Project brief narrative/i),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText(/Build a billing service/i),
+      await screen.findByRole('heading', { name: 'Project Brief', level: 3 }),
     ).toBeInTheDocument();
     expect(
-      await screen.findByText(/Preferred language\/framework/i),
+      await screen.findByText(/MARKETPLACE_BRIEF_EXTRA/),
     ).toBeInTheDocument();
-    expect(await screen.findByText('Python + FastAPI')).toBeInTheDocument();
-    expect(await screen.findByText(/Rubric summary/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Rubric' }));
     expect(
-      await screen.findByText(/Assess API correctness, clarity/i),
+      await screen.findByText(
+        /Winoe will evaluate candidates against these dimensions/i,
+      ),
     ).toBeInTheDocument();
-    expect(
-      await screen.findByText(/Project brief narrative/i),
-    ).toBeInTheDocument();
-    expect(await screen.findByText('Clarity')).toBeInTheDocument();
-    expect(
-      await screen.findByText(/^Planning and Design Doc$/i),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText(/^Implementation Kickoff$/i),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText(/^Implementation Wrap-Up$/i),
-    ).toBeInTheDocument();
-    expect(await screen.findByText(/^Handoff \+ Demo$/i)).toBeInTheDocument();
-    expect(await screen.findByText(/^Reflection Essay$/i)).toBeInTheDocument();
-    expect(
-      await screen.findByText(/^Implementation Kickoff workspace$/i),
-    ).toBeInTheDocument();
-    expect(await screen.findByText(/Repo provisioned/i)).toBeInTheDocument();
-    expect(
-      await screen.findByText(/Repo not provisioned yet/i),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText(/AI Evaluation: Disabled/i),
-    ).toBeInTheDocument();
-    expect(
-      screen.getAllByText(/AI Evaluation: Enabled/i).length,
-    ).toBeGreaterThan(0);
-    expect(
-      (await screen.findAllByText(/Not generated yet/i)).length,
-    ).toBeGreaterThanOrEqual(2);
+
     expect(screen.queryByText(/Template/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Tech stack/i)).not.toBeInTheDocument();
   });
 
   it('normalizes plan data from nested task objects', async () => {
+    const user = userEvent.setup();
     installFetchMock(async (input: RequestInfo | URL) => {
       const url = getRequestUrl(input);
       if (url === '/api/trials') return trialListResponse();
@@ -82,7 +54,17 @@ describe('TalentPartnerTrialDetailPage - plan rendering', () => {
           stack_name: 'Node + TypeScript',
           preferred_language_framework: 'Rust + Axum',
           focus_area: ['Performance', 'Reliability'],
-          scenario: { summary: 'Project brief summary from object.' },
+          activeScenarioVersionId: '7',
+          scenario: {
+            id: '7',
+            versionIndex: 1,
+            status: 'ready',
+            storylineMd: 'Legacy storyline',
+            projectBriefMd: 'Project brief summary from object.\n\nBody.',
+            rubricJson: {},
+            taskPromptsJson: [],
+          },
+          projectBriefMd: 'Project brief summary from object.\n\nBody.',
           tasks: {
             day_1: {
               title: 'Discovery',
@@ -108,31 +90,19 @@ describe('TalentPartnerTrialDetailPage - plan rendering', () => {
       return textResponse('Not found', 404);
     });
     render(<TalentPartnerTrialDetailPage />);
+
+    await user.click(screen.getByRole('button', { name: 'Brief' }));
     expect(
       await screen.findByText(/Project brief summary from object/i),
     ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Rubric' }));
     expect(
-      await screen.findByText(/Preferred language\/framework/i),
+      await screen.findByText(
+        /Winoe will evaluate candidates against these dimensions/i,
+      ),
     ).toBeInTheDocument();
-    expect(await screen.findByText('Rust + Axum')).toBeInTheDocument();
-    expect(
-      await screen.findByText('Performance, Reliability'),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText(/^Review the project brief\.$/i),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText(/Clear and concise notes/i),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText(/^Implementation Kickoff workspace$/i),
-    ).toBeInTheDocument();
-    expect(
-      (await screen.findAllByText(/Repo provisioned/i)).length,
-    ).toBeGreaterThan(0);
-    expect(
-      await screen.findByText(/Repo not provisioned yet/i),
-    ).toBeInTheDocument();
+
     expect(screen.queryByText('node-express-ts')).toBeNull();
     expect(screen.queryByText('Node + TypeScript')).toBeNull();
     expect(screen.queryByText('Node, TypeScript')).toBeNull();
@@ -161,7 +131,8 @@ describe('TalentPartnerTrialDetailPage - plan rendering', () => {
     expect(await screen.findByText('Report ready')).toBeInTheDocument();
   });
 
-  it('uses neutral copy when provisioning status is unknown', async () => {
+  it('shows Activity tab empty state when no audit feed exists', async () => {
+    const user = userEvent.setup();
     installFetchMock(async (input: RequestInfo | URL) => {
       const url = getRequestUrl(input);
       if (url === '/api/trials') return trialListResponse();
@@ -186,15 +157,9 @@ describe('TalentPartnerTrialDetailPage - plan rendering', () => {
       return textResponse('Not found', 404);
     });
     render(<TalentPartnerTrialDetailPage />);
+    await user.click(screen.getByRole('button', { name: 'Activity' }));
     expect(
-      await screen.findByText(
-        /Provisioning happens per-candidate after invite/i,
-      ),
+      await screen.findByText(/No Trial activity recorded yet/i),
     ).toBeInTheDocument();
-    expect(screen.queryByText(/Repo provisioned/i)).not.toBeInTheDocument();
-    expect(
-      screen.queryByText(/Repo not provisioned yet/i),
-    ).not.toBeInTheDocument();
-    expect(await screen.findByText(/Repository link/i)).toBeInTheDocument();
   });
 });

--- a/tests/integration/talent-partner/trials/tests/TrialDetailContent.testlib.tsx
+++ b/tests/integration/talent-partner/trials/tests/TrialDetailContent.testlib.tsx
@@ -50,7 +50,19 @@ export const trialDetailResponse = () =>
         '5': true,
       },
     },
-    scenario: 'Build a billing service for a growing marketplace.',
+    activeScenarioVersionId: '300',
+    scenario: {
+      id: '300',
+      versionIndex: 1,
+      status: 'ready',
+      storylineMd: 'Separate storyline text',
+      projectBriefMd:
+        'Build a billing service for a growing marketplace.\n\nMARKETPLACE_BRIEF_EXTRA.',
+      rubricJson: {},
+      taskPromptsJson: [],
+    },
+    projectBriefMd:
+      'Build a billing service for a growing marketplace.\n\nMARKETPLACE_BRIEF_EXTRA.',
     rubricSummary: 'Assess API correctness, clarity, and error handling.',
     tasks: [
       {

--- a/tests/integration/talent-partner/trials/tests/TrialDetailTerminate.access.test.tsx
+++ b/tests/integration/talent-partner/trials/tests/TrialDetailTerminate.access.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { textResponse } from '../../../../setup/responseHelpers';
 import {
   installTerminateFetchMock,
+  openTerminateTrialFromHeader,
   resetTerminateIntegrationState,
 } from './TrialDetailTerminate.testlib';
 import TalentPartnerTrialDetailPage from '@/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage';
@@ -23,13 +24,11 @@ describe('Trial detail terminate access handling', () => {
     render(<TalentPartnerTrialDetailPage />);
     await waitFor(() =>
       expect(
-        screen.getByRole('button', { name: /^terminate trial$/i }),
+        screen.getByTestId('trial-detail-overflow-menu'),
       ).toBeInTheDocument(),
     );
 
-    await user.click(
-      screen.getByRole('button', { name: /^terminate trial$/i }),
-    );
+    await openTerminateTrialFromHeader(user);
     const modal = await screen.findByTestId('terminate-trial-modal');
     await user.click(within(modal).getByLabelText('confirm-terminate-trial'));
     await user.click(

--- a/tests/integration/talent-partner/trials/tests/TrialDetailTerminate.test.tsx
+++ b/tests/integration/talent-partner/trials/tests/TrialDetailTerminate.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { getRequestUrl, jsonResponse } from '../../../../setup/responseHelpers';
 import {
   installTerminateFetchMock,
+  openTerminateTrialFromHeader,
   resetTerminateIntegrationState,
 } from './TrialDetailTerminate.testlib';
 import TalentPartnerTrialDetailPage from '@/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage';
@@ -37,9 +38,7 @@ describe('Trial detail terminate flow', () => {
     expect(
       await screen.findByRole('button', { name: /^send invite$/i }),
     ).toBeInTheDocument();
-    await user.click(
-      screen.getByRole('button', { name: /^terminate trial$/i }),
-    );
+    await openTerminateTrialFromHeader(user);
 
     const modal = await screen.findByTestId('terminate-trial-modal');
     const confirmButton = within(modal).getByRole('button', {

--- a/tests/integration/talent-partner/trials/tests/TrialDetailTerminate.testlib.tsx
+++ b/tests/integration/talent-partner/trials/tests/TrialDetailTerminate.testlib.tsx
@@ -1,6 +1,8 @@
 import '../../../setup/paramsMock';
 import { setMockParams } from '../../../setup/paramsMock';
 import React from 'react';
+import { screen, within } from '@testing-library/react';
+import type { UserEvent } from '@testing-library/user-event';
 import {
   getRequestUrl,
   jsonResponse,
@@ -57,6 +59,12 @@ export function resetTerminateIntegrationState() {
   __resetCandidateCache();
   __resetHttpClientCache();
   setMockParams({ id: '1' });
+}
+
+export async function openTerminateTrialFromHeader(user: UserEvent) {
+  const menu = await screen.findByTestId('trial-detail-overflow-menu');
+  await user.click(within(menu).getByText(/^More$/));
+  await user.click(screen.getByRole('button', { name: /^Terminate Trial$/i }));
 }
 
 export function installTerminateFetchMock(

--- a/tests/unit/features/talent-partner/api/invitesBatchApi.test.ts
+++ b/tests/unit/features/talent-partner/api/invitesBatchApi.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+import { inviteCandidatesBatch } from '@/features/talent-partner/api/invitesBatchApi';
+
+const mockRequestTalentPartnerBff = jest.fn();
+
+jest.mock('@/features/talent-partner/api/requestTalentPartnerBffApi', () => ({
+  requestTalentPartnerBff: (...args: unknown[]) =>
+    mockRequestTalentPartnerBff(...args),
+}));
+
+describe('invitesBatchApi', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('posts to the BFF trials invite-candidates route', async () => {
+    mockRequestTalentPartnerBff.mockResolvedValueOnce({
+      data: {
+        invites: [
+          {
+            candidateSessionId: 9,
+            name: 'A',
+            email: 'a@example.com',
+            inviteUrl: 'https://x/invite',
+            status: 'sent',
+          },
+        ],
+      },
+    });
+
+    const res = await inviteCandidatesBatch('trial-42', [
+      { name: 'A', email: 'a@example.com' },
+    ]);
+
+    expect(mockRequestTalentPartnerBff).toHaveBeenCalledWith(
+      '/trials/trial-42/invite-candidates',
+      expect.objectContaining({
+        method: 'POST',
+        body: {
+          candidates: [{ name: 'A', email: 'a@example.com' }],
+        },
+      }),
+    );
+    expect(res.invites[0]?.status).toBe('sent');
+    expect(res.invites[0]?.candidateSessionId).toBe('9');
+  });
+
+  it('maps failed invite rows', async () => {
+    mockRequestTalentPartnerBff.mockResolvedValueOnce({
+      data: {
+        invites: [
+          {
+            candidateSessionId: null,
+            name: 'B',
+            email: 'b@example.com',
+            inviteUrl: '',
+            status: 'failed',
+            errorCode: 'TRIAL_TERMINATED',
+            errorMessage: 'Trial has been terminated.',
+          },
+        ],
+      },
+    });
+
+    const res = await inviteCandidatesBatch('trial-1', [
+      { name: 'B', email: 'b@example.com' },
+    ]);
+
+    expect(res.invites[0]?.status).toBe('failed');
+    expect(res.invites[0]?.errorMessage).toBe('Trial has been terminated.');
+  });
+});

--- a/tests/unit/features/talent-partner/api/trialLifecycle.test.ts
+++ b/tests/unit/features/talent-partner/api/trialLifecycle.test.ts
@@ -1,10 +1,12 @@
 import {
   activateTrialInviting,
+  approveTrialForInviting,
   approveScenarioVersion,
   patchScenarioVersion,
   regenerateTrialScenario,
   retryTrialGeneration,
 } from '@/features/talent-partner/api/trialLifecycleApi';
+import { mapActionError } from '@/features/talent-partner/api/trialLifecycle.errorsApi';
 
 const mockRequestTalentPartnerBff = jest.fn();
 
@@ -29,6 +31,19 @@ describe('trialLifecycle', () => {
     expect(result.ok).toBe(false);
     expect(result).toHaveProperty('statusCode');
     expect(result.message).toBeTruthy();
+  });
+
+  it('approveTrialForInviting posts to the trials approve BFF route', async () => {
+    mockRequestTalentPartnerBff.mockResolvedValueOnce({
+      data: { trialId: 1, status: 'active_inviting' },
+    });
+
+    const result = await approveTrialForInviting('trial-77');
+    expect(result.ok).toBe(true);
+    expect(mockRequestTalentPartnerBff).toHaveBeenCalledWith(
+      '/trials/trial-77/approve',
+      { method: 'POST', body: { confirm: true } },
+    );
   });
 
   it('approveScenarioVersion posts to version-specific approve endpoint', async () => {
@@ -74,6 +89,18 @@ describe('trialLifecycle', () => {
     expect(result.message).toMatch(/Unable to activate trial/i);
   });
 
+  it('approveTrialForInviting maps SCENARIO_APPROVAL_PENDING with actionable copy', async () => {
+    mockRequestTalentPartnerBff.mockRejectedValueOnce({
+      status: 409,
+      errorCode: 'SCENARIO_APPROVAL_PENDING',
+    });
+
+    const result = await approveTrialForInviting('trial-88');
+    expect(result.ok).toBe(false);
+    expect(result.errorCode).toBe('SCENARIO_APPROVAL_PENDING');
+    expect(result.message).toMatch(/pending scenario version/i);
+  });
+
   it('patchScenarioVersion returns SCENARIO_LOCKED details from 409 responses', async () => {
     mockRequestTalentPartnerBff.mockRejectedValueOnce({
       status: 409,
@@ -94,6 +121,20 @@ describe('trialLifecycle', () => {
       detail: 'Scenario version is locked.',
       errorCode: 'SCENARIO_LOCKED',
     });
+  });
+
+  it('mapActionError strips raw GitHub URLs from generic mapped messages', () => {
+    const res = mapActionError(
+      {
+        status: 502,
+        message:
+          'GitHub API error (400) (https://api.github.com/repos/o/r/codespaces)',
+      },
+      'Safe fallback',
+    );
+    expect(res.ok).toBe(false);
+    expect(res.message).toBe('Safe fallback');
+    expect(res.message).not.toMatch(/api\.github\.com/);
   });
 
   it('retryTrialGeneration returns ok:false when request rejects', async () => {

--- a/tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.component.interactions.test.tsx
+++ b/tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.component.interactions.test.tsx
@@ -8,7 +8,6 @@ import {
 describe('TalentPartnerTrialDetailPage component interactions', () => {
   beforeEach(() => {
     primeDetailMocks();
-    jest.useFakeTimers();
   });
 
   afterEach(() => {
@@ -18,13 +17,25 @@ describe('TalentPartnerTrialDetailPage component interactions', () => {
   it('opens invite modal', async () => {
     await renderDetailPage();
     await waitFor(() =>
-      expect(screen.getByText(/No candidates yet/i)).toBeInTheDocument(),
+      expect(
+        screen.getByText(/No candidates invited yet/i),
+      ).toBeInTheDocument(),
     );
-    fireEvent.click(screen.getByRole('button', { name: /Invite candidate/i }));
-    expect(await screen.findByTestId('invite-modal')).toBeInTheDocument();
+    const inviteButtons = screen.getAllByRole('button', {
+      name: /^Invite candidates$/i,
+    });
+    const enabled = inviteButtons.find(
+      (b) => !(b as HTMLButtonElement).disabled,
+    );
+    expect(enabled).toBeTruthy();
+    fireEvent.click(enabled!);
+    expect(
+      await screen.findByRole('heading', { name: 'Invite candidates' }),
+    ).toBeInTheDocument();
   });
 
   it('filters candidates by search input', async () => {
+    jest.useFakeTimers();
     listTrialCandidatesMock.mockResolvedValue([
       {
         candidateSessionId: 1,

--- a/tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.component.rendering.test.tsx
+++ b/tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.component.rendering.test.tsx
@@ -1,4 +1,5 @@
 import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   listTrialCandidatesMock,
   primeDetailMocks,
@@ -10,41 +11,61 @@ describe('TalentPartnerTrialDetailPage component rendering', () => {
     primeDetailMocks();
   });
 
-  it('renders the trial plan shell and metadata', async () => {
+  it('shows Active badge and overflow menu for active inviting Trial', async () => {
     await renderDetailPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('trial-active-badge')).toBeInTheDocument(),
+    );
+    expect(screen.getByText('Active')).toBeInTheDocument();
     expect(
-      screen.getByRole('heading', { name: 'Project Brief' }),
+      screen.getByTestId('trial-detail-overflow-menu'),
     ).toBeInTheDocument();
+  });
+
+  it('renders hero, underline tabs, and Brief tab content', async () => {
+    const user = userEvent.setup();
+    await renderDetailPage();
     await waitFor(() =>
       expect(screen.getByText('Test Trial')).toBeInTheDocument(),
     );
-    expect(screen.getByText(/Developer/)).toBeInTheDocument();
-    expect(screen.getByText(/Project brief narrative/i)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Candidates' }),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByRole('button', { name: 'Brief' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Rubric' })).toBeInTheDocument();
     expect(
-      screen.getByText(/Build a project brief from scratch/i),
+      screen.getByRole('button', { name: 'Activity' }),
     ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Brief' }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole('heading', { name: 'Project Brief', level: 3 }),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/UNIQUE_SUPPORTING_DETAIL/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Rubric' }));
     expect(
-      screen.getByText(/Preferred language\/framework/i),
+      screen.getByText(
+        /Winoe will evaluate candidates against these dimensions/i,
+      ),
     ).toBeInTheDocument();
-    expect(screen.getByText(/React \+ TypeScript/)).toBeInTheDocument();
-    expect(screen.getByText(/Rubric summary/i)).toBeInTheDocument();
-    expect(
-      screen.getByText(/Assess clarity, correctness, and resilience/i),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/^Planning and Design Doc$/i)).toBeInTheDocument();
-    expect(screen.getByText(/^Implementation Kickoff$/i)).toBeInTheDocument();
-    expect(screen.getByText(/^Implementation Wrap-Up$/i)).toBeInTheDocument();
-    expect(screen.getByText(/^Handoff \+ Demo$/i)).toBeInTheDocument();
-    expect(screen.getByText(/^Reflection Essay$/i)).toBeInTheDocument();
+
     expect(screen.queryByText(/template/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/tech stack/i)).not.toBeInTheDocument();
   });
 
   it('shows empty candidates state', async () => {
     await renderDetailPage();
-    await waitFor(() =>
-      expect(screen.getByText(/No candidates yet/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No candidates invited yet/i),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/real-work evidence/)).toBeInTheDocument();
+    });
   });
 
   it('renders candidates table rows when candidates exist', async () => {

--- a/tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.component.testlib.tsx
+++ b/tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.component.testlib.tsx
@@ -87,7 +87,19 @@ export const primeDetailMocks = () => {
     techStack: 'React',
     preferredLanguageFramework: 'React + TypeScript',
     focus: 'Testing',
-    scenario: 'Build a project brief from scratch',
+    activeScenarioVersionId: '100',
+    scenario: {
+      id: '100',
+      versionIndex: 1,
+      status: 'ready',
+      storylineMd: 'Short storyline for editor',
+      projectBriefMd:
+        'Build a project brief from scratch\n\nUNIQUE_SUPPORTING_DETAIL.',
+      rubricJson: {},
+      taskPromptsJson: [],
+    },
+    projectBriefMd:
+      'Build a project brief from scratch\n\nUNIQUE_SUPPORTING_DETAIL.',
     rubricSummary: 'Assess clarity, correctness, and resilience.',
     tasks: [
       { dayIndex: 1, title: 'Day 1', type: 'text', prompt: 'Task 1' },

--- a/tests/unit/features/talent-partner/trial-management/detail/TrialDetailTabs.brief.test.tsx
+++ b/tests/unit/features/talent-partner/trial-management/detail/TrialDetailTabs.brief.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TrialDetailTabs } from '@/features/talent-partner/trial-management/detail/components/TrialDetailTabs';
+import type { TrialDetailViewProps } from '@/features/talent-partner/trial-management/detail/components/types';
+
+const scenarioVersion = {
+  id: 'sv-1',
+  versionIndex: 1,
+  status: 'locked',
+  uiStatus: 'locked' as const,
+  lockedAt: '2020-01-01',
+  isLocked: true,
+  isActive: true,
+  isPending: false,
+  contentAvailability: 'canonical' as const,
+  storylineMd: 'STORYLINE_NOT_BRIEF',
+  projectBriefMd: '# Project Brief\n\nONLY_FROM_PROJECT_BRIEF_MD',
+  taskPrompts: [] as Array<Record<string, unknown>>,
+  rubric: {} as Record<string, unknown>,
+};
+
+const search = {
+  search: '',
+  setSearch: jest.fn(),
+  pagedCandidates: [] as const,
+  visibleCandidates: [] as const,
+  page: 1,
+  pageCount: 1,
+  setPage: jest.fn(),
+};
+
+const minimalProps: TrialDetailViewProps = {
+  trialId: 't1',
+  trialStatus: 'active_inviting',
+  selectedScenarioStatusForDisplay: 'locked',
+  scenarioVersionLabel: 'v1',
+  scenarioIdLabel: 'sv-1',
+  scenarioLocked: true,
+  scenarioLockedAt: '2020-01-01',
+  scenarioVersions: [scenarioVersion],
+  selectedScenarioVersionId: 'sv-1',
+  onSelectScenarioVersion: jest.fn(),
+  selectedScenarioVersion: scenarioVersion,
+  previousScenarioVersion: null,
+  scenarioLockBannerMessage: null,
+  scenarioContentUnavailableMessage: null,
+  scenarioGeneratingLabel: null,
+  scenarioEditorDisabled: true,
+  scenarioEditorDisabledReason: null,
+  scenarioEditorSaving: false,
+  scenarioEditorSaveError: null,
+  scenarioEditorFieldErrors: {},
+  scenarioEditorDraft: null,
+  onScenarioEditorDraftChange: jest.fn(),
+  onSaveScenarioEdits: jest.fn(),
+  inviteEnabled: true,
+  inviteDisabledReason: null,
+  inviteResendEnabled: true,
+  inviteResendDisabledReason: null,
+  actionError: null,
+  canApprove: false,
+  approveButtonLabel: 'Approve',
+  approveLoading: false,
+  onApprove: jest.fn(),
+  regenerateLoading: false,
+  regenerateDisabled: true,
+  onRegenerate: jest.fn(),
+  terminatePending: false,
+  terminateModalOpen: false,
+  setTerminateModalOpen: jest.fn(),
+  onTerminate: jest.fn(async () => {}),
+  cleanupJobIds: [],
+  retryGenerateLoading: false,
+  onRetryGenerate: jest.fn(),
+  titleLabel: 'T',
+  roleLabel: 'R',
+  preferredLanguageFrameworkLabel: 'Py',
+  levelLabel: 'Mid',
+  focusLabel: 'F',
+  companyContextLabel: 'C',
+  notesLabel: null,
+  aiConfig: null,
+  scenarioLabel: 'WRONG_SCENARIO_LABEL',
+  rubricSummary: null,
+  scenarioContentUnavailableMessageForPlan: null,
+  planDays: [],
+  planLoading: false,
+  planStatusCode: null,
+  generating: false,
+  jobFailureMessage: null,
+  jobFailureCode: null,
+  planError: null,
+  reloadPlan: jest.fn(),
+  canActivate: false,
+  activateButtonLabel: 'Activate',
+  activateLoading: false,
+  onActivate: jest.fn(async () => {}),
+  candidates: [],
+  candidatesLoading: false,
+  candidatesError: null,
+  reloadCandidates: jest.fn(),
+  search,
+  rowStates: {},
+  onCopy: jest.fn(),
+  onResend: jest.fn(),
+  onCloseManual: jest.fn(),
+  cooldownNow: 0,
+  inviteModalOpen: false,
+  setInviteModalOpen: jest.fn(),
+  inviteFlowState: { status: 'idle' },
+  submitInvite: jest.fn(async () => {}),
+  resetInviteFlow: jest.fn(),
+};
+
+describe('TrialDetailTabs Brief', () => {
+  it('renders Project Brief from projectBriefMd, not scenario label', async () => {
+    const user = userEvent.setup();
+    render(<TrialDetailTabs props={minimalProps} onInvite={jest.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: 'Brief' }));
+
+    const heading = screen.getByRole('heading', {
+      name: 'Project Brief',
+      level: 3,
+    });
+    const region = heading.parentElement;
+    expect(region).toBeTruthy();
+    expect(
+      within(region!).getByText(/ONLY_FROM_PROJECT_BRIEF_MD/),
+    ).toBeInTheDocument();
+    expect(
+      within(region!).queryByText('WRONG_SCENARIO_LABEL'),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('TrialDetailTabs Activity', () => {
+  it('summarizes locked scenario and invited candidates', async () => {
+    const user = userEvent.setup();
+    const props: TrialDetailViewProps = {
+      ...minimalProps,
+      candidates: [
+        {
+          candidateSessionId: 1,
+          inviteEmail: 'a@example.com',
+          candidateName: 'A',
+          status: 'not_started',
+          startedAt: null,
+          completedAt: null,
+          hasReport: false,
+          inviteUrl: 'https://example.com/invite/1',
+          inviteEmailSentAt: '2026-05-01T12:00:00.000Z',
+        },
+      ],
+    };
+    render(<TrialDetailTabs props={props} onInvite={jest.fn()} />);
+    await user.click(screen.getByRole('button', { name: 'Activity' }));
+    expect(
+      await screen.findByText(/Scenario v1 is locked/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/1 candidate invite link\(s\) are available/i),
+    ).toBeInTheDocument();
+  });
+
+  it('shows empty state when there is no scenario milestone or invites', async () => {
+    const user = userEvent.setup();
+    const props: TrialDetailViewProps = {
+      ...minimalProps,
+      selectedScenarioVersion: {
+        ...scenarioVersion,
+        uiStatus: 'generating',
+        isLocked: false,
+      },
+      candidates: [],
+    };
+    render(<TrialDetailTabs props={props} onInvite={jest.fn()} />);
+    await user.click(screen.getByRole('button', { name: 'Activity' }));
+    expect(
+      await screen.findByText(/No Trial activity recorded yet/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/unit/features/talent-partner/trial-management/detail/components/CandidatesTable.gap.test.tsx
+++ b/tests/unit/features/talent-partner/trial-management/detail/components/CandidatesTable.gap.test.tsx
@@ -78,10 +78,10 @@ describe('CandidatesTable gap coverage', () => {
     });
     render(<CandidatesTable {...props} />);
     const inviteButton = screen.getByRole('button', {
-      name: /Invite your first candidate/i,
+      name: /Invite candidates/i,
     });
 
-    expect(screen.getByText('No candidates yet')).toBeInTheDocument();
+    expect(screen.getByText('No candidates invited yet.')).toBeInTheDocument();
     expect(inviteButton).toBeDisabled();
     expect(inviteButton).toHaveAttribute(
       'title',

--- a/tests/unit/features/talent-partner/trial-management/detail/components/TerminateTrialModal.test.tsx
+++ b/tests/unit/features/talent-partner/trial-management/detail/components/TerminateTrialModal.test.tsx
@@ -42,6 +42,21 @@ describe('TerminateTrialModal', () => {
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
+  it('uses neutral cleanup copy instead of destructive wording', () => {
+    render(
+      <TerminateTrialModal
+        open={true}
+        pending={false}
+        onClose={() => {}}
+        onConfirm={() => {}}
+      />,
+    );
+    expect(
+      screen.getByText(/Candidate access will be revoked/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/destructive/i)).not.toBeInTheDocument();
+  });
+
   it('disables controls while request is pending', () => {
     render(
       <TerminateTrialModal

--- a/tests/unit/features/talent-partner/trial-management/invitations/InviteCandidateModal.a11y.test.tsx
+++ b/tests/unit/features/talent-partner/trial-management/invitations/InviteCandidateModal.a11y.test.tsx
@@ -39,7 +39,7 @@ describe('InviteCandidateModal a11y gap coverage', () => {
     const dialog = screen.getByRole('dialog');
     expect(dialog).toHaveAttribute('aria-modal', 'true');
     expect(
-      screen.getByRole('heading', { name: /Invite candidate/i }),
+      screen.getByRole('heading', { name: /Invite candidates/i }),
     ).toBeInTheDocument();
 
     const nameInput = screen.getByLabelText(/Candidate name/i);

--- a/tests/unit/features/talent-partner/trial-management/invitations/InviteCandidatesBatchModal.test.tsx
+++ b/tests/unit/features/talent-partner/trial-management/invitations/InviteCandidatesBatchModal.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  InviteCandidatesBatchModal,
+  formatInviteBatchFailureMessage,
+} from '@/features/talent-partner/trial-management/invitations/InviteCandidatesBatchModal';
+import type { InviteBatchUiState } from '@/features/talent-partner/trial-management/invitations/InviteBatchCandidateTypes';
+
+jest.mock('@/features/talent-partner/utils/formattersUtils', () => ({
+  copyInviteLink: jest.fn().mockResolvedValue(undefined),
+}));
+
+function renderModal(state: InviteBatchUiState) {
+  const onClose = jest.fn();
+  const onSubmit = jest.fn();
+  render(
+    <InviteCandidatesBatchModal
+      open
+      title="Acme · Senior Engineer"
+      state={state}
+      onClose={onClose}
+      onSubmit={onSubmit}
+    />,
+  );
+  return { onClose, onSubmit };
+}
+
+describe('formatInviteBatchFailureMessage', () => {
+  it('replaces SQLAlchemy / asyncpg errors with a safe message', () => {
+    const raw =
+      '(sqlalchemy.dialects.postgresql.asyncpg.ProgrammingError) column "workspace_provisioning_status" does not exist [SQL: INSERT INTO workspaces';
+    expect(formatInviteBatchFailureMessage(raw)).toBe(
+      'Something went wrong on our side while preparing this invite. Please try again in a moment. If this keeps happening, contact support.',
+    );
+  });
+
+  it('passes through normal product errors', () => {
+    expect(formatInviteBatchFailureMessage('Trial has been terminated.')).toBe(
+      'Trial has been terminated.',
+    );
+  });
+});
+
+describe('InviteCandidatesBatchModal', () => {
+  it('requires full name and email', async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal({ status: 'idle' });
+
+    await user.click(screen.getByRole('button', { name: /Send invite/i }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(
+      screen.getAllByText('Full name is required.').length,
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText('Email is required.').length).toBeGreaterThan(0);
+  });
+
+  it('rejects duplicate emails in the modal', async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal({ status: 'idle' });
+
+    await user.type(screen.getByLabelText(/Full name \(row 1\)/i), 'A');
+    await user.type(
+      screen.getByLabelText(/Email \(row 1\)/i),
+      'dup@example.com',
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: /Add another candidate/i }),
+    );
+
+    const nameFields = screen.getAllByLabelText(/Full name \(row/i);
+    const emailFields = screen.getAllByLabelText(/Email \(row/i);
+    await user.type(nameFields[1]!, 'B');
+    await user.type(emailFields[1]!, 'dup@example.com');
+
+    expect(
+      screen.getByText('Duplicate email in this list.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Send 2 invites/i }),
+    ).toBeDisabled();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('sends multiple candidates when valid', async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal({ status: 'idle' });
+
+    await user.type(
+      screen.getByLabelText(/Full name \(row 1\)/i),
+      'Jordan Smith',
+    );
+    await user.type(
+      screen.getByLabelText(/Email \(row 1\)/i),
+      'jordan@example.com',
+    );
+    await user.click(
+      screen.getByRole('button', { name: /Add another candidate/i }),
+    );
+
+    const nameFields = screen.getAllByLabelText(/Full name \(row/i);
+    const emailFields = screen.getAllByLabelText(/Email \(row/i);
+    await user.type(nameFields[1]!, 'Sam Lee');
+    await user.type(emailFields[1]!, 'sam@example.com');
+
+    await user.click(screen.getByRole('button', { name: /Send 2 invites/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith([
+      { name: 'Jordan Smith', email: 'jordan@example.com' },
+      { name: 'Sam Lee', email: 'sam@example.com' },
+    ]);
+  });
+
+  it('shows copyable invite URLs after success', () => {
+    renderModal({
+      status: 'success',
+      message: '2 invites sent.',
+      invites: [
+        {
+          candidateSessionId: 'cs1',
+          name: 'Jordan Smith',
+          email: 'jordan@example.com',
+          inviteUrl: 'https://app.test/invite/jordan',
+          status: 'sent',
+        },
+        {
+          candidateSessionId: 'cs2',
+          name: 'Sam Lee',
+          email: 'sam@example.com',
+          inviteUrl: 'https://app.test/invite/sam',
+          status: 'sent',
+        },
+      ],
+    });
+
+    expect(screen.getByTestId('invite-batch-success')).toBeInTheDocument();
+    expect(screen.getByText('2 invites sent.')).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue('https://app.test/invite/jordan'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue('https://app.test/invite/sam'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument();
+  });
+
+  it('shows per-row failures in success state', () => {
+    renderModal({
+      status: 'success',
+      message: '1 invite sent; 1 failed. Review errors below.',
+      invites: [
+        {
+          candidateSessionId: 'cs1',
+          name: 'Jordan Smith',
+          email: 'jordan@example.com',
+          inviteUrl: 'https://app.test/invite/jordan',
+          status: 'sent',
+        },
+        {
+          candidateSessionId: '',
+          name: 'Bad Row',
+          email: 'bad@example.com',
+          inviteUrl: '',
+          status: 'failed',
+          errorMessage: 'Trial has been terminated.',
+        },
+      ],
+    });
+
+    expect(screen.getByText(/Could not send/i)).toBeInTheDocument();
+    expect(screen.getByText('Trial has been terminated.')).toBeInTheDocument();
+  });
+
+  it('sanitizes ORM errors in failed invite rows', () => {
+    const sqlish =
+      '(sqlalchemy.dialects.postgresql.asyncpg.ProgrammingError) column "x" does not exist [SQL: INSERT INTO workspaces';
+    renderModal({
+      status: 'success',
+      message: 'No invites were sent (1 failed). Review the errors below.',
+      invites: [
+        {
+          candidateSessionId: '',
+          name: 'Bad Row',
+          email: 'bad@example.com',
+          inviteUrl: '',
+          status: 'failed',
+          errorMessage: sqlish,
+        },
+      ],
+    });
+
+    expect(
+      screen.getByText(
+        'Something went wrong on our side while preparing this invite. Please try again in a moment. If this keeps happening, contact support.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(sqlish)).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/features/talent-partner/trial-management/list/TrialListRow.test.tsx
+++ b/tests/unit/features/talent-partner/trial-management/list/TrialListRow.test.tsx
@@ -46,7 +46,7 @@ describe('TrialListRow', () => {
     expect(screen.getByText('0 candidate(s)')).toBeInTheDocument();
     expect(screen.getByText('Active inviting')).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /Invite candidate/i }),
+      screen.getByRole('button', { name: /Invite candidates/i }),
     ).toBeInTheDocument();
     expect(screen.queryByText(/Template:/i)).toBeNull();
   });

--- a/tests/unit/features/talent-partner/trial-management/preview/TrialPreviewContent.test.tsx
+++ b/tests/unit/features/talent-partner/trial-management/preview/TrialPreviewContent.test.tsx
@@ -1,0 +1,308 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TrialPreviewContent } from '@/features/talent-partner/trial-management/preview/TrialPreviewContent';
+
+const mockReload = jest.fn();
+const mockPush = jest.fn();
+const mockRefresh = jest.fn();
+const mockNotify = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    refresh: mockRefresh,
+  }),
+}));
+
+jest.mock('@/shared/notifications', () => ({
+  useNotifications: () => ({ notify: mockNotify }),
+}));
+
+const approveTrialForInviting = jest.fn();
+const regenerateTrialScenario = jest.fn();
+const terminateTrial = jest.fn();
+
+jest.mock('@/features/talent-partner/api/trialLifecycleApi', () => ({
+  approveTrialForInviting: (...a: unknown[]) => approveTrialForInviting(...a),
+  regenerateTrialScenario: (...a: unknown[]) => regenerateTrialScenario(...a),
+  terminateTrial: (...a: unknown[]) => terminateTrial(...a),
+}));
+
+const useTrialPlanMock = jest.fn();
+
+jest.mock(
+  '@/features/talent-partner/trial-management/detail/hooks/useTrialPlan',
+  () => ({
+    useTrialPlan: (...args: unknown[]) => useTrialPlanMock(...args),
+  }),
+);
+
+function readyDetail() {
+  return {
+    status: 'ready_for_review' as const,
+    statusRaw: 'ready_for_review',
+    projectBrief: '# Project Brief\n\nONLY_IN_PROJECT_BRIEF **body**.',
+    storyline: 'STORYLINE_SHOULD_NOT_RENDER_AS_BRIEF',
+    rubricJson: [{ dimension: 'Clarity', criteria: 'Readable', weight: '30%' }],
+    rubricSummary: 'Summary',
+    level: 'Senior',
+    plan: {
+      role: 'Backend Engineer',
+      preferredLanguageFramework: 'Go',
+      days: [
+        { dayIndex: 1, title: 'D1', type: 'text', prompt: 'Custom day 1' },
+      ],
+    },
+    scenarioVersion: { status: 'ready', id: 'sv1' },
+    generationJob: null,
+    hasJobFailure: false,
+  };
+}
+
+describe('TrialPreviewContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    approveTrialForInviting.mockResolvedValue({ ok: true });
+    regenerateTrialScenario.mockResolvedValue({ ok: true });
+    terminateTrial.mockResolvedValue({ ok: true });
+    mockReload.mockResolvedValue(undefined);
+  });
+
+  it('renders tags, Project Brief, rubric, cadence, and sticky decision panel', () => {
+    useTrialPlanMock.mockReturnValue({
+      detail: readyDetail(),
+      plan: readyDetail().plan,
+      loading: false,
+      error: null,
+      statusCode: null,
+      isGenerating: false,
+      reload: mockReload,
+    });
+
+    render(<TrialPreviewContent trialId="trial-99" />);
+
+    expect(
+      screen.getAllByText('Backend Engineer').length,
+    ).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Go').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('5-day Trial')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Project Brief', level: 2 }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/ONLY_IN_PROJECT_BRIEF/)).toBeInTheDocument();
+    expect(
+      screen.queryByText('STORYLINE_SHOULD_NOT_RENDER_AS_BRIEF'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Evaluation Rubric' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', { name: 'Dimension' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Clarity')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Suggested Daily Cadence' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Day 1 — Design Doc')).toBeInTheDocument();
+    expect(screen.getByText('Custom day 1')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Approve this Trial?' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Approve & Invite Candidates' }),
+    ).toBeInTheDocument();
+  });
+
+  it('approve calls API and redirects to Trial Detail', async () => {
+    const user = userEvent.setup();
+    useTrialPlanMock.mockReturnValue({
+      detail: readyDetail(),
+      plan: readyDetail().plan,
+      loading: false,
+      error: null,
+      statusCode: null,
+      isGenerating: false,
+      reload: mockReload,
+    });
+
+    render(<TrialPreviewContent trialId="trial-99" />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Approve & Invite Candidates' }),
+    );
+
+    await waitFor(() => {
+      expect(approveTrialForInviting).toHaveBeenCalledWith('trial-99');
+    });
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tone: 'success',
+        title: 'Trial approved',
+      }),
+    );
+    expect(mockPush).toHaveBeenCalledWith('/talent-partner/trials/trial-99');
+  });
+
+  it('approve with SCENARIO_APPROVAL_PENDING uses warning notification tone', async () => {
+    const user = userEvent.setup();
+    approveTrialForInviting.mockResolvedValueOnce({
+      ok: false,
+      statusCode: 409,
+      errorCode: 'SCENARIO_APPROVAL_PENDING',
+      message:
+        'A regenerated Project Brief is waiting for your approval. Open this Trial, select the pending scenario version, approve that brief, then return here to approve the Trial for inviting.',
+      details: null,
+    });
+    useTrialPlanMock.mockReturnValue({
+      detail: readyDetail(),
+      plan: readyDetail().plan,
+      loading: false,
+      error: null,
+      statusCode: null,
+      isGenerating: false,
+      reload: mockReload,
+    });
+
+    render(<TrialPreviewContent trialId="trial-99" />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Approve & Invite Candidates' }),
+    );
+
+    await waitFor(() => {
+      expect(mockNotify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tone: 'warning',
+          title: 'Approve the regenerated brief first',
+        }),
+      );
+    });
+  });
+
+  it('regenerate navigates to Trial Detail after success', async () => {
+    const user = userEvent.setup();
+    useTrialPlanMock.mockReturnValue({
+      detail: readyDetail(),
+      plan: readyDetail().plan,
+      loading: false,
+      error: null,
+      statusCode: null,
+      isGenerating: false,
+      reload: mockReload,
+    });
+
+    render(<TrialPreviewContent trialId="trial-99" />);
+
+    await user.click(screen.getByRole('button', { name: 'Regenerate' }));
+
+    await waitFor(() => {
+      expect(regenerateTrialScenario).toHaveBeenCalledWith('trial-99');
+    });
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/talent-partner/trials/trial-99');
+    });
+    expect(mockReload).not.toHaveBeenCalled();
+  });
+
+  it('regenerate shows clean error when API rejects', async () => {
+    const user = userEvent.setup();
+    regenerateTrialScenario.mockResolvedValue({
+      ok: false,
+      message: 'Not allowed',
+    });
+    useTrialPlanMock.mockReturnValue({
+      detail: readyDetail(),
+      plan: readyDetail().plan,
+      loading: false,
+      error: null,
+      statusCode: null,
+      isGenerating: false,
+      reload: mockReload,
+    });
+
+    render(<TrialPreviewContent trialId="trial-99" />);
+
+    await user.click(screen.getByRole('button', { name: 'Regenerate' }));
+
+    await waitFor(() => {
+      expect(mockNotify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tone: 'error',
+          title: 'Regeneration unavailable',
+          description: 'Not allowed',
+        }),
+      );
+    });
+  });
+
+  it('discard opens confirmation modal', async () => {
+    const user = userEvent.setup();
+    useTrialPlanMock.mockReturnValue({
+      detail: readyDetail(),
+      plan: readyDetail().plan,
+      loading: false,
+      error: null,
+      statusCode: null,
+      isGenerating: false,
+      reload: mockReload,
+    });
+
+    render(<TrialPreviewContent trialId="trial-99" />);
+
+    await user.click(screen.getByRole('button', { name: 'Discard draft' }));
+
+    expect(screen.getByTestId('discard-draft-modal')).toBeInTheDocument();
+    expect(
+      screen.getByText(/ends the Trial as terminated/i),
+    ).toBeInTheDocument();
+  });
+
+  it('Print brief as PDF calls window.print', async () => {
+    const user = userEvent.setup();
+    const printSpy = jest.spyOn(window, 'print').mockImplementation(() => {});
+    useTrialPlanMock.mockReturnValue({
+      detail: readyDetail(),
+      plan: readyDetail().plan,
+      loading: false,
+      error: null,
+      statusCode: null,
+      isGenerating: false,
+      reload: mockReload,
+    });
+
+    render(<TrialPreviewContent trialId="trial-99" />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Print brief as PDF' }),
+    );
+
+    expect(printSpy).toHaveBeenCalled();
+    printSpy.mockRestore();
+  });
+
+  it('shows generation state when Trial is generating', () => {
+    useTrialPlanMock.mockReturnValue({
+      detail: {
+        ...readyDetail(),
+        status: 'generating' as const,
+        projectBrief: '',
+        storyline: '',
+        rubricSummary: '',
+        plan: { ...readyDetail().plan, days: [] },
+      },
+      plan: { ...readyDetail().plan, days: [] },
+      loading: false,
+      error: null,
+      statusCode: null,
+      isGenerating: true,
+      reload: mockReload,
+    });
+
+    render(<TrialPreviewContent trialId="trial-99" />);
+
+    expect(screen.getByText(/Generation in progress/i)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/features/talent-partner/trial-management/preview/rubricMapper.test.ts
+++ b/tests/unit/features/talent-partner/trial-management/preview/rubricMapper.test.ts
@@ -1,0 +1,21 @@
+import { mapRubricJsonToRows } from '@/features/talent-partner/trial-management/preview/rubricMapper';
+
+describe('mapRubricJsonToRows', () => {
+  it('maps array of dimension objects', () => {
+    const rows = mapRubricJsonToRows([
+      {
+        dimension: 'Architecture',
+        whatWinoeWillLookFor: 'Clear structure',
+        weight: 0.3,
+      },
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].dimension).toBe('Architecture');
+    expect(rows[0].whatWinoeWillLookFor).toBe('Clear structure');
+    expect(rows[0].weightLabel).toBe('0.3');
+  });
+
+  it('returns empty for null', () => {
+    expect(mapRubricJsonToRows(null)).toEqual([]);
+  });
+});

--- a/tests/unit/talent-partner/InviteCandidateModal.test.tsx
+++ b/tests/unit/talent-partner/InviteCandidateModal.test.tsx
@@ -131,7 +131,7 @@ describe('InviteCandidateModal', () => {
 
     expect(screen.getByTestId('invite-success')).toBeInTheDocument();
     expect(
-      screen.getByRole('heading', { name: /Invite candidate/i }),
+      screen.getByRole('heading', { name: /Invite candidates/i }),
     ).toBeInTheDocument();
     expect(screen.getByLabelText(/Invite URL/i)).toHaveValue(
       'https://example.com/candidate/session/token-123',


### PR DESCRIPTION
# Task 5 (Iteration 2): Trial Preview, Approval, Detail, and Candidate Invite

## Summary

- **Trial Preview** at `/talent-partner/trials/{id}/preview`: Project Brief from **`readProjectBrief` / `detail.projectBrief`** (canonical markdown), not the scenario label; honest fallback when only storyline-like content exists. Rubric table, cadence, sticky actions (approve, regenerate, discard, print).
- **Trial Detail** tabs: **Brief** uses **`selectedScenarioVersion.projectBriefMd`** (version snapshot), not `scenarioLabel`. **MarkdownRenderer** uses design-token-friendly defaults where adjusted (e.g. `pre` surface).
- **Batch invite** modal: token-oriented styling, **`fieldset` / `legend`**, row-scoped labels (**`Full name (row n)`**, **`Email (row n)`**), duplicate validation, **`aria-live`** summary, success UI lists **sent** and **failed** rows with per-row errors; invite URLs copyable with accessible controls.
- **BFF**: Next routes under `src/app/api/trials/[id]/approve` and `invite-candidates` forward to the backend; clients use **`requestTalentPartnerBff`** with **`/trials/{id}/approve`** and **`/trials/{id}/invite-candidates`** (same convention as other trial BFF calls — not `/backend/trials/...`).

## Preview / Detail data sources

| Surface            | Project Brief source                                                                                  |
| ------------------ | ----------------------------------------------------------------------------------------------------- |
| Preview            | `detail.projectBrief` from normalized trial detail / `readProjectBrief()`; not scenario display label |
| Detail → Brief tab | Active / selected scenario snapshot **`projectBriefMd`**                                              |

Scenario label / version string is **not** used as a stand-in for the Project Brief.

## BFF / API route paths

- **`approveTrialForInviting`**: `POST` **`/trials/{id}/approve`** via `requestTalentPartnerBff`.
- **`inviteCandidatesBatch`**: `POST` **`/trials/{id}/invite-candidates`** via `requestTalentPartnerBff`.
- Unit tests assert these URL paths (see `trialLifecycle.test.ts`, `invitesBatchApi.test.ts`).

## Invite modal behavior

- Duplicate emails in the form: user-visible errors; row-specific **`id` / `htmlFor`** wiring for multiple rows.
- API partial success: **`status: 'failed'`** rows show **`errorCode` / `errorMessage`**; **`useInviteBatchCandidateFlow`** (and related copy) treats mixed sent/failed outcomes explicitly.

## Regenerate / discard

- **Regenerate**: on success, navigates to **`/talent-partner/trials/{id}`** with **`router.refresh`** so the Talent Partner lands on the **Task 4-style trial detail / generation** experience instead of a stale preview-only reload.
- **Discard draft**: calls **`terminateTrial`**; modal copy describes **termination** (draft ends in **terminated** state), not a misleading “hard delete” promise if the backend archives/terminates rather than destroying rows.

## Components / files (non-exhaustive)

- `src/shared/ui/MarkdownRenderer.tsx`
- `src/features/talent-partner/trial-management/preview/TrialPreviewContent.tsx`
- `src/features/talent-partner/trial-management/detail/components/TrialDetailTabs.tsx`
- `src/features/talent-partner/trial-management/invitations/InviteCandidatesBatchModal.tsx`, `InviteInputField.tsx`
- `src/features/talent-partner/api/trialLifecycle.actions.approveApi.ts`, `invitesBatchApi.ts`
- `src/app/api/trials/[id]/approve/route.ts`, `invite-candidates/route.ts`

## Tests run

```bash
npm run lint
npm run typecheck
npm test -- --runInBand
```

**Pass** (Iteration 2): **517** test suites, **1640** tests; Prettier + ESLint clean.

## Iteration 5 — Manual QA blocker fixes (May 2026)

- **Trial Detail (active inviting)**: **Regenerate** moved into the **overflow menu** (with Edit details / Terminate); primary header actions stay **Invite candidates** + **More**. **Scenario workbench** is tucked under **“Advanced — scenario workbench”** `<details>` so tabs + Candidates stay the default surface.
- **Lock copy**: Scenario lock messaging no longer claims “invites exist” by default; it states the version is locked because the **Trial is approved for inviting**.
- **Preview approve UX**: **`SCENARIO_APPROVAL_PENDING`** surfaces as a **warning**-tone notification (not a generic error-only toast).
- **Action error sanitization**: `mapActionError` strips UI-facing strings that include **`api.github.com`** or **`GitHub API error`** before falling back to a safe message.
- **Print brief as PDF**: Existing unit test continues to assert **`window.print`** via the **Print brief as PDF** button; print CSS still hides **`.tp-no-print`** chrome.

### Manual QA rerun (this iteration)

- **Not claimed as pass**: Full browser manual QA was **not** re-run end-to-end in this agent session after these changes.
- **`./precommit.sh`** remains the automated gate for this branch.

## Known limitations

- If the backend regeneration endpoint does not fully mirror Task 4’s streaming/progress contract, the UI still relies on **detail refresh + trial route** for progress; any gap is owned by backend/Task 4 alignment.
- **Activity** tab has no dedicated audit API yet; it summarizes **scenario approval/lock** and **invite-related candidate row signals** (invite URL / sent timestamp) from existing detail data.
- No browser QA or screenshots in this pass.

## Iteration 7 (May 2026)

- **Prettier**: `InviteCandidatesBatchModal` + batch modal tests formatted; `./precommit.sh` green.
- **Activity tab**: `TrialDetailTabs` shows short bullets when the scenario is **approved/locked** or **ready for review**, and when candidates have **invite URLs** or **invite email sent** timestamps; otherwise the previous empty-state copy remains.
- **Tests**: `TrialDetailTabs.brief.test.tsx` extended with Activity coverage.
- **Manual QA**: Full invite/GitHub tree pass **not re-run** in this session; follow backend `pr.md` Iteration 7 for log/tree verification steps.

## Iteration 9 (May 2026)

- **No frontend code changes** for this iteration; behavior depends on backend fixes in **`winoe-ai-backend` `pr.md` → Iteration 9** (Anthropic scenario generation request ordering + richer error classification; invite email persistence uses **`flush`** so batch + Codespace finalization share one coherent transaction boundary per row).
- **Manual QA**: Full two-candidate + real LLM path **not re-run** in this agent session (no provider keys in the environment). Re-run the supervisor checklist once backend is deployed with keys.

## Iteration 11 (May 2026) — Stabilization (precommit, BFF, seed, generation UI)

### Root causes fixed

- **Backend coverage gate**: Total coverage was fractionally under **96%** while rounding to `96.00%`. Added **approve lifecycle unit tests**, **Anthropic `call_anthropic_json` contract tests**, and **batch invite / provisioning** tests so the gate clears without lowering `cov-fail-under`.
- **Next BFF 500 on `/api/trials`**: `forwardJson` always called **`getSessionNormalized()`** after BFF auth succeeded; in local/dev that call can **throw** (Auth0/session edge cases), turning good upstream calls into **500**. Session lookup is now **best-effort** inside a `try`/`catch`; **`x-dev-user-email`** is omitted when lookup fails instead of failing the proxy.
- **Scenario generation model / env drift**: Repo **`.env`** still pinned **`WINOE_SCENARIO_GENERATION_MODEL=claude-opus-4-7`** while defaults moved to **`claude-3-5-sonnet-20241022`** (Anthropic Messages API–friendly). **`.env`**, **`runBackend.sh` default**, and **`SettingsFields`** are aligned so local runs and tests resolve the same model.
- **`scenario_generation_llm_failed` grepability**: Added a second plain-text log line **`scenario_generation_llm_failed_message errorSummary=…`** after the structured warning so aggregators that drop `extra=` still surface **`errorSummary=`** for classification.
- **Local QA seed**: **`scripts/local_qa_backend.sh`** now runs **`poetry run python scripts/seed_local_talent_partners.py`** after migrations (idempotent; **`WINOE_LOCAL_QA_SKIP_SEED=1`** to skip). Shell test documents **`WINOE_LOCAL_QA_SKIP_SEED`** alongside the alembic skip guard.
- **Generation wizard stuck on “Drafting”**: While SSE remains primary, the wizard now **polls `GET /api/trials/{id}`** for **`generationStatus === 'failed'`** (and **`ready_for_review`**) so a missed **`failed`** SSE frame does not leave the UI spinning forever. Failed state adds **Back to Trials** next to **Edit context** / **Try again**.

### Files changed (representative)

- `src/platform/server/bff/forward.ts` — resilient Auth0 session read for dev email header.
- `src/features/talent-partner/trial-management/create/NewTrialWizard.tsx` — detail polling + return control.
- `tests/trials/services/test_trials_lifecycle_approve_service_unit.py`, `tests/ai/test_ai_provider_clients_call_anthropic_json_contract.py`, `tests/trials/services/test_trials_invite_batch_service.py`, `tests/scripts/test_local_qa_backend_shell.py` — coverage and script guards.

### Commands run (this session)

- **`cd winoe-ai-backend && ./precommit.sh`**: **PASS** (after fixes).
- **`cd winoe-ai-frontend && ./precommit.sh`**: **PASS**.

### Anthropic / job `aba0f408-d6ea-4f7c-89f6-295a90001482`

- **No server log artifact** was present in this workspace for that job id; classification from stored logs was **not possible** here. With the new **`scenario_generation_llm_failed_message errorSummary=`** line and aligned model default, re-run generation and grep worker output for **`anthropic_request_failed:`** + **`tool_attempt=`** / **`json_prompt_attempt=`** to classify (**invalid model** vs **payload/schema** vs **account/entitlement** vs **429**/outage).

### Known limitations

- **Full narrow live smoke** (backend + Next + curl BFF) was **not** executed in this session (no long-running servers started). **Recommendation**: run the supervisor’s narrow smoke checklist on a dev machine with DB + keys before full Task 5 manual QA.
- **Not CODE READY** note **superseded** by **Final Task 5 QA Signoff — CODE READY** (post–Iteration 12) below.

## Final Task 5 QA Signoff — CODE READY

### Status

**CODE READY — proceed to final handoff / PR packaging.**

The frontend passed the Task 5 Talent Partner flow in live manual QA after Iteration 12. **Task 5 is CODE READY despite the Anthropic billing caveat** below — the UI path was fully verified in demo mode after real generation failed only for provider account/credits, not for frontend implementation defects.

### Final verification summary

- Frontend `./precommit.sh`: PASS
- Backend `./precommit.sh`: PASS
- `/api/dev/qa-login`: PASS
- BFF `GET /api/trials`: PASS
- BFF `POST /api/v1/trials`: PASS
- BFF `GET /api/trials/{id}`: PASS
- Trial Preview rendered correctly: PASS
- Approve through UI: PASS
- Active Trial Detail rendered correctly: PASS
- Two-candidate invite modal: PASS
- Invite URLs visible/copyable: PASS
- Candidate rows refreshed: PASS
- Repo tree proof passed for both candidates: PASS
- README proof passed for both candidates: PASS
- Termination UI: PASS
- No raw provider errors in the final successful Talent Partner UI path: PASS

### Preview / approval

Verified on Trial ID `3`.

The Preview page showed:

- Tags row
- Actual Project Brief
- Rubric table
- Daily cadence pills
- Sticky decision panel
- Print path
- Approval flow

Approval worked through the Talent Partner UI and moved the Trial to active detail.

### Active Trial Detail

Verified:

- Hero/title
- Role context
- Active badge
- Invite candidates button
- Overflow menu
- Tabs: Candidates / Brief / Rubric / Activity
- Scenario workbench behind Advanced
- Brief tab showing approved Project Brief
- Rubric tab showing approved rubric

### Candidate invite UI

Verified candidate emails:

```txt
task5-final-a+1778782430@example.com
task5-final-b+1778782430@example.com
```

Both invites returned as sent with visible/copyable invite URLs.

The UI correctly represented workspace setup as needing attention because Codespace provisioning failed externally, while repo bootstrap succeeded.

No raw provider errors were visible in the final successful Talent Partner UI path.

### Termination UI

Verified:

- Neutral termination copy.
- Checkbox confirmation.
- Trial terminated state.
- Invite/resend/copy actions disabled.
- Cleanup-in-progress messaging with job id.
- No raw provider errors.

### Real LLM caveat

Real LLM generation was attempted before demo-mode QA. Anthropic returned a billing/credit error:

```txt
credit balance too low
```

Classification:

```txt
quota / billing / insufficient Anthropic credits
```

The full Task 5 UI/invite/repo/termination QA was completed using demo mode after this provider-account failure. This is acceptable for Task 5 signoff because the frontend flow itself passed and the real-generation failure is not a frontend implementation blocker.

### Operational note

During QA, local DB Alembic drift caused invite failures before the schema was corrected. After the DB was brought to the true repo head and migration `202605120001` was actually applied, the invite flow passed.

Optional follow-up:

- Ensure local QA setup detects schema drift before the Talent Partner invite flow.
- Continue sanitizing backend-originated ORM/SQL failures defensively, even though the correct fix is migration hygiene.
