### PR TITLE
Task 11: Background Jobs Hardening + Operator Tooling + Notifications

### DIFF
--- a/pr.md
+++ b/pr.md
@@ -1,140 +1,84 @@
-# Task 9: Complete Candidate Days 2–5 Trial Experience
+# Task 11: Surface verified report evidence and finalized candidate states
 
-## Status
+## Summary
 
-PASS — Task 9 is fully addressed, manually end-to-end QA verified, and ready for PR.
+- Surfaces backend-validated Winoe Report evidence in the Talent Partner report experience.
+- Updates candidate portal report states so pending, finalized/reviewed, and Talent Partner-shared reports are distinct.
+- Gates internal AI/runtime controls behind backend-provided viewer capabilities.
+- Aligns frontend normalization with backend citation payload fields used by the Task 11 Evidence Trail.
+- Task 11 is code ready and approved for QA signoff / PR prep based on Iteration 5 verification.
 
-## Frontend Summary
+## Frontend Implementation Details
 
-- Implements and hardens the candidate-facing Day 2/3 implementation workspace experience.
-- Adds GitHub username gating before Codespace access.
-- Updates Day 2 and Day 3 workspace copy to reflect from-scratch Codespace work.
-- Aligns run-tests UI state with the `succeeded` terminal state.
-- Protects Day 1/2/3 submit-label behavior.
-- Verifies Day 4 handoff/demo and Day 5 reflection surfaces through targeted tests and manual QA.
-- Removes retired Day 1 `template` wording from candidate-facing help copy.
-- Adds regression coverage for terminology and candidate-state behavior.
+- Winoe Report Evidence Trail now renders backend report-level citation payloads.
+- Evidence empty-state only appears when citations are truly absent.
+- Frontend normalizers now support backend citation fields:
+  - `citations`
+  - `evidenceTrail`
+  - `artifact_type`
+  - `artifact_ref`
+  - `dimension`
+  - `excerpt`
+- Frontend state handling supports candidate finalized report fields returned by the backend.
+- UI visibility for internal AI/runtime controls is derived from `viewerCapabilities.canManageInternalAiControls`.
 
-## Frontend Files
+## Talent Partner Report UX Changes
 
-### Candidate workspace / Day 2-3
+- The Talent Partner report view renders persisted report-level citations in the Winoe Report Evidence Trail.
+- Citation rendering supports backend Evidence Trail payload shapes instead of relying only on older normalized frontend-only fields.
+- The Evidence Trail empty-state is reserved for reports where citations are truly absent.
+- Manual QA covered the Report Evidence Trail UX against deterministic backend data.
 
-- `src/features/candidate/session/views/WorkspaceAndTests.tsx`
-- `src/features/candidate/tasks/components/GithubUsernamePromptModal.tsx`
-- `src/features/candidate/tasks/components/WorkspacePanel.tsx`
-- `src/features/candidate/tasks/components/WorkspacePanelHeader.tsx`
-- `src/features/candidate/tasks/components/WorkspacePanelBody.tsx`
-- `src/features/candidate/tasks/components/TaskHeader.tsx`
-- `src/features/candidate/tasks/CandidateTaskViewInner.tsx`
+## Candidate Portal Changes
 
-### Run-tests UI
+- Candidate portal distinguishes:
+  - Pending report.
+  - Finalized/reviewed report.
+  - Report shared with Talent Partner.
+- Candidate copy does not imply Winoe makes hiring decisions.
+- Candidate copy says the Winoe Report and Evidence Trail were shared with the Talent Partner.
+- Manual QA covered candidate finalized state and invite persistence.
 
-- `src/features/candidate/tasks/components/RunTestsPanelHeader.tsx`
-- `src/features/candidate/tasks/hooks/useRunTestsCopy.ts`
-- `src/features/candidate/tasks/hooks/useRunTestsMessages.ts`
-- `src/features/candidate/tasks/hooks/useRunTestsTypes.ts`
+## Trial Detail / Internal Controls Gating
 
-### Terminology fix
+- Talent Partner Trial detail gates internal AI/runtime controls behind `viewerCapabilities.canManageInternalAiControls`.
+- Regular Talent Partner users no longer see internal AI override/runtime controls.
+- Internal controls remain available only when the backend capability payload permits them.
 
-- `src/features/candidate/tasks/components/Day1DesignDocWorkspace.tsx`
+## Tests Run
 
-### Tests
+- Frontend precommit passed.
+- Backend precommit passed as part of the completed Task 11 verification.
+- Frontend tests were added or updated for:
+  - Winoe Report citation rendering.
+  - Evidence empty-state behavior.
+  - Candidate finalized/pending portal states.
+  - Internal AI controls visibility.
 
-- `tests/unit/features/candidate/session/views/WorkspaceAndTests.test.tsx`
-- `tests/unit/features/candidate/tasks/components/WorkspacePanelCopy.test.tsx`
-- `tests/unit/features/candidate/tasks/hooks/useRunTestsCopy.test.ts`
-- `tests/unit/features/candidate/tasks/hooks/runTestsMeta.test.ts`
-- `tests/unit/features/candidate/tasks/hooks/runTestsMessages.test.ts`
-- `tests/unit/features/candidate/tasks/CandidateTaskView.submitFeedback.test.tsx`
-- `tests/unit/features/candidate/tasks/CandidateTaskView.closedReadOnly.test.tsx`
-- `tests/unit/features/candidate/tasks/CandidateTaskView.day3ImplementationWrapUp.test.tsx`
-- `tests/unit/features/candidate/tasks/components/Day5ReflectionPanel.validation.test.tsx`
-- `tests/unit/features/candidate/tasks/handoff/HandoffUploadPanel.day4Requirements.test.tsx`
-- `tests/unit/features/candidate/tasks/CandidateTaskView.day1DesignDoc.test.tsx`
-- updated `RunTestsPanel.*` tests as relevant
+## Manual QA Evidence
 
-## Frontend Behavior
+Iteration 5 QA reported full local manual QA passed with:
 
-### Day 2
+- Backend API.
+- Backend worker.
+- Frontend.
+- Database.
+- Admin endpoints.
+- Notification audit.
+- Report Evidence Trail UX.
+- Candidate finalized state.
+- Invite persistence.
+- DLQ/retry.
+- Health/readiness.
 
-- Candidate is blocked by GitHub username modal when missing.
-- Valid GitHub username unlocks the Codespace workspace.
-- Day 2 copy says `Day 2 — Implementation Kickoff`.
-- Day 2 copy says `Build from scratch in your Codespace. AI tools welcome.`
-- Codespace card explains the from-scratch repo contents:
-  - `.devcontainer/`
-  - `README.md` Project Brief
-  - Evidence Trail workflow
-  - no starter code
-- Run-tests state machine uses:
-  - `idle`
-  - `starting`
-  - `running`
-  - `succeeded`
-  - `failed`
-- Day 2 submit label:
-  - `Submit Day 2 & continue tomorrow at 9 AM`
+## Known Limitations / Accepted Tradeoffs
 
-### Day 3
+- Local QA used deterministic demo backend data.
+- Live email/provider rendering was not exercised from frontend.
+- Operator-only admin UI was not added; Task 11 operator tooling is API-first.
 
-- Uses the same Codespace/workspace lineage.
-- Day 3 copy says `Day 3 — Implementation Wrap-Up`.
-- Day 3 copy says `Continue in the same Codespace. Polish and finalize.`
-- Day 3 submit label:
-  - `Submit Day 3 & continue to Day 4 — Demo handoff`
+## Risk Notes
 
-### Day 4
-
-- Existing handoff/demo upload and transcript UX was verified.
-- Transcript gating tests remain green.
-- Candidate review surface shows submitted recording/transcript evidence.
-
-### Day 5
-
-- Existing reflection essay surface was verified.
-- 9 PM local deadline copy is covered.
-- Completion/read-only state is verified.
-
-### Terminology
-
-- Removed visible Day 1 `template` copy.
-- Added regression test to prevent candidate-visible `template` wording from returning.
-
-## Frontend Checks
-
-- `npm ci` — pass
-- `npm run typecheck` — pass
-- Focused Task 9 frontend Jest suite — pass
-- `./precommit.sh` — pass
-- Next build via precommit — pass
-- Frontend precommit included lint, prettier, tests, coverage, typecheck, and build
-
-## Frontend Manual QA
-
-- Local frontend ran at `http://localhost:3000`.
-- Candidate Days 2–5 were manually exercised.
-- Day 2 GitHub username / Codespace flow passed.
-- Day 3 same-workspace flow passed.
-- Day 4 handoff/demo evidence and transcript flow passed.
-- Day 5 reflection, 9 PM deadline, completion, and read-only review passed.
-- Post-Trial read-only review passed.
-- Terminology audit passed after Day 1 copy fix.
-
-## Risks / Follow-up
-
-- Talent Partner onboarding BFF 500 was observed during QA setup but is out of scope for this Task 9 candidate Days 2–5 PR.
-- Recommendation: track as a separate follow-up issue.
-
-## Checklist
-
-- [x] Uses current Winoe AI terminology.
-- [x] Avoids retired terminology in candidate-visible copy.
-- [x] Preserves Evidence Trail integrity.
-- [x] Handles locked/read-only candidate states.
-- [x] Covers Day 2/3 implementation workspace behavior.
-- [x] Covers Day 4 handoff/demo evidence behavior.
-- [x] Covers Day 5 reflection/completion behavior.
-- [x] Includes targeted automated tests.
-- [x] Passed local typecheck/build where applicable.
-- [x] Passed precommit.
-- [x] Manually QA verified locally.
+- Report Evidence Trail rendering depends on backend citation payloads remaining present and normalized across supported field names.
+- Candidate report state copy depends on finalized/shared state fields from the backend.
+- Internal AI/runtime controls must remain gated by `viewerCapabilities.canManageInternalAiControls` to avoid exposing operator-only controls to regular Talent Partner users.

--- a/src/features/candidate/portal/components/CandidatePortalTrialHero.tsx
+++ b/src/features/candidate/portal/components/CandidatePortalTrialHero.tsx
@@ -10,6 +10,7 @@ import { formatRelativePast } from '@/shared/time/relativePast';
 import {
   deriveCandidateInviteState,
   isCompletedInvite,
+  isReviewReadyInvite,
   isReviewRouteInvite,
   isTerminatedInvite,
   normalizeTrialProgress,
@@ -91,6 +92,7 @@ export function CandidatePortalTrialHero({
     [invite, nowMs],
   );
   const progress = normalizeTrialProgress(invite.progress);
+  const reportReady = isReviewReadyInvite(invite);
   const timezone =
     invite.candidateTimezone?.trim() ||
     Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -191,11 +193,13 @@ export function CandidatePortalTrialHero({
         <div className="mt-6 space-y-4">
           <p className="text-sm font-medium text-gray-900">Completed</p>
           <p className="text-sm leading-relaxed text-gray-600">
-            Trial submitted{' '}
-            {invite.completedAt
-              ? formatRelativePast(invite.completedAt, nowMs)
-              : 'recently'}
-            . Your report is being prepared.
+            {reportReady
+              ? 'Your Winoe Trial submission has been reviewed. The Winoe Report and linked Evidence Trail have been shared with the Talent Partner.'
+              : `Trial submitted ${
+                  invite.completedAt
+                    ? formatRelativePast(invite.completedAt, nowMs)
+                    : 'recently'
+                }. Your report is being prepared.`}
           </p>
           <Button
             variant="secondary"

--- a/src/features/candidate/portal/utils/candidateInviteViewModel.ts
+++ b/src/features/candidate/portal/utils/candidateInviteViewModel.ts
@@ -31,6 +31,8 @@ type CandidateInviteLike = Pick<
   | 'completedAt'
   | 'reportReady'
   | 'hasReport'
+  | 'reportStatus'
+  | 'reportSharedWithTalentPartner'
   | 'terminatedAt'
   | 'isExpired'
   | 'isTerminated'
@@ -138,7 +140,11 @@ export function filterCandidateInvitesForViewer(
 }
 
 export function isReviewReadyInvite(invite: CandidateInviteLike): boolean {
-  return invite.reportReady === true || invite.hasReport === true;
+  return (
+    invite.reportReady === true ||
+    invite.reportStatus === 'finalized' ||
+    invite.reportSharedWithTalentPartner === true
+  );
 }
 
 export function isReviewRouteInvite(invite: CandidateInviteLike): boolean {

--- a/src/features/candidate/session/api/inviteNormalizeApi.ts
+++ b/src/features/candidate/session/api/inviteNormalizeApi.ts
@@ -155,20 +155,27 @@ export function normalizeCandidateInvite(raw: unknown): CandidateInvite {
     toDateString(rec.scheduleLockedAt) ?? toDateString(rec.schedule_locked_at);
   const completedAt =
     toDateString(rec.completedAt) ?? toDateString(rec.completed_at);
+  const rawReportStatus = toStringOrNull(rec.reportStatus ?? rec.report_status);
+  const reportStatus =
+    rawReportStatus === 'not_started' ||
+    rawReportStatus === 'pending' ||
+    rawReportStatus === 'finalized' ||
+    rawReportStatus === 'failed'
+      ? rawReportStatus
+      : null;
+  const reportSharedWithTalentPartner =
+    rec.reportSharedWithTalentPartner === true ||
+    rec.report_shared_with_talent_partner === true
+      ? true
+      : null;
   const reportReady =
     rec.reportReady === true ||
     rec.report_ready === true ||
-    rec.hasReport === true ||
-    rec.has_report === true
+    reportStatus === 'finalized' ||
+    reportSharedWithTalentPartner === true
       ? true
       : null;
-  const hasReport =
-    rec.hasReport === true ||
-    rec.has_report === true ||
-    rec.reportReady === true ||
-    rec.report_ready === true
-      ? true
-      : null;
+  const hasReport = rec.hasReport === true || rec.has_report === true;
   const terminatedAt =
     toDateString(rec.terminatedAt) ?? toDateString(rec.terminated_at);
   const isTerminated =
@@ -218,7 +225,9 @@ export function normalizeCandidateInvite(raw: unknown): CandidateInvite {
     scheduleLockedAt,
     completedAt,
     reportReady,
-    hasReport,
+    hasReport: hasReport ? true : null,
+    reportStatus,
+    reportSharedWithTalentPartner,
     terminatedAt,
     isTerminated,
     expiresAt,

--- a/src/features/candidate/session/api/types.bootstrapApi.ts
+++ b/src/features/candidate/session/api/types.bootstrapApi.ts
@@ -51,6 +51,8 @@ export type CandidateInvite = {
   completedAt?: string | null;
   reportReady?: boolean | null;
   hasReport?: boolean | null;
+  reportStatus?: 'not_started' | 'pending' | 'finalized' | 'failed' | null;
+  reportSharedWithTalentPartner?: boolean | null;
   terminatedAt?: string | null;
   isTerminated?: boolean;
   expiresAt: string | null;

--- a/src/features/talent-partner/trial-management/detail/TrialDetailContainer.tsx
+++ b/src/features/talent-partner/trial-management/detail/TrialDetailContainer.tsx
@@ -74,6 +74,7 @@ export default function TrialDetailContainer() {
     scenarioActions: scenarioModel.scenarioActions,
     labels,
     aiConfig: detail?.aiConfig ?? null,
+    canManageInternalAiControls: detail?.canManageInternalAiControls === true,
     approveButtonLabel: scenarioModel.callbacks.approveButtonLabel,
     activateButtonLabel: scenarioModel.callbacks.activateButtonLabel,
     activateLoading: scenarioModel.callbacks.activateLoading,

--- a/src/features/talent-partner/trial-management/detail/components/TrialDetailHeader.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/TrialDetailHeader.tsx
@@ -15,6 +15,7 @@ type Props = Pick<
   | 'titleLabel'
   | 'roleLabel'
   | 'preferredLanguageFrameworkLabel'
+  | 'canManageInternalAiControls'
   | 'inviteEnabled'
   | 'inviteDisabledReason'
   | 'canApprove'
@@ -48,6 +49,7 @@ export function TrialDetailHeader({
   roleLabel,
   preferredLanguageFrameworkLabel,
   commandCenterActive,
+  canManageInternalAiControls,
   onRevealScenarioWorkbench,
   inviteEnabled,
   inviteDisabledReason,
@@ -79,6 +81,7 @@ export function TrialDetailHeader({
       roleLabel={roleLabel}
       preferredLanguageFrameworkLabel={preferredLanguageFrameworkLabel}
       commandCenterActive={commandCenterActive}
+      canManageInternalAiControls={canManageInternalAiControls}
       onRevealScenarioWorkbench={onRevealScenarioWorkbench}
       inviteEnabled={inviteEnabled}
       inviteDisabledReason={inviteDisabledReason}

--- a/src/features/talent-partner/trial-management/detail/components/TrialDetailHeaderActions.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/TrialDetailHeaderActions.tsx
@@ -7,6 +7,7 @@ import { TrialDetailOverflowMenu } from './TrialDetailOverflowMenu';
 
 type Props = {
   commandCenterActive: boolean;
+  canManageInternalAiControls: boolean;
   onRevealScenarioWorkbench: () => void;
   canApprove: boolean;
   approveButtonLabel: string;
@@ -30,6 +31,7 @@ type Props = {
 
 export function TrialDetailHeaderActions({
   commandCenterActive,
+  canManageInternalAiControls,
   onRevealScenarioWorkbench,
   canApprove,
   approveButtonLabel,
@@ -65,18 +67,22 @@ export function TrialDetailHeaderActions({
           Invite candidates
         </Button>
         <TrialDetailOverflowMenu
-          onEditDetails={onRevealScenarioWorkbench}
+          onEditDetails={
+            canManageInternalAiControls ? onRevealScenarioWorkbench : null
+          }
           onTerminate={onOpenTerminateModal}
           terminatePending={terminatePending}
           trialTerminated={trialStatus === 'terminated'}
           midMenuSlot={
-            <RegenerateScenarioButton
-              appearance="menu"
-              loading={regenerateLoading}
-              disabled={regenerateDisabled}
-              currentVersionLabel={scenarioVersionLabel}
-              onConfirm={onRegenerate}
-            />
+            canManageInternalAiControls ? (
+              <RegenerateScenarioButton
+                appearance="menu"
+                loading={regenerateLoading}
+                disabled={regenerateDisabled}
+                currentVersionLabel={scenarioVersionLabel}
+                onConfirm={onRegenerate}
+              />
+            ) : null
           }
         />
         <Link
@@ -111,12 +117,14 @@ export function TrialDetailHeaderActions({
           {activateButtonLabel}
         </Button>
       ) : null}
-      <RegenerateScenarioButton
-        loading={regenerateLoading}
-        disabled={regenerateDisabled}
-        currentVersionLabel={scenarioVersionLabel}
-        onConfirm={onRegenerate}
-      />
+      {canManageInternalAiControls ? (
+        <RegenerateScenarioButton
+          loading={regenerateLoading}
+          disabled={regenerateDisabled}
+          currentVersionLabel={scenarioVersionLabel}
+          onConfirm={onRegenerate}
+        />
+      ) : null}
       <Button
         onClick={onInvite}
         size="sm"

--- a/src/features/talent-partner/trial-management/detail/components/TrialDetailHeaderCore.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/TrialDetailHeaderCore.tsx
@@ -18,6 +18,7 @@ type Props = {
   roleLabel: string;
   preferredLanguageFrameworkLabel: string | null;
   commandCenterActive: boolean;
+  canManageInternalAiControls: boolean;
   onRevealScenarioWorkbench: () => void;
   inviteEnabled: boolean;
   inviteDisabledReason: string | null;
@@ -49,6 +50,7 @@ export function TrialDetailHeaderCore({
   roleLabel,
   preferredLanguageFrameworkLabel,
   commandCenterActive,
+  canManageInternalAiControls,
   onRevealScenarioWorkbench,
   inviteEnabled,
   inviteDisabledReason,
@@ -84,6 +86,7 @@ export function TrialDetailHeaderCore({
         <PageHeader title={title} subtitle={heroSubtitle} />
         <TrialDetailHeaderActions
           commandCenterActive={commandCenterActive}
+          canManageInternalAiControls={canManageInternalAiControls}
           onRevealScenarioWorkbench={onRevealScenarioWorkbench}
           canApprove={canApprove}
           approveButtonLabel={approveButtonLabel}

--- a/src/features/talent-partner/trial-management/detail/components/TrialDetailHeaderSection.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/TrialDetailHeaderSection.tsx
@@ -30,6 +30,7 @@ export function TrialDetailHeaderSection({
       roleLabel={props.roleLabel}
       preferredLanguageFrameworkLabel={props.preferredLanguageFrameworkLabel}
       commandCenterActive={commandCenterActive}
+      canManageInternalAiControls={props.canManageInternalAiControls}
       onRevealScenarioWorkbench={onRevealScenarioWorkbench}
       inviteEnabled={props.inviteEnabled}
       inviteDisabledReason={props.inviteDisabledReason}

--- a/src/features/talent-partner/trial-management/detail/components/TrialDetailOverflowMenu.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/TrialDetailOverflowMenu.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react';
 import { useEffect, useId, useRef, useState } from 'react';
 
 type Props = {
-  onEditDetails: () => void;
+  onEditDetails: (() => void) | null;
   onTerminate: () => void;
   terminatePending: boolean;
   trialTerminated: boolean;
@@ -60,16 +60,18 @@ export function TrialDetailOverflowMenu({
           id={menuId}
           className="absolute right-0 z-20 mt-1 min-w-[200px] rounded-md border border-subtle bg-elevated py-1 shadow-lg"
         >
-          <button
-            type="button"
-            className="block w-full px-3 py-2 text-left text-sm text-primary hover:bg-muted/30"
-            onClick={() => {
-              onEditDetails();
-              close();
-            }}
-          >
-            Edit details
-          </button>
+          {onEditDetails ? (
+            <button
+              type="button"
+              className="block w-full px-3 py-2 text-left text-sm text-primary hover:bg-muted/30"
+              onClick={() => {
+                onEditDetails();
+                close();
+              }}
+            >
+              Edit details
+            </button>
+          ) : null}
           {midMenuSlot ? (
             <div className="border-t border-subtle">{midMenuSlot}</div>
           ) : null}

--- a/src/features/talent-partner/trial-management/detail/components/TrialDetailView.tsx
+++ b/src/features/talent-partner/trial-management/detail/components/TrialDetailView.tsx
@@ -17,6 +17,7 @@ export function TrialDetailView(props: TrialDetailViewProps) {
     setInviteModalOpen: props.setInviteModalOpen,
   });
   const showScenarioControls = useDeferredScenarioControls();
+  const canManageInternalAiControls = props.canManageInternalAiControls;
 
   const commandSurfaceFirst =
     props.trialStatus === 'active_inviting' &&
@@ -82,15 +83,15 @@ export function TrialDetailView(props: TrialDetailViewProps) {
       ) : commandSurfaceFirst ? (
         <>
           {tabsBlock}
-          {scenarioBlock}
+          {canManageInternalAiControls ? scenarioBlock : null}
         </>
       ) : (
         <>
-          {scenarioBlock}
+          {canManageInternalAiControls ? scenarioBlock : null}
           {tabsBlock}
         </>
       )}
-      {props.aiConfig ? (
+      {props.aiConfig && canManageInternalAiControls ? (
         <TrialAiOverridesPanel
           trialId={props.trialId}
           aiConfig={props.aiConfig}

--- a/src/features/talent-partner/trial-management/detail/components/types.ts
+++ b/src/features/talent-partner/trial-management/detail/components/types.ts
@@ -67,6 +67,7 @@ export type TrialDetailViewProps = {
   companyContextLabel: string;
   notesLabel: string | null;
   aiConfig: TrialAiConfig | null;
+  canManageInternalAiControls: boolean;
   scenarioLabel: string | null;
   rubricSummary: string | null;
   scenarioContentUnavailableMessageForPlan: string | null;

--- a/src/features/talent-partner/trial-management/detail/container/buildTrialDetailViewProps.ts
+++ b/src/features/talent-partner/trial-management/detail/container/buildTrialDetailViewProps.ts
@@ -25,6 +25,7 @@ type BuildTrialDetailViewPropsArgs = {
   scenarioActions: ReturnType<typeof useTrialScenarioActions>;
   labels: ReturnType<typeof useTrialLabels>;
   aiConfig: TrialAiConfig | null;
+  canManageInternalAiControls: boolean;
   approveButtonLabel: string;
   planLoading: boolean;
   planStatusCode: number | null;
@@ -55,6 +56,7 @@ export function buildTrialDetailViewProps({
   scenarioActions,
   labels,
   aiConfig,
+  canManageInternalAiControls,
   approveButtonLabel,
   planLoading,
   planStatusCode,
@@ -98,6 +100,7 @@ export function buildTrialDetailViewProps({
     onTerminate,
     cleanupJobIds,
     aiConfig,
+    canManageInternalAiControls,
     activateButtonLabel,
     activateLoading,
     onActivate,

--- a/src/features/talent-partner/trial-management/detail/utils/detail/normalizePreviewUtils.ts
+++ b/src/features/talent-partner/trial-management/detail/utils/detail/normalizePreviewUtils.ts
@@ -30,6 +30,9 @@ export function normalizeTrialDetailPreview(raw: unknown): TrialDetailPreview {
   const record = asRecord(raw) ?? {};
   const scenario = asRecord(record.scenario);
   const ai = asRecord(record.ai);
+  const viewerCapabilities = asRecord(
+    record.viewerCapabilities ?? record.viewer_capabilities,
+  );
   const aiConfig = normalizeTrialAiConfig(ai);
   const statusRaw = toStringOrNull(record.status)?.toLowerCase() ?? null;
   const status = parseLifecycleStatus(statusRaw);
@@ -99,6 +102,9 @@ export function normalizeTrialDetailPreview(raw: unknown): TrialDetailPreview {
       record.companyContext ?? record.company_context,
     ),
     aiConfig,
+    canManageInternalAiControls:
+      viewerCapabilities?.canManageInternalAiControls === true ||
+      viewerCapabilities?.can_manage_internal_ai_controls === true,
     aiEvaluationEnabledByDay: normalizeTrialEvalEnabledByDay(
       aiConfig.evalEnabledByDay ??
         record.evalEnabledByDay ??

--- a/src/features/talent-partner/trial-management/detail/utils/detail/typesUtils.ts
+++ b/src/features/talent-partner/trial-management/detail/utils/detail/typesUtils.ts
@@ -49,6 +49,7 @@ export type TrialDetailPreview = {
   level: string | null;
   companyContext: string | null;
   aiConfig: TrialAiConfig;
+  canManageInternalAiControls: boolean;
   aiEvaluationEnabledByDay: TrialEvalEnabledByDay;
   generationJob: TrialGenerationJob | null;
   hasJobFailure: boolean;

--- a/src/features/talent-partner/winoe-report/winoeReport.normalizeEvidence.ts
+++ b/src/features/talent-partner/winoe-report/winoeReport.normalizeEvidence.ts
@@ -29,7 +29,10 @@ export function normalizeEvidence(value: unknown): WinoeReportEvidence | null {
     record.dayIndex ??
       record.day_index ??
       record.sourceDay ??
-      record.source_day,
+      record.source_day ??
+      record.day ??
+      record.taskDay ??
+      record.task_day,
   );
   const normalizedDayIndex =
     dayIndex === null ? null : Math.max(0, Math.round(dayIndex));
@@ -66,8 +69,26 @@ export function normalizeEvidence(value: unknown): WinoeReportEvidence | null {
       toNullableString(
         record.description ?? record.detail ?? record.details ?? record.note,
       ) ?? null,
-    ref: toNullableString(record.ref),
-    url: toNullableString(record.url),
+    ref:
+      toNullableString(
+        record.ref ??
+          record.artifactRef ??
+          record.artifact_ref ??
+          record.reference ??
+          record.locator ??
+          record.location ??
+          record.sourceRef ??
+          record.source_ref,
+      ) ?? null,
+    url:
+      toNullableString(
+        record.url ??
+          record.href ??
+          record.viewUrl ??
+          record.view_url ??
+          record.artifactUrl ??
+          record.artifact_url,
+      ) ?? null,
     excerpt: toNullableString(record.excerpt),
     startMs: startMs === null ? null : Math.max(0, Math.round(startMs)),
     endMs: endMs === null ? null : Math.max(0, Math.round(endMs)),

--- a/src/features/talent-partner/winoe-report/winoeReport.normalizeReport.ts
+++ b/src/features/talent-partner/winoe-report/winoeReport.normalizeReport.ts
@@ -46,6 +46,17 @@ const REVIEWER_ARRAY_KEYS = [
   'reviewer_reports',
 ];
 
+const REPORT_EVIDENCE_ARRAY_KEYS = [
+  'citations',
+  'evidenceTrail',
+  'evidence_trail',
+  'evidence',
+  'evidenceItems',
+  'evidence_items',
+  'linkedArtifacts',
+  'linked_artifacts',
+];
+
 function getRecordArray(
   record: Record<string, unknown>,
   keys: string[],
@@ -71,10 +82,25 @@ function getEvidenceArray(
     (Array.isArray(record.artifacts) ? record.artifacts : null) ??
     (Array.isArray(record.linkedArtifacts) ? record.linkedArtifacts : null) ??
     (Array.isArray(record.linked_artifacts) ? record.linked_artifacts : null) ??
+    (Array.isArray(record.citations) ? record.citations : null) ??
+    (Array.isArray(record.evidenceTrail) ? record.evidenceTrail : null) ??
+    (Array.isArray(record.evidence_trail) ? record.evidence_trail : null) ??
     [];
   return raw
     .map(normalizeEvidence)
     .filter((item): item is WinoeReportEvidence => Boolean(item));
+}
+
+function getReportEvidenceArray(
+  record: Record<string, unknown>,
+): WinoeReportEvidence[] {
+  return REPORT_EVIDENCE_ARRAY_KEYS.flatMap((key) => {
+    const raw = record[key];
+    if (!Array.isArray(raw)) return [];
+    return raw
+      .map(normalizeEvidence)
+      .filter((item): item is WinoeReportEvidence => Boolean(item));
+  });
 }
 
 function uniqueEvidenceCount(evidence: WinoeReportEvidence[]): number {
@@ -141,21 +167,24 @@ function collectDimensionEvidence(
   key: string,
   label: string,
   dayScores: WinoeReportDayScore[],
+  reportEvidence: WinoeReportEvidence[],
 ): WinoeReportEvidence[] {
-  return dayScores.flatMap((day) =>
-    day.evidence.filter((item) => {
-      const dimensionKey =
-        item.dimensionKey ?? item.dimensionLabel ?? item.sourceLabel;
-      if (!dimensionKey) return false;
-      const definition = getDimensionDefinition(dimensionKey);
-      return Boolean(
-        definition?.key === key ||
-        definition?.label === label ||
-        dimensionKey === key ||
-        dimensionKey === label,
-      );
-    }),
-  );
+  const evidence = [
+    ...dayScores.flatMap((day) => day.evidence),
+    ...reportEvidence,
+  ];
+  return evidence.filter((item) => {
+    const dimensionKey =
+      item.dimensionKey ?? item.dimensionLabel ?? item.sourceLabel;
+    if (!dimensionKey) return false;
+    const definition = getDimensionDefinition(dimensionKey);
+    return Boolean(
+      definition?.key === key ||
+      definition?.label === label ||
+      dimensionKey === key ||
+      dimensionKey === label,
+    );
+  });
 }
 
 function collectDimensionScoreSamples(
@@ -236,6 +265,7 @@ function buildDimensionFromParts({
 function buildExplicitDimension(
   record: Record<string, unknown>,
   dayScores: WinoeReportDayScore[],
+  reportEvidence: WinoeReportEvidence[],
 ): WinoeReportDimension | null {
   const rawLabel = chooseString(
     record.label,
@@ -268,13 +298,19 @@ function buildExplicitDimension(
   );
   const explanation = chooseString(
     record.summary,
+    record.justification,
     record.explanation,
     record.description,
     record.notes,
     record.detail,
   );
   const evidence = getEvidenceArray(record);
-  const matchingDayEvidence = collectDimensionEvidence(key, label, dayScores);
+  const matchingDayEvidence = collectDimensionEvidence(
+    key,
+    label,
+    dayScores,
+    reportEvidence,
+  );
   const mergedEvidence = mergeEvidenceItems(evidence, matchingDayEvidence);
   const scoreSamples = collectDimensionScoreSamples(key, label, dayScores);
 
@@ -302,6 +338,7 @@ function buildCanonicalDimension(
   definition: DimensionDefinition,
   dayScores: WinoeReportDayScore[],
   explicitDimension: WinoeReportDimension | null,
+  reportEvidence: WinoeReportEvidence[],
 ): WinoeReportDimension {
   if (explicitDimension) return explicitDimension;
 
@@ -309,6 +346,7 @@ function buildCanonicalDimension(
     definition.key,
     definition.label,
     dayScores,
+    reportEvidence,
   );
   const scoreSamples = collectDimensionScoreSamples(
     definition.key,
@@ -338,10 +376,11 @@ function buildCanonicalDimension(
 function buildDimensions(
   record: Record<string, unknown>,
   dayScores: WinoeReportDayScore[],
+  reportEvidence: WinoeReportEvidence[],
 ): WinoeReportDimension[] {
   const dimensionRecords = getRecordArray(record, DIMENSION_ARRAY_KEYS);
   const explicitDimensions = dimensionRecords
-    .map((item) => buildExplicitDimension(item, dayScores))
+    .map((item) => buildExplicitDimension(item, dayScores, reportEvidence))
     .filter((item): item is WinoeReportDimension => Boolean(item));
 
   if (explicitDimensions.length >= 8) {
@@ -363,6 +402,7 @@ function buildDimensions(
       definition,
       dayScores,
       explicitByKey.get(definition.key) ?? null,
+      reportEvidence,
     ),
   );
 
@@ -513,7 +553,8 @@ export function normalizeReport(value: unknown): WinoeReportReport | null {
     });
   });
   dayScores.sort((a, b) => a.dayIndex - b.dayIndex);
-  const dimensionScores = buildDimensions(record, dayScores);
+  const reportEvidence = getReportEvidenceArray(record);
+  const dimensionScores = buildDimensions(record, dayScores, reportEvidence);
   const reviewerSummaries = buildReviewerSummaries(record, dayScores);
   const narrativeAssessment = chooseString(
     record.narrativeAssessment,

--- a/tests/integration/talent-partner/TrialDetailPageClient.scenarioActions.test.tsx
+++ b/tests/integration/talent-partner/TrialDetailPageClient.scenarioActions.test.tsx
@@ -28,6 +28,7 @@ describe('TalentPartnerTrialDetailPage - scenario actions', () => {
         status: 'active_inviting',
         title: 'Trial trial-1',
         templateKey: 'python-fastapi',
+        viewerCapabilities: { canManageInternalAiControls: true },
         scenario: {
           id: 101,
           versionIndex: 2,
@@ -87,6 +88,121 @@ describe('TalentPartnerTrialDetailPage - scenario actions', () => {
       );
       expect(calls.length).toBe(1);
     });
+  });
+
+  it('hides internal AI controls for regular Talent Partner detail responses', async () => {
+    mockFetchHandlers({
+      '/api/trials': jsonResponse([]),
+      '/api/trials/trial-1': jsonResponse({
+        id: 'trial-1',
+        status: 'active_inviting',
+        title: 'Trial trial-1',
+        templateKey: 'python-fastapi',
+        viewerCapabilities: { canManageInternalAiControls: false },
+        ai: {
+          promptPackVersion: 'winoe-ai-pack-v4',
+          activeScenarioSnapshot: {
+            scenarioVersionId: 101,
+            promptPackVersion: 'winoe-ai-pack-v4',
+            agents: [
+              {
+                key: 'day1',
+                provider: 'openai',
+                model: 'gpt-5.1',
+                runtimeMode: 'real',
+              },
+            ],
+          },
+        },
+        scenario: {
+          id: 101,
+          versionIndex: 2,
+          status: 'ready',
+          lockedAt: '2026-03-01T12:00:00.000Z',
+        },
+        tasks: [
+          {
+            dayIndex: 1,
+            title: 'Discovery',
+            description: 'Define requirements.',
+          },
+        ],
+      }),
+      '/api/trials/trial-1/candidates': jsonResponse([]),
+    });
+
+    renderPage();
+
+    expect(await screen.findByText(/Trial trial-1/i)).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('regenerate-scenario-trigger'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Trial AI overrides/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Frozen agent runtime/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Advanced — scenario workbench/i),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', { name: /Trial actions menu/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Edit details/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('regenerate-scenario-trigger'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows internal AI controls when the viewer has operator capability', async () => {
+    mockFetchHandlers({
+      '/api/trials': jsonResponse([]),
+      '/api/trials/trial-1': jsonResponse({
+        id: 'trial-1',
+        status: 'ready_for_review',
+        title: 'Trial trial-1',
+        templateKey: 'python-fastapi',
+        viewerCapabilities: { canManageInternalAiControls: true },
+        ai: {
+          promptPackVersion: 'winoe-ai-pack-v4',
+          activeScenarioSnapshot: {
+            scenarioVersionId: 101,
+            promptPackVersion: 'winoe-ai-pack-v4',
+            agents: [
+              {
+                key: 'day1',
+                provider: 'openai',
+                model: 'gpt-5.1',
+                runtimeMode: 'real',
+              },
+            ],
+          },
+        },
+        scenario: {
+          id: 101,
+          versionIndex: 2,
+          status: 'ready',
+          lockedAt: null,
+          storylineMd: 'Storyline for editor textarea',
+          taskPromptsJson: [],
+          rubricJson: {},
+        },
+        tasks: [
+          {
+            dayIndex: 1,
+            title: 'Discovery',
+            description: 'Define requirements.',
+          },
+        ],
+      }),
+      '/api/trials/trial-1/candidates': jsonResponse([]),
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByTestId('regenerate-scenario-trigger'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Trial AI overrides/i)).toBeInTheDocument();
+    expect(screen.getByText(/Frozen agent runtime/i)).toBeInTheDocument();
   });
 
   it('calls approve endpoint when Approve is used', async () => {

--- a/tests/integration/talent-partner/TrialDetailPageClient.testlib.tsx
+++ b/tests/integration/talent-partner/TrialDetailPageClient.testlib.tsx
@@ -18,6 +18,7 @@ const trialDetailResponse = () =>
     status: 'active_inviting',
     title: `Trial ${params.id}`,
     templateKey: 'python-fastapi',
+    viewerCapabilities: { canManageInternalAiControls: true },
     role: 'Backend Engineer',
     techStack: 'Node.js + Postgres',
     preferredLanguageFramework: 'Node.js + Postgres',

--- a/tests/integration/talent-partner/TrialDetailScenarioVersions.regenerateLifecycle.test.tsx
+++ b/tests/integration/talent-partner/TrialDetailScenarioVersions.regenerateLifecycle.test.tsx
@@ -66,6 +66,9 @@ describe('TrialDetail scenario versions - regenerate lifecycle', () => {
       }),
     });
     renderPage();
+    fireEvent.click(
+      await screen.findByRole('button', { name: /Trial actions menu/i }),
+    );
     fireEvent.click(await screen.findByTestId('regenerate-scenario-trigger'));
     const dialog = await screen.findByRole('dialog', {
       name: /Confirm scenario regenerate/i,

--- a/tests/integration/talent-partner/TrialDetailScenarioVersions.testlib.tsx
+++ b/tests/integration/talent-partner/TrialDetailScenarioVersions.testlib.tsx
@@ -28,6 +28,7 @@ export function buildDetail(overrides: Record<string, unknown> = {}) {
     status: 'ready_for_review',
     title: 'Trial trial-1',
     templateKey: 'python-fastapi',
+    viewerCapabilities: { canManageInternalAiControls: true },
     activeScenarioVersionId: 10,
     pendingScenarioVersionId: null,
     scenarioVersions: [

--- a/tests/integration/talent-partner/trials/candidates/WinoeReportPage.rendering.test.tsx
+++ b/tests/integration/talent-partner/trials/candidates/WinoeReportPage.rendering.test.tsx
@@ -17,6 +17,7 @@ describe('WinoeReportPage rendering', () => {
   });
 
   it('renders exactly eight top-level dimensions for the seeded Sarah Chen report shape', async () => {
+    const user = userEvent.setup();
     setFetchForWinoeReport(async (url) =>
       url === '/api/candidate_sessions/2/winoe_report'
         ? jsonResponse({
@@ -173,6 +174,22 @@ describe('WinoeReportPage rendering', () => {
     expect(
       screen.getAllByText(/Reflection & Ownership/i).length,
     ).toBeGreaterThan(0);
+
+    await user.click(screen.getAllByTestId('view-evidence-button')[0]);
+    const drawer = await screen.findByRole('dialog', {
+      name: /Evidence Trail · Architecture & Design/i,
+    });
+    expect(
+      within(drawer).queryByText(/Evidence is unavailable/i),
+    ).not.toBeInTheDocument();
+    expect(
+      within(drawer).getByText(/day1-design-doc\.md:L1-L20/i),
+    ).toBeInTheDocument();
+    expect(
+      within(drawer).getByText(
+        /Use a small FastAPI service with one core domain module/i,
+      ),
+    ).toBeInTheDocument();
   });
 
   it('toggles print-mode class while mounted', () => {

--- a/tests/unit/features/candidate/portal/CandidateDashboardPage.content.test.tsx
+++ b/tests/unit/features/candidate/portal/CandidateDashboardPage.content.test.tsx
@@ -78,6 +78,70 @@ describe('CandidateDashboardPage content states', () => {
     expect(screen.getByText(/Progress: 2\/5/)).toBeInTheDocument();
   });
 
+  it('shows pending report copy when a completed Trial is not finalized', async () => {
+    listCandidateInvitesMock.mockResolvedValue([
+      {
+        candidateSessionId: 21,
+        title: 'Pending Report Trial',
+        role: 'Developer',
+        company: 'TestCo',
+        status: 'completed',
+        isExpired: false,
+        token: 'invite-token',
+        progress: { completed: 5, total: 5 },
+        completedAt: '2024-01-15T00:00:00Z',
+        hasReport: true,
+        reportReady: false,
+        reportStatus: 'pending',
+        reportSharedWithTalentPartner: false,
+        lastActivityAt: '2024-01-15T00:00:00Z',
+        expiresAt: '2024-02-15T00:00:00Z',
+        candidateEmail: 'test@example.com',
+      },
+    ]);
+    await renderDashboardPage({ signedInEmail: 'test@example.com' });
+
+    expect(
+      await screen.findByText(/Your report is being prepared/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/linked Evidence Trail/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows reviewed and shared copy when the Winoe Report is finalized', async () => {
+    listCandidateInvitesMock.mockResolvedValue([
+      {
+        candidateSessionId: 22,
+        title: 'Finalized Report Trial',
+        role: 'Developer',
+        company: 'TestCo',
+        status: 'completed',
+        isExpired: false,
+        token: 'invite-token',
+        progress: { completed: 5, total: 5 },
+        completedAt: '2024-01-15T00:00:00Z',
+        hasReport: true,
+        reportReady: true,
+        reportStatus: 'finalized',
+        reportSharedWithTalentPartner: true,
+        lastActivityAt: '2024-01-15T00:00:00Z',
+        expiresAt: '2024-02-15T00:00:00Z',
+        candidateEmail: 'test@example.com',
+      },
+    ]);
+    await renderDashboardPage({ signedInEmail: 'test@example.com' });
+
+    expect(
+      await screen.findByText(
+        /Your Winoe Trial submission has been reviewed\. The Winoe Report and linked Evidence Trail have been shared with the Talent Partner\./i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Your report is being prepared/i),
+    ).not.toBeInTheDocument();
+  });
+
   it('filters out invites that do not belong to the signed-in email', async () => {
     listCandidateInvitesMock.mockResolvedValue([
       {

--- a/tests/unit/features/candidate/portal/candidateInviteViewModel.test.ts
+++ b/tests/unit/features/candidate/portal/candidateInviteViewModel.test.ts
@@ -5,6 +5,7 @@ import {
   inviteMatchesSignedInEmail,
   normalizeCandidateInviteEmail,
   normalizeTrialProgress,
+  isReviewReadyInvite,
   isReviewRouteInvite,
 } from '@/features/candidate/portal/utils/candidateInviteViewModel';
 
@@ -31,6 +32,8 @@ const makeInvite = (
     completedAt: null,
     reportReady: null,
     hasReport: null,
+    reportStatus: null,
+    reportSharedWithTalentPartner: null,
     terminatedAt: null,
     isTerminated: false,
     expiresAt: null,
@@ -251,10 +254,29 @@ describe('candidateInviteViewModel', () => {
         progress: { completed: 5, total: 5 },
         reportReady: true,
         hasReport: true,
+        reportStatus: 'finalized',
+        reportSharedWithTalentPartner: true,
       }),
       expected: {
         state: 'report_ready',
         statusLabel: 'Report ready',
+        currentDayLabel: 'Day 5 of 5',
+        actionLabel: 'Review submissions',
+        actionDisabled: false,
+      },
+    },
+    {
+      name: 'completed with unfinalized report',
+      invite: makeInvite({
+        status: 'completed',
+        progress: { completed: 5, total: 5 },
+        completedAt: '2025-01-15T10:00:00Z',
+        hasReport: true,
+        reportStatus: 'pending',
+      }),
+      expected: {
+        state: 'complete',
+        statusLabel: 'Complete',
         currentDayLabel: 'Day 5 of 5',
         actionLabel: 'Review submissions',
         actionDisabled: false,
@@ -310,9 +332,29 @@ describe('candidateInviteViewModel', () => {
           status: 'completed',
           reportReady: true,
           hasReport: true,
+          reportStatus: 'finalized',
+          reportSharedWithTalentPartner: true,
         }),
       ),
     ).toBe(true);
+    expect(
+      isReviewRouteInvite(
+        makeInvite({
+          status: 'completed',
+          hasReport: true,
+          reportStatus: 'pending',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isReviewReadyInvite(
+        makeInvite({
+          status: 'in_progress',
+          hasReport: true,
+          reportStatus: 'pending',
+        }),
+      ),
+    ).toBe(false);
     expect(
       isReviewRouteInvite(
         makeInvite({

--- a/tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.component.misc.test.tsx
+++ b/tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.component.misc.test.tsx
@@ -16,6 +16,7 @@ describe('TalentPartnerTrialDetailPage miscellaneous states', () => {
   it('renders days without generated tasks', async () => {
     talentPartnerGetMock.mockResolvedValue({
       title: 'Test',
+      viewerCapabilities: { canManageInternalAiControls: true },
       days: [{ dayIndex: 1, title: 'Day 1' }],
     });
     await renderDetailPage();

--- a/tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.helpers.preview.test.ts
+++ b/tests/unit/features/talent-partner/trial-management/detail/TalentPartnerTrialDetailPage.helpers.preview.test.ts
@@ -45,6 +45,7 @@ describe('TalentPartnerTrialDetailPage helper preview normalization', () => {
         productArea: 'Payments',
         preferredLanguageFramework: 'Python + FastAPI',
       },
+      viewerCapabilities: { canManageInternalAiControls: true },
       ai: { evalEnabledByDay: { '4': false } },
       scenario: {
         id: 10,
@@ -81,6 +82,17 @@ describe('TalentPartnerTrialDetailPage helper preview normalization', () => {
     expect(__testables.scenarioVersionLabel(2)).toBe('v2');
     expect(__testables.isPreviewGenerating(detail)).toBe(true);
     expect(__testables.isPreviewEmpty(detail)).toBe(false);
+    expect(detail.canManageInternalAiControls).toBe(true);
+  });
+
+  it('defaults internal AI management capability off for Talent Partner detail payloads', () => {
+    const detail = __testables.normalizeTrialDetailPreview({
+      id: 9,
+      status: 'active_inviting',
+      tasks: [],
+    });
+
+    expect(detail.canManageInternalAiControls).toBe(false);
   });
 
   it('drops retired template and stack fields from preview normalization', () => {

--- a/tests/unit/features/talent-partner/trial-management/detail/TrialDetailTabs.brief.test.tsx
+++ b/tests/unit/features/talent-partner/trial-management/detail/TrialDetailTabs.brief.test.tsx
@@ -83,6 +83,7 @@ const minimalProps: TrialDetailViewProps = {
   companyContextLabel: 'C',
   notesLabel: null,
   aiConfig: null,
+  canManageInternalAiControls: false,
   scenarioLabel: 'WRONG_SCENARIO_LABEL',
   rubricSummary: null,
   scenarioContentUnavailableMessageForPlan: null,

--- a/tests/unit/features/talent-partner/winoe-report/winoeReport.normalizeReport.test.ts
+++ b/tests/unit/features/talent-partner/winoe-report/winoeReport.normalizeReport.test.ts
@@ -137,6 +137,11 @@ describe('normalizeReport', () => {
           ref: 'commit-1',
           dimensionKey: 'architecture_and_design',
         }),
+        expect.objectContaining({
+          kind: 'design_doc',
+          ref: 'day1-design-doc.md:L1-L20',
+          excerpt: 'Use a small FastAPI service with one core domain module.',
+        }),
       ]),
     );
     expect(report?.dimensionScores[6]?.evidence).toEqual(
@@ -147,6 +152,53 @@ describe('normalizeReport', () => {
         }),
       ]),
     );
+  });
+
+  it('merges backend report-level citation payloads into matching dimensions', () => {
+    const report = normalizeReport({
+      overallWinoeScore: 0.78,
+      recommendation: 'positive_signal',
+      confidence: 0.74,
+      dimensions: [
+        {
+          name: 'Architecture & Design',
+          score: 8.8,
+          justification: 'The Day 1 design doc keeps the scope small.',
+        },
+      ],
+      citations: [
+        {
+          dimension: 'Architecture & Design',
+          artifact_type: 'design_doc',
+          artifact_ref: 'day1-design-doc.md:L1-L20',
+          excerpt: 'Use a small FastAPI service with one core domain module.',
+        },
+      ],
+      dayScores: [],
+      reviewerReports: [],
+      disabledDayIndexes: [],
+    });
+
+    const architecture = report?.dimensionScores.find(
+      (item) => item.key === 'architecture_and_design',
+    );
+
+    expect(architecture).toMatchObject({
+      label: 'Architecture & Design',
+      summary: 'The Day 1 design doc keeps the scope small.',
+      evidenceCount: 1,
+      linkedArtifactCount: 1,
+    });
+    expect(architecture?.score).toBeCloseTo(0.88);
+    expect(architecture?.evidence).toEqual([
+      expect.objectContaining({
+        kind: 'design_doc',
+        ref: 'day1-design-doc.md:L1-L20',
+        excerpt: 'Use a small FastAPI service with one core domain module.',
+        dimensionKey: 'architecture_and_design',
+        dimensionLabel: 'Architecture & Design',
+      }),
+    ]);
   });
 
   it('merges explicit backend dimensions, derived day-level dimensions, and canonical from-scratch dimensions', () => {


### PR DESCRIPTION
# Task 11: Surface verified report evidence and finalized candidate states

## Summary

- Surfaces backend-validated Winoe Report evidence in the Talent Partner report experience.
- Updates candidate portal report states so pending, finalized/reviewed, and Talent Partner-shared reports are distinct.
- Gates internal AI/runtime controls behind backend-provided viewer capabilities.
- Aligns frontend normalization with backend citation payload fields used by the Task 11 Evidence Trail.
- Task 11 is code ready and approved for QA signoff / PR prep based on Iteration 5 verification.

## Frontend Implementation Details

- Winoe Report Evidence Trail now renders backend report-level citation payloads.
- Evidence empty-state only appears when citations are truly absent.
- Frontend normalizers now support backend citation fields:
  - `citations`
  - `evidenceTrail`
  - `artifact_type`
  - `artifact_ref`
  - `dimension`
  - `excerpt`
- Frontend state handling supports candidate finalized report fields returned by the backend.
- UI visibility for internal AI/runtime controls is derived from `viewerCapabilities.canManageInternalAiControls`.

## Talent Partner Report UX Changes

- The Talent Partner report view renders persisted report-level citations in the Winoe Report Evidence Trail.
- Citation rendering supports backend Evidence Trail payload shapes instead of relying only on older normalized frontend-only fields.
- The Evidence Trail empty-state is reserved for reports where citations are truly absent.
- Manual QA covered the Report Evidence Trail UX against deterministic backend data.

## Candidate Portal Changes

- Candidate portal distinguishes:
  - Pending report.
  - Finalized/reviewed report.
  - Report shared with Talent Partner.
- Candidate copy does not imply Winoe makes hiring decisions.
- Candidate copy says the Winoe Report and Evidence Trail were shared with the Talent Partner.
- Manual QA covered candidate finalized state and invite persistence.

## Trial Detail / Internal Controls Gating

- Talent Partner Trial detail gates internal AI/runtime controls behind `viewerCapabilities.canManageInternalAiControls`.
- Regular Talent Partner users no longer see internal AI override/runtime controls.
- Internal controls remain available only when the backend capability payload permits them.

## Tests Run

- Frontend precommit passed.
- Backend precommit passed as part of the completed Task 11 verification.
- Frontend tests were added or updated for:
  - Winoe Report citation rendering.
  - Evidence empty-state behavior.
  - Candidate finalized/pending portal states.
  - Internal AI controls visibility.

## Manual QA Evidence

Iteration 5 QA reported full local manual QA passed with:

- Backend API.
- Backend worker.
- Frontend.
- Database.
- Admin endpoints.
- Notification audit.
- Report Evidence Trail UX.
- Candidate finalized state.
- Invite persistence.
- DLQ/retry.
- Health/readiness.

## Known Limitations / Accepted Tradeoffs

- Local QA used deterministic demo backend data.
- Live email/provider rendering was not exercised from frontend.
- Operator-only admin UI was not added; Task 11 operator tooling is API-first.

## Risk Notes

- Report Evidence Trail rendering depends on backend citation payloads remaining present and normalized across supported field names.
- Candidate report state copy depends on finalized/shared state fields from the backend.
- Internal AI/runtime controls must remain gated by `viewerCapabilities.canManageInternalAiControls` to avoid exposing operator-only controls to regular Talent Partner users.
